### PR TITLE
Add nested data CLI commands

### DIFF
--- a/.github/workflows/external-data.yml
+++ b/.github/workflows/external-data.yml
@@ -54,7 +54,7 @@ jobs:
         run: git diff --exit-code -- mhcgnomes/data/allele_aliases.yaml
 
       - name: Fetch exhaustive validation inputs
-        run: python -m mhcgnomes.external_data --group validation
+        run: mhcgnomes data download --group validation
 
       - name: Validate every official IMGT/IPD allele name
         run: mhcgnomes-validate-data

--- a/EXTERNAL_DATA.md
+++ b/EXTERNAL_DATA.md
@@ -17,29 +17,40 @@ do not contain "obfuscated" source caches.
 From a checkout or an installed package:
 
 ```bash
-mhcgnomes-data
+mhcgnomes data
 ```
 
-With no arguments, this fetches only the three inputs needed to regenerate `allele_aliases.yaml`.
-Every source is pinned to an immutable commit in the provider's official repository and verified by
-SHA-256 before use. Working copies go to `.external-data/`. Reusable content-addressed copies go
-under `$XDG_CACHE_HOME/mhcgnomes/external-data-v1/` when that variable is set, or under
+This lists all registered sources, releases, and purpose groups without accessing the network. The
+explicit equivalent is `mhcgnomes data list`.
+
+Download the three default inputs needed to regenerate `allele_aliases.yaml` with:
+
+```bash
+mhcgnomes data download
+```
+
+Source selection, destination, cache, mirror, and offline options belong to the `download`
+subcommand; run `mhcgnomes data download --help` for the complete interface.
+
+Every source is pinned to an immutable commit in the provider's official repository and verified
+by SHA-256 before use. Working copies go to `.external-data/`. Reusable content-addressed copies
+go under `$XDG_CACHE_HOME/mhcgnomes/external-data-v1/` when that variable is set, or under
 `~/.cache/mhcgnomes/external-data-v1/` otherwise.
 
 Useful variants:
 
 ```bash
 # Show all registered releases and purpose groups.
-mhcgnomes-data --list
+mhcgnomes data list
 
 # Fetch inputs for exhaustive upstream compatibility validation.
-mhcgnomes-data --group validation
+mhcgnomes data download --group validation
 
 # Preseed or consume a shared filesystem mirror, then forbid network fallback.
-mhcgnomes-data --mirror /shared/mhcgnomes-data --offline
+mhcgnomes data download --mirror /shared/mhcgnomes-data --offline
 
 # Try organization caches before the official URLs.
-mhcgnomes-data --mirror /shared/mhcgnomes-data \
+mhcgnomes data download --mirror /shared/mhcgnomes-data \
   --mirror https://artifacts.example.org/mhcgnomes
 ```
 
@@ -77,7 +88,7 @@ not an alias input: the old shell command repeated an argparse option, causing 3
 3.5.0.1. Preserving only 3.8.0.0 keeps the generated runtime index byte-for-byte stable.
 
 Exhaustive compatibility validation and the evaluation notebook use the optional protein inputs.
-Fetch them first with `mhcgnomes-data --group validation`; they are read from
+Fetch them first with `mhcgnomes data download --group validation`; they are read from
 `.external-data/` and do not need copies in `tests/` or `evaluation/`. Run every official allele
 name through the parser without generating or committing a transformed copy of the database:
 

--- a/mhcgnomes/cli.py
+++ b/mhcgnomes/cli.py
@@ -105,6 +105,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="mhcgnomes",
         description="Parse MHC strings and print a table with parsed properties.",
+        epilog="Manage pinned external data with 'mhcgnomes data'.",
     )
     parser.add_argument(
         "names",
@@ -155,6 +156,12 @@ def _collect_names(positional_names: Sequence[str]) -> list[str]:
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    if argv and argv[0] == "data":
+        from .external_data import main as external_data_main
+
+        return external_data_main(argv[1:])
+
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
 

--- a/mhcgnomes/data/combine_allele_aliases.sh
+++ b/mhcgnomes/data/combine_allele_aliases.sh
@@ -9,7 +9,7 @@ repo_root=$(cd "$data_dir/../.." && pwd)
 external_data_dir=${MHCGNOMES_EXTERNAL_DATA_DIR:-"$repo_root/.external-data"}
 
 cd "$repo_root"
-python3 -m mhcgnomes.external_data \
+python3 -m mhcgnomes data download \
     --group allele-aliases \
     --destination "$external_data_dir"
 

--- a/mhcgnomes/external_data.py
+++ b/mhcgnomes/external_data.py
@@ -319,15 +319,11 @@ def materialize_sources(
     return tuple(paths)
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="mhcgnomes-data",
-        description="Fetch checksum-pinned IMGT/IPD inputs through local and CI-friendly caches.",
-    )
+def _add_download_arguments(parser: argparse.ArgumentParser) -> None:
+    """Attach source-selection and retrieval options to the download command."""
     parser.add_argument("source_ids", nargs="*", help="Source IDs (defaults to maintained inputs)")
     parser.add_argument("--group", action="append", default=[], help="Select a purpose group")
-    parser.add_argument("--all", action="store_true", help="Fetch every registered source")
-    parser.add_argument("--list", action="store_true", help="List registered sources and exit")
+    parser.add_argument("--all", action="store_true", help="Download every registered source")
     parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
     parser.add_argument("--cache-dir", type=Path, default=default_cache_dir())
     parser.add_argument("--destination", type=Path, default=Path(".external-data"))
@@ -338,20 +334,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Local directory or HTTP(S) base URL; repeat for fallback order",
     )
     parser.add_argument("--offline", action="store_true", help="Forbid all network access")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mhcgnomes data",
+        description="List or download checksum-pinned IMGT/IPD inputs.",
+    )
+    subparsers = parser.add_subparsers(dest="data_command")
+    subparsers.add_parser(
+        "list",
+        help="List registered sources (default)",
+        description="List registered external-data sources and purpose groups.",
+    )
+    download_parser = subparsers.add_parser(
+        "download",
+        help="Download and cache verified sources",
+        description="Download checksum-pinned inputs through local and CI-friendly caches.",
+    )
+    _add_download_arguments(download_parser)
     return parser
+
+
+def print_sources(sources: Sequence[Source]) -> None:
+    for source in sources:
+        groups = ",".join(source.groups)
+        default = " default" if source.default else ""
+        print(f"{source.id}\t{source.provider} {source.release}\t{groups}{default}")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
     try:
-        sources = load_manifest(args.manifest)
-        if args.list:
-            for source in sources:
-                groups = ",".join(source.groups)
-                default = " default" if source.default else ""
-                print(f"{source.id}\t{source.provider} {source.release}\t{groups}{default}")
+        if args.data_command in {None, "list"}:
+            print_sources(load_manifest())
             return 0
+        sources = load_manifest(args.manifest)
         selected = select_sources(
             sources,
             source_ids=args.source_ids,

--- a/mhcgnomes/validate_external_names.py
+++ b/mhcgnomes/validate_external_names.py
@@ -74,7 +74,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for path in args.paths:
         if not path.is_file():
             print(
-                f"ERROR: missing {path}; run 'mhcgnomes-data --group validation' first",
+                f"ERROR: missing {path}; run 'mhcgnomes data download --group validation' first",
                 file=sys.stderr,
             )
             failed = True

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.33.1"
+__version__ = "3.33.2"
 
 
 def print_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ Documentation = "https://pirl-unc.github.io/mhcgnomes/"
 
 [project.scripts]
 mhcgnomes = "mhcgnomes.cli:main"
-mhcgnomes-data = "mhcgnomes.external_data:main"
 mhcgnomes-validate-data = "mhcgnomes.validate_external_names:main"
 
 [tool.setuptools.dynamic]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import subprocess
 import sys
@@ -27,6 +28,89 @@ def test_cli_help():
     assert result.returncode == 0
     assert "usage:" in result.stdout.lower()
     assert "mhcgnomes" in result.stdout.lower()
+    assert "mhcgnomes data" in result.stdout
+
+
+def test_data_command_lists_sources_by_default():
+    result = run_cli("data")
+
+    assert result.returncode == 0
+    assert "imgt-hla-allele-history-3.42.0" in result.stdout
+    assert "ipd-mhc-3.8.0.0-protein" in result.stdout
+
+
+def test_data_list_is_explicit_alias_for_default_action():
+    default = run_cli("data")
+    explicit = run_cli("data", "list")
+
+    assert explicit.returncode == 0
+    assert explicit.stdout == default.stdout
+
+
+def test_data_download_help_owns_download_options():
+    result = run_cli("data", "download", "--help")
+
+    assert result.returncode == 0
+    assert "--cache-dir" in result.stdout
+    assert "--destination" in result.stdout
+    assert "--mirror" in result.stdout
+    assert "--offline" in result.stdout
+
+
+def test_data_download_options_are_not_accepted_by_data_group():
+    result = run_cli("data", "--offline")
+
+    assert result.returncode == 2
+    assert "unrecognized arguments: --offline" in result.stderr
+
+
+def test_data_download_materializes_from_local_mirror_offline(tmp_path):
+    payload = b"nested CLI payload"
+    digest = hashlib.sha256(payload).hexdigest()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "sources": [
+                    {
+                        "id": "nested-cli-source",
+                        "filename": "nested.dat",
+                        "provider": "Example",
+                        "release": "1",
+                        "url": "https://official.example/nested.dat",
+                        "sha256": digest,
+                        "license_url": "https://official.example/license",
+                        "groups": ["example"],
+                        "default": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    mirror = tmp_path / "mirror"
+    mirror.mkdir()
+    (mirror / "nested.dat").write_bytes(payload)
+    destination = tmp_path / "destination"
+
+    result = run_cli(
+        "data",
+        "download",
+        "--manifest",
+        str(manifest),
+        "--cache-dir",
+        str(tmp_path / "cache"),
+        "--destination",
+        str(destination),
+        "--mirror",
+        str(mirror),
+        "--offline",
+    )
+
+    assert result.returncode == 0
+    assert (destination / "nested.dat").read_bytes() == payload
+    assert "nested-cli-source" in result.stdout
 
 
 def test_cli_table_output_for_valid_allele():

--- a/tests/test_external_data.py
+++ b/tests/test_external_data.py
@@ -57,6 +57,21 @@ def test_shipped_manifest_is_valid_and_uses_official_providers():
     assert all("/ANHIG/" in source.url for source in sources)
 
 
+@pytest.mark.parametrize("arguments", [[], ["list"]])
+def test_data_command_lists_sources_by_default_without_downloading(arguments, monkeypatch, capsys):
+    monkeypatch.setattr(
+        external_data,
+        "_download_to_cache",
+        lambda *_args, **_kwargs: pytest.fail("listing must not download data"),
+    )
+
+    assert external_data.main(arguments) == 0
+
+    output = capsys.readouterr().out
+    assert "imgt-hla-allele-history-3.42.0" in output
+    assert "ipd-mhc-3.8.0.0-protein" in output
+
+
 def test_select_sources_defaults_and_unions_explicit_groups():
     default = make_source()
     optional = make_source(
@@ -281,6 +296,7 @@ def test_cli_can_materialize_from_local_mirror_offline(tmp_path, capsys):
 
     result = external_data.main(
         [
+            "download",
             "--manifest",
             str(manifest),
             "--cache-dir",

--- a/tests/test_validate_external_names.py
+++ b/tests/test_validate_external_names.py
@@ -57,4 +57,4 @@ def test_cli_reports_missing_source(tmp_path, capsys):
     missing = tmp_path / "missing.fasta"
 
     assert main([str(missing)]) == 1
-    assert "mhcgnomes-data --group validation" in capsys.readouterr().err
+    assert "mhcgnomes data download --group validation" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- make `mhcgnomes data` list registered external sources by default, without network access
- add explicit `mhcgnomes data list` and put all retrieval options on `mhcgnomes data download`
- route project scripts and cross-species CI through the nested command and retire the standalone `mhcgnomes-data` entry point
- update documentation and error guidance, with a patch version bump to 3.33.2

The underlying external-data model is unchanged: sources remain immutable and SHA-256 verified,
with destination, content-addressed local cache, filesystem/HTTP mirrors, CI cache, and official
servers as fallbacks. The change does not add name- or filename-regex biological classification;
both IMGT/HLA and cross-species IPD-MHC sources remain covered.

## Validation

- `./format.sh`
- `./lint.sh`
- `./test.sh` — 15,091 passed, 91% total coverage
- `python -m build --no-isolation`
- inspected sdist/wheel contents and console entry points
- smoke-tested the built wheel: `mhcgnomes data`, `mhcgnomes data list`, and `mhcgnomes data download --help`

Follow-up to the external-data management added for #28.
