### PR TITLE
remove caching error and fix version issue with installation

### DIFF
--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -883,7 +883,7 @@ class Parser(object):
         """
         if parse_candidate is None:
             return None
-        # if parse_candidate in self._transform_cache:
+        # if parse_candidate in self._transform_cache: ##FG removed. causing caching issues
         #     return self._transform_cache[parse_candidate]
         t = type(parse_candidate)
         transformed = None
@@ -1524,7 +1524,7 @@ class Parser(object):
                     default_species= tokenization_result.attributes["OS"])
         return self.transform_parse_candidates(results)
 
-    #@cache # removing caching until issue with DPB110401 is resolved
+    @cache
     def parse(
             self,
             name: str,
@@ -1623,7 +1623,6 @@ class Parser(object):
                 raise ParseError("Could not parse '%s'" % name)
             else:
                 return None
-
         result = pick_best_result(candidates)
 
         if infer_class2_pairing:

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -883,8 +883,8 @@ class Parser(object):
         """
         if parse_candidate is None:
             return None
-        if parse_candidate in self._transform_cache:
-            return self._transform_cache[parse_candidate]
+        # if parse_candidate in self._transform_cache:
+        #     return self._transform_cache[parse_candidate]
         t = type(parse_candidate)
         transformed = None
         if t in (Serotype, Haplotype):

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -1524,7 +1524,7 @@ class Parser(object):
                     default_species= tokenization_result.attributes["OS"])
         return self.transform_parse_candidates(results)
 
-    @cache
+    #@cache # removing caching until issue with DPB110401 is resolved
     def parse(
             self,
             name: str,

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.9.0 " 
+__version__ = "1.9"
 
 def print_version():
     print(f"v{__version__}")


### PR DESCRIPTION
This fixes the issue reported here: https://github.com/pirl-unc/mhcgnomes/issues/18#issue-1627352688 as well as https://github.com/pirl-unc/mhcgnomes/issues/22#issue-2220926965

I commented the self._transform_cache caching which led to the strange behavior. I'm not sure why but the sort_key function in result_sorting.py changes behavior when the we use it.

the @cache is still active in the parse function.
 
