### PR TITLE
Add cross-species pseudogene metadata and TAP families

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Note that `Ps` can also appear as part of a gene name (prefix or suffix) in
 non-human primates, such as `Caja-G2Ps*01`. In those cases `Ps` is treated as
 part of the gene name, not an allele annotation.
 
+The suffix-specific `annotation_pseudogene` property remains separate from
+species/gene ontology status. `Gene.pseudogene_status` is `True`, `False`, or
+`None` when no status has been curated; `Gene.is_pseudogene` is true only for a
+curated pseudogene. `Allele.is_pseudogene` combines gene-level status with an
+explicit `Ps` suffix:
+
+```python
+>>> mhcgnomes.parse("HLA-H*02:01").is_pseudogene
+True
+>>> mhcgnomes.parse("Mamu-G*01:01").is_pseudogene
+True
+>>> mhcgnomes.parse("HLA-G*01:01").is_pseudogene
+False
+>>> mhcgnomes.parse("Caja-B5*01:01Ps").annotation_pseudogene
+True
+```
+
 ### Mutations
 
 MHC proteins are sometimes described in terms of mutations to a known allele.
@@ -234,7 +251,7 @@ in YAML data files under `mhcgnomes/data/`. The key files are:
 
 | File | Purpose |
 | --- | --- |
-| `species.yaml` | Canonical species entries with MHC prefix, gene names, and class assignments |
+| `species.yaml` | Canonical species entries with MHC prefixes, genes, classes, properties, and families |
 | `gene_aliases.yaml` | Alternative gene spellings that normalize to canonical genes |
 | `allele_aliases.yaml` | Retired or shorthand allele names that normalize to canonical alleles |
 | `known_alleles.yaml` | Curated known allele labels per species/gene |
@@ -276,6 +293,29 @@ Genes in `species.yaml` are organized by MHC class:
 - **IIa**: Classical class II alpha/beta chains presenting peptides
 - **IIb**: Accessory or non-classical class II proteins
 - **other**: Antigen processing genes (TAP1, TAP2, TAPBP, B2M)
+
+### Species-specific gene properties and families
+
+`species.yaml` can attach source-backed properties to canonical genes. These
+properties inherit through the species tree and descendants can override them,
+so the same gene name may have different biology in different lineages. For
+example, human HLA-G is explicitly functional while MHC-G is a pseudogene in
+the macaque lineage. Missing metadata remains unknown rather than being inferred
+from the spelling of a gene.
+
+The ontology can also define exact gene families. The jawed-vertebrate root
+defines `TAP` as the family containing `TAP1` and `TAP2`. The strict parser does
+not promote `TAP` to a gene, but the species-aware `parse_gene_class` API can
+classify legacy family-level inputs without choosing a family member:
+
+```python
+>>> info = mhcgnomes.parse_gene_class("SLA-TAP*1*01:01")
+>>> (info.gene_name, info.mhc_class, info.non_mhc, info.source)
+('TAP', 'other', True, 'ontology_family')
+```
+
+This classification uses the selected species' inherited ontology family; it
+does not infer TAP membership from a regex or a shared gene-name pattern.
 
 ### Species prefix tiers
 

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -83,7 +83,7 @@ These are loaded by [`mhcgnomes/data.py`](https://github.com/pirl-unc/mhcgnomes/
 
 | File | Put this here | Do not put this here |
 | --- | --- | --- |
-| [`species.yaml`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/data/species.yaml) | Canonical species entries, canonical gene names, MHC class placement, stable parent/prefix relationships | Paper-local aliases, uncertain gene symbols, unresolved candidate loci |
+| [`species.yaml`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/data/species.yaml) | Canonical species entries, canonical gene names, MHC class placement, source-backed gene properties/families, stable parent/prefix relationships | Paper-local aliases, uncertain gene symbols, unresolved candidate loci |
 | [`gene_aliases.yaml`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/data/gene_aliases.yaml) | Alternative gene spellings or retired/provisional names that normalize to an existing canonical gene in `species.yaml` | New genes that do not yet have a canonical destination in `species.yaml` |
 | [`allele_aliases.yaml`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/data/allele_aliases.yaml) | Retired, shorthand, or formatting variants that normalize to a canonical allele string | New literature-only alleles with no stable canonical allele target |
 | [`known_alleles.yaml`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/data/known_alleles.yaml) | Curated known allele labels for a species/gene where the ontology already exists | A substitute for adding missing species or genes |

--- a/mhcgnomes/allele.py
+++ b/mhcgnomes/allele.py
@@ -393,6 +393,8 @@ class Allele(ResultWithGene):
         d["annotations"] = self.annotations
         d["mutations"] = self.mutation_string()
         d["is_mutant"] = self.is_mutant
+        d["pseudogene_status"] = self.pseudogene_status
+        d["is_pseudogene"] = self.is_pseudogene
         return d
 
     def _check_annotation(self, annotation):
@@ -433,9 +435,21 @@ class Allele(ResultWithGene):
 
     @property
     def annotation_pseudogene(self):
-        # designates a group of genomic sequence alleles
-        # with identical peptide binding region
+        # Ps is an explicit allele-name suffix and remains distinct from the
+        # ontology's species-specific gene status.
         return self._check_annotation("Ps")
+
+    @property
+    def is_pseudogene(self):
+        """Whether the gene or the explicitly annotated allele is a pseudogene."""
+        return self.pseudogene_status is True
+
+    @property
+    def pseudogene_status(self):
+        """Return combined explicit status, preserving unknown gene status as ``None``."""
+        if self.annotation_pseudogene:
+            return True
+        return self.gene.pseudogene_status
 
     @property
     def annotation_splice_variant(self):

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -66,6 +66,12 @@ Gnathostomata sp.:
       - TAP-L
       - TAPBP
       - B2M
+  # TAP is a transporter family, not a canonical gene. Keeping the relationship
+  # in the ontology lets lenient classification preserve TAP1/TAP2 ambiguity.
+  gene families:
+    TAP:
+      - TAP1
+      - TAP2
 
 
 ######################################################
@@ -484,6 +490,19 @@ Homo sapiens:
       DM:
         - DMA
         - DMB
+  # Source: https://www.ebi.ac.uk/ipd/imgt/hla/about/statistics/
+  gene properties:
+    G: {pseudogene: false}
+    H: {pseudogene: true}
+    J: {pseudogene: true}
+    K: {pseudogene: true}
+    L: {pseudogene: true}
+    P: {pseudogene: true}
+    V: {pseudogene: true}
+    DRB6: {pseudogene: true}
+    DRB7: {pseudogene: true}
+    DRB8: {pseudogene: true}
+    DRB9: {pseudogene: true}
 ######################################################
 #
 # Mouse
@@ -4662,6 +4681,10 @@ Macaca sp.:
       DM:
         - DMA
         - DMB
+  # IPD-MHC states that MHC-G is a pseudogene in Old World monkeys.
+  # Source: https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature/
+  gene properties:
+    G: {pseudogene: true}
 Macaca mulatta:
   parent: Macaca sp.
   prefix: Mamu
@@ -4871,6 +4894,10 @@ Pongo pygmaeus:
   parent: Pongo sp.
   prefix: Popy
   name: Bornean Orangutan
+  # IPD-MHC defines Ap as an MHC-A pseudogene specifically in Pongo pygmaeus.
+  # Source: https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature/
+  gene properties:
+    Ap: {pseudogene: true}
 Rhinopithecus roxellana:
   parent: Primata sp.
   prefix: Rhro

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -389,6 +389,32 @@ def _infer_gene_rule(gene_token: str):
     return None
 
 
+def _build_gene_class_info_from_family(species: Species, gene_token: str, raw_string: str):
+    family_name = species.find_matching_gene_family_name(gene_token)
+    if family_name is None:
+        return None
+
+    member_names = species.get_gene_family_members(family_name)
+    member_classes = {species.get_mhc_class_of_gene(member_name) for member_name in member_names}
+    if len(member_classes) != 1:
+        return None
+    mhc_class = member_classes.pop()
+
+    member_chains = {
+        _chain_for_species_gene(species, member_name, mhc_class) for member_name in member_names
+    }
+    chain = member_chains.pop() if len(member_chains) == 1 else None
+    return GeneClassInfo(
+        species=species,
+        gene_name=family_name,
+        mhc_class=mhc_class,
+        chain=chain,
+        non_mhc=mhc_class == "other",
+        source="ontology_family",
+        raw_string=raw_string,
+    )
+
+
 def _build_gene_class_info_from_token(species: Species, gene_token: str, raw_string: str):
     canonical_gene_name = species.find_matching_gene_name(gene_token)
     if canonical_gene_name is not None:
@@ -414,6 +440,10 @@ def _build_gene_class_info_from_token(species: Species, gene_token: str, raw_str
             source="canonical_locus",
             raw_string=raw_string,
         )
+
+    family_info = _build_gene_class_info_from_family(species, gene_token, raw_string)
+    if family_info is not None:
+        return family_info
 
     normalized = _normalize_inference_gene_token(gene_token)
     if normalized in _NON_MHC_REGION_GENE_NAMES:
@@ -455,7 +485,8 @@ def parse_gene_class(
     This function first attempts the normal strict parser. If that fails, it
     falls back to species-aware gene-token inference for source-backed suffixes
     such as ``F10`` or ``DR-1`` and for known non-MHC-region helper genes like
-    ``CIITA`` or ``TAP1``.
+    ``CIITA`` or ``TAP1``. Exact ontology-backed family names such as ``TAP``
+    can be classified without inventing a specific member gene.
     """
     expected_species = Species.get(species) if species is not None else None
     if species is not None and expected_species is None:

--- a/mhcgnomes/gene.py
+++ b/mhcgnomes/gene.py
@@ -192,6 +192,16 @@ class Gene(ResultWithMhcClass):
     def is_mutant(self):
         return len(self.mutations) > 0
 
+    @property
+    def pseudogene_status(self):
+        """Return explicit ontology status, or ``None`` when it is not curated."""
+        return self.species.get_pseudogene_status_of_gene(self.name)
+
+    @property
+    def is_pseudogene(self):
+        """Whether this species-specific gene is curated as a pseudogene."""
+        return self.pseudogene_status is True
+
     def to_record(self):
         """
         Returns a user-viewable ordered dictionary with a representation  of
@@ -204,6 +214,8 @@ class Gene(ResultWithMhcClass):
         d["mhc_class"] = self.mhc_class
         d["mutations"] = self.mutation_string()
         d["is_mutant"] = self.is_mutant
+        d["pseudogene_status"] = self.pseudogene_status
+        d["is_pseudogene"] = self.is_pseudogene
         return d
 
     def restrict_allele_fields(self, num_fields, drop_annotations=False, drop_mutations=False):

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -130,6 +130,8 @@ class Species(Result):
     mhc_prefix: str = ""
     gene_names: Any = None
     gene_name_to_mhc_class: Any = None
+    gene_name_to_properties: Any = None
+    gene_family_name_to_gene_names: Any = None
     class2_loci: Any = None
     class2_locus_to_gene_names: Any = None
     class2_gene_name_to_chain_type: Any = None
@@ -170,11 +172,20 @@ class Species(Result):
         context_only_mhc_prefixes: Iterable[str] = [],
         other_common_names: Iterable[str] = [],
         raw_string: Union[str, None] = None,
+        gene_name_to_properties: Union[Mapping[str, Mapping[str, Any]], None] = None,
+        gene_family_name_to_gene_names: Union[Mapping[str, Iterable[str]], None] = None,
     ):
         Result.__init__(self, raw_string=raw_string)
 
         gene_names = _ensure_normalizing_set(gene_names)
         gene_name_to_mhc_class = _ensure_normalizing_dictionary(gene_name_to_mhc_class)
+        gene_name_to_properties = _ensure_normalizing_dictionary(gene_name_to_properties)
+        gene_family_name_to_gene_names = _ensure_normalizing_dictionary(
+            gene_family_name_to_gene_names
+        )
+        gene_family_name_to_gene_names = gene_family_name_to_gene_names.map_values(
+            _ensure_normalizing_set
+        )
         class2_loci = _ensure_normalizing_set(class2_loci)
         class2_locus_to_gene_names = _ensure_normalizing_dictionary(
             class2_locus_to_gene_names, default_value_fn=set
@@ -212,6 +223,16 @@ class Species(Result):
         self._set_field(self, "gene_names", _freeze_nested_value(gene_names))
         self._set_field(
             self, "gene_name_to_mhc_class", _freeze_nested_value(gene_name_to_mhc_class)
+        )
+        self._set_field(
+            self,
+            "gene_name_to_properties",
+            _freeze_nested_value(gene_name_to_properties),
+        )
+        self._set_field(
+            self,
+            "gene_family_name_to_gene_names",
+            _freeze_nested_value(gene_family_name_to_gene_names),
         )
         self._set_field(self, "class2_loci", _freeze_nested_value(class2_loci))
         self._set_field(
@@ -529,6 +550,21 @@ class Species(Result):
                     return self.gene_names.get_original(candidate)
         return None
 
+    def find_matching_gene_family_name(self, family_name):
+        """Return the canonical name of an exact, ontology-backed gene family."""
+        if type(family_name) in (int, float):
+            family_name = str(family_name)
+        if family_name in self.gene_family_name_to_gene_names:
+            return self.gene_family_name_to_gene_names.original_key(family_name)
+        return None
+
+    def get_gene_family_members(self, family_name):
+        """Return canonical member names for an ontology-backed gene family."""
+        canonical_family_name = self.find_matching_gene_family_name(family_name)
+        if canonical_family_name is None:
+            return None
+        return tuple(sorted(self.gene_family_name_to_gene_names[canonical_family_name]))
+
     def find_matching_class2_locus_name(self, locus_name):
         """
         Use known aliases and normalized capitalization to infer
@@ -572,6 +608,20 @@ class Species(Result):
         """
         gene_name = self.normalize_gene_name_if_exists(gene_name)
         return self.gene_name_to_mhc_class.get(gene_name)
+
+    def get_gene_properties(self, gene_name):
+        """Return immutable ontology properties for a canonical gene."""
+        gene_name = self.find_matching_gene_name(gene_name)
+        if gene_name is None:
+            return None
+        return self.gene_name_to_properties.get(gene_name, MappingProxyType({}))
+
+    def get_pseudogene_status_of_gene(self, gene_name):
+        """Return explicit pseudogene status, or ``None`` when it is not curated."""
+        properties = self.get_gene_properties(gene_name)
+        if properties is None:
+            return None
+        return properties.get("pseudogene")
 
     def get_known_allele(self, gene_name, allele_name):
         gene_name_candidates = {gene_name}
@@ -913,12 +963,18 @@ def create_species_for_latin_name(latin_name):
     if parent_species is None:
         gene_names = NormalizingSet()
         gene_name_to_mhc_class = NormalizingDictionary()
+        gene_name_to_properties = NormalizingDictionary()
+        gene_family_name_to_gene_names = NormalizingDictionary()
         class2_loci = NormalizingSet()
         class2_locus_to_gene_names = NormalizingDictionary(default_value_fn=set)
         class2_gene_name_to_chain_type = NormalizingDictionary()
     else:
         gene_names = parent_species.gene_names.copy()
         gene_name_to_mhc_class = parent_species.gene_name_to_mhc_class.copy()
+        gene_name_to_properties = parent_species.gene_name_to_properties.map_values(dict)
+        gene_family_name_to_gene_names = parent_species.gene_family_name_to_gene_names.map_values(
+            _ensure_normalizing_set
+        )
         class2_loci = parent_species.class2_loci.copy()
         class2_locus_to_gene_names = parent_species.class2_locus_to_gene_names.map_values(set)
         class2_gene_name_to_chain_type = parent_species.class2_gene_name_to_chain_type.copy()
@@ -953,6 +1009,83 @@ def create_species_for_latin_name(latin_name):
                     #  the YAML file ontology
                     chain_type = guess_class2_chain_type(gene_name)
                     class2_gene_name_to_chain_type[gene_name] = chain_type
+
+    raw_gene_properties = species_info.get("gene properties", {})
+    if not isinstance(raw_gene_properties, dict):
+        raise ValueError(f"Malformed gene properties for '{latin_name}'")
+    for raw_gene_name, raw_properties in raw_gene_properties.items():
+        canonical_gene_name = gene_names.get_original(raw_gene_name)
+        if canonical_gene_name is None:
+            raise ValueError(
+                f"Gene properties for '{latin_name}' reference unknown gene '{raw_gene_name}'"
+            )
+        if not isinstance(raw_properties, dict):
+            raise ValueError(
+                f"Malformed properties for gene '{canonical_gene_name}' of '{latin_name}'"
+            )
+        unexpected_properties = set(raw_properties).difference({"pseudogene"})
+        if unexpected_properties:
+            raise ValueError(
+                f"Unknown properties for gene '{canonical_gene_name}' of '{latin_name}': "
+                f"{sorted(unexpected_properties)}"
+            )
+        if "pseudogene" in raw_properties and type(raw_properties["pseudogene"]) is not bool:
+            raise ValueError(
+                f"Pseudogene status for gene '{canonical_gene_name}' of '{latin_name}' "
+                "must be boolean"
+            )
+        combined_properties = dict(gene_name_to_properties.get(canonical_gene_name, {}))
+        combined_properties.update(raw_properties)
+        gene_name_to_properties[canonical_gene_name] = combined_properties
+
+    raw_gene_families = species_info.get("gene families", {})
+    if not isinstance(raw_gene_families, dict):
+        raise ValueError(f"Malformed gene families for '{latin_name}'")
+    for raw_family_name, raw_family_members in raw_gene_families.items():
+        if not isinstance(raw_family_members, list) or not raw_family_members:
+            raise ValueError(
+                f"Gene family '{raw_family_name}' of '{latin_name}' must be a non-empty list"
+            )
+        if raw_family_name in gene_names:
+            raise ValueError(
+                f"Gene family '{raw_family_name}' of '{latin_name}' conflicts with a gene name"
+            )
+        canonical_members = NormalizingSet()
+        member_classes = set()
+        for raw_member_name in raw_family_members:
+            canonical_member_name = gene_names.get_original(raw_member_name)
+            if canonical_member_name is None:
+                raise ValueError(
+                    f"Gene family '{raw_family_name}' of '{latin_name}' references unknown gene "
+                    f"'{raw_member_name}'"
+                )
+            canonical_members.add(canonical_member_name)
+            member_classes.add(gene_name_to_mhc_class[canonical_member_name])
+        if len(member_classes) != 1:
+            raise ValueError(
+                f"Gene family '{raw_family_name}' of '{latin_name}' spans MHC classes "
+                f"{sorted(member_classes)}"
+            )
+        gene_family_name_to_gene_names[str(raw_family_name)] = canonical_members
+
+    # Revalidate inherited families against the descendant's effective gene
+    # ontology. A descendant may reclassify a gene, but a family classification
+    # is only valid when all exact members still share one class.
+    for family_name, family_members in gene_family_name_to_gene_names.items():
+        if family_name in gene_names:
+            raise ValueError(
+                f"Gene family '{family_name}' of '{latin_name}' conflicts with a gene name"
+            )
+        member_classes = {gene_name_to_mhc_class.get(member) for member in family_members}
+        if None in member_classes:
+            raise ValueError(
+                f"Gene family '{family_name}' of '{latin_name}' references an unknown gene"
+            )
+        if len(member_classes) != 1:
+            raise ValueError(
+                f"Gene family '{family_name}' of '{latin_name}' spans MHC classes "
+                f"{sorted(member_classes)}"
+            )
 
     # Side tables inherit by lineage, but parent prefixes/common names must not
     # become implicit aliases for child species.
@@ -993,6 +1126,8 @@ def create_species_for_latin_name(latin_name):
         old_mhc_prefix=old_mhc_prefix,
         gene_names=gene_names,
         gene_name_to_mhc_class=gene_name_to_mhc_class,
+        gene_name_to_properties=gene_name_to_properties,
+        gene_family_name_to_gene_names=gene_family_name_to_gene_names,
         class2_loci=class2_loci,
         class2_locus_to_gene_names=class2_locus_to_gene_names,
         class2_gene_name_to_chain_type=class2_gene_name_to_chain_type,

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.32.1"
+__version__ = "3.33.0"
 
 
 def print_version():

--- a/tests/test_gene_class_inference.py
+++ b/tests/test_gene_class_inference.py
@@ -98,6 +98,37 @@ def test_parse_gene_class_marks_known_other_genes_as_non_mhc():
     assert result.source in {"parsed_gene", "canonical_gene"}
 
 
+@pytest.mark.parametrize(
+    "raw_string, expected_species",
+    [
+        ("SLA-TAP*1*01:01", "Sus sp."),
+        ("SLA-TAP", "Sus sp."),
+        ("HLA-TAP", "Homo sapiens"),
+        ("Mamu-TAP", "Macaca mulatta"),
+        ("Xetr-TAP", "Xenopus tropicalis"),
+    ],
+)
+def test_parse_gene_class_recognizes_ontology_backed_tap_family(raw_string, expected_species):
+    result = parse_gene_class(raw_string)
+
+    eq_(result.species.name, expected_species)
+    eq_(result.gene_name, "TAP")
+    eq_(result.mhc_class, "other")
+    eq_(result.chain, None)
+    assert result.non_mhc
+    eq_(result.source, "ontology_family")
+
+
+@pytest.mark.parametrize("raw_string", ["SLA-TAP", "Mamu-TAP", "Xetr-TAP"])
+def test_strict_parse_does_not_promote_tap_family_to_a_gene(raw_string):
+    assert parse(raw_string, raise_on_error=False) is None
+
+
+@pytest.mark.parametrize("raw_string", ["SLA-TAP0", "SLA-TAPA", "SLA-TAP12"])
+def test_parse_gene_class_requires_exact_ontology_family_name(raw_string):
+    assert parse_gene_class(raw_string, raise_on_error=False) is None
+
+
 def test_parse_gene_class_marks_known_non_ontology_helper_gene_as_non_mhc():
     for raw_string, expected_gene in [
         ("Ciita", "CIITA"),

--- a/tests/test_gene_properties.py
+++ b/tests/test_gene_properties.py
@@ -1,0 +1,87 @@
+import pytest
+
+from mhcgnomes import Gene, Species, parse
+
+
+@pytest.mark.parametrize(
+    "gene_name",
+    ["H", "J", "K", "L", "P", "V", "DRB6", "DRB7", "DRB8", "DRB9"],
+)
+def test_curated_human_pseudogene_loci(gene_name):
+    gene = Gene.get("HLA", gene_name)
+
+    assert gene.pseudogene_status is True
+    assert gene.is_pseudogene
+
+
+def test_human_gene_level_pseudogene_status_is_distinct_from_allele_annotation():
+    allele = parse("HLA-H*02:01")
+
+    assert allele.gene.pseudogene_status is True
+    assert allele.gene.is_pseudogene
+    assert not allele.annotation_pseudogene
+    assert allele.is_pseudogene
+
+
+def test_explicit_ps_annotation_still_marks_allele_without_gene_level_status():
+    allele = parse("Caja-B5*01:01ps")
+
+    assert allele.gene.pseudogene_status is None
+    assert not allele.gene.is_pseudogene
+    assert allele.annotation_pseudogene
+    assert allele.is_pseudogene
+
+
+def test_gene_pseudogene_status_is_species_specific_and_inherited():
+    human_g = Gene.get("HLA", "G")
+    rhesus_g = Gene.get("Mamu", "G")
+    crab_eating_macaque_g = Gene.get("Mafa", "G")
+
+    assert human_g.pseudogene_status is False
+    assert not human_g.is_pseudogene
+    assert rhesus_g.pseudogene_status is True
+    assert rhesus_g.is_pseudogene
+    assert crab_eating_macaque_g.pseudogene_status is True
+    assert crab_eating_macaque_g.is_pseudogene
+
+
+def test_descendant_specific_pseudogene_status_does_not_leak_to_sibling_species():
+    bornean_orangutan_ap = Gene.get("Popy", "Ap")
+    sumatran_orangutan_ap = Gene.get("Poab", "Ap")
+
+    assert bornean_orangutan_ap.pseudogene_status is True
+    assert bornean_orangutan_ap.is_pseudogene
+    assert sumatran_orangutan_ap.pseudogene_status is None
+    assert not sumatran_orangutan_ap.is_pseudogene
+
+
+def test_gene_record_exposes_combined_pseudogene_status():
+    hla_h_record = Gene.get("HLA", "H").to_record()
+    hla_a_record = parse("HLA-A*02:01").to_record()
+    annotated_record = parse("Caja-B5*01:01ps").to_record()
+
+    assert hla_h_record["pseudogene_status"] is True
+    assert hla_h_record["is_pseudogene"] is True
+    assert hla_a_record["pseudogene_status"] is None
+    assert hla_a_record["is_pseudogene"] is False
+    assert annotated_record["pseudogene_status"] is True
+    assert annotated_record["is_pseudogene"] is True
+
+
+def test_gene_properties_and_families_are_immutable():
+    human = Species.get("HLA")
+
+    with pytest.raises(TypeError):
+        human.gene_name_to_properties["H"] = {"pseudogene": False}
+    with pytest.raises(TypeError):
+        human.gene_name_to_properties["H"]["pseudogene"] = False
+    with pytest.raises(TypeError):
+        human.gene_family_name_to_gene_names["TAP"].add("TAPBP")
+
+
+@pytest.mark.parametrize("species_prefix", ["HLA", "SLA", "Mamu", "Xetr"])
+def test_tap_family_is_inherited_cross_species(species_prefix):
+    species = Species.get(species_prefix)
+
+    assert species.find_matching_gene_family_name("tap") == "TAP"
+    assert species.get_gene_family_members("TAP") == ("TAP1", "TAP2")

--- a/tests/test_result_contracts.py
+++ b/tests/test_result_contracts.py
@@ -41,6 +41,8 @@ GOLDEN_PARSE_CASES = [
                 ("mhc_class", "Ia"),
                 ("mutations", ""),
                 ("is_mutant", False),
+                ("pseudogene_status", None),
+                ("is_pseudogene", False),
             ]
         ),
         "expected_annotations": _expected_annotation_values(),
@@ -60,6 +62,8 @@ GOLDEN_PARSE_CASES = [
                 ("mhc_class", "Ia"),
                 ("mutations", ""),
                 ("is_mutant", False),
+                ("pseudogene_status", None),
+                ("is_pseudogene", False),
                 ("allele", "HLA-A*02:01"),
                 ("annotations", ()),
             ]
@@ -97,6 +101,8 @@ GOLDEN_PARSE_CASES = [
                 ("mhc_class", "Ia"),
                 ("mutations", "N80I"),
                 ("is_mutant", True),
+                ("pseudogene_status", None),
+                ("is_pseudogene", False),
                 ("allele", "HLA-A*02:01 N80I mutant"),
                 ("annotations", ()),
             ]
@@ -118,6 +124,8 @@ GOLDEN_PARSE_CASES = [
                 ("mhc_class", "Ib"),
                 ("mutations", ""),
                 ("is_mutant", False),
+                ("pseudogene_status", True),
+                ("is_pseudogene", True),
                 ("allele", "Saoe-G*03:12Ps"),
                 ("annotations", ("Ps",)),
             ]


### PR DESCRIPTION
## Summary

- add immutable, inherited species/gene properties and expose tri-state pseudogene_status plus boolean is_pseudogene on genes and alleles
- curate the currently represented human pseudogene loci, the macaque MHC-G lineage status, and the Pongo pygmaeus Ap status from IPD
- declare TAP as an exact TAP1/TAP2 ontology family at the jawed-vertebrate root and classify legacy family-level inputs through parse_gene_class
- bump the package version from 3.32.1 to 3.33.0

Closes #85.
Closes #86.

## Why

Downstream users currently duplicate locus status tables and raw-string TAP regexes. These biological facts belong in the species ontology, where lineage inheritance and descendant overrides represent cross-species differences safely.

TAP recognition is based only on exact membership in the selected species inherited ontology. It does not infer family membership from regexes or gene-name shapes, and the strict parser still rejects ambiguous family-level TAP as a gene.

## Cross-species coverage

- human HLA-G is explicitly non-pseudogene while macaque MHC-G is pseudogene
- Macaca metadata is inherited by rhesus and crab-eating macaques
- Pongo pygmaeus Ap status does not leak into sibling Pongo abelii
- TAP family classification is tested with HLA, SLA, Mamu, and Xetr prefixes
- nearby tokens TAP0, TAPA, and TAP12 remain unclassified

## Sources

- [IPD-IMGT/HLA locus statistics](https://www.ebi.ac.uk/ipd/imgt/hla/about/statistics/)
- [IPD-MHC non-human primate nomenclature](https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature/)

## Checks

- ./format.sh
- ./lint.sh
- ./test.sh — 52,737 passed
- mkdocs build --strict
