### PR TITLE
Speed up cold allele parsing

### DIFF
--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -2153,6 +2153,36 @@ class Parser:
                 )
         return self.transform_parse_candidates(results)
 
+    def _parse_explicit_species_allele_candidates(self, name: str):
+        """Parse a simple, explicitly species-prefixed allele without tokenizing it.
+
+        This path reuses the complete parser's ontology-backed gene lookup,
+        allele-field parsing, and candidate transformations. It deliberately
+        returns no candidates for unprefixed, non-allele, or complex inputs so
+        callers can fall back to the general parser.
+        """
+        if self.verbose or not isinstance(name, str):
+            return []
+
+        species, name_without_species = self.parse_species_from_prefix(name)
+        if species is None:
+            return []
+
+        candidates = self.parse_allele_or_gene_candidates(
+            species=species,
+            str_after_species=self.strip_extra_chars(name_without_species),
+            raw_string=name,
+        )
+        candidates = self.transform_parse_candidates(candidates)
+        if candidates and all(
+            type(candidate) is Allele
+            and len(candidate.allele_fields) >= 2
+            and all(field.isdigit() for field in candidate.allele_fields)
+            for candidate in candidates
+        ):
+            return candidates
+        return []
+
     def parse(
         self,
         name: str,
@@ -2248,7 +2278,9 @@ class Parser:
             - Supertype
             - Class2Locus
         """
-        candidates = self.parse_multiple_candidates(name, default_species=default_species)
+        candidates = self._parse_explicit_species_allele_candidates(name)
+        if len(candidates) == 0:
+            candidates = self.parse_multiple_candidates(name, default_species=default_species)
         if len(candidates) == 0 and self.use_allele_aliases:
             resolved_alias = self._resolve_unparsed_allele_alias(name, default_species)
             if resolved_alias is not None:

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -2278,7 +2278,12 @@ class Parser:
             - Supertype
             - Class2Locus
         """
-        candidates = self._parse_explicit_species_allele_candidates(name)
+        has_candidate_filters = bool(
+            preferred_result_types or required_result_types or only_class1 or only_class2
+        )
+        candidates = (
+            [] if has_candidate_filters else self._parse_explicit_species_allele_candidates(name)
+        )
         if len(candidates) == 0:
             candidates = self.parse_multiple_candidates(name, default_species=default_species)
         if len(candidates) == 0 and self.use_allele_aliases:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.33.3"
+__version__ = "3.33.4"
 
 
 def print_version():

--- a/tests/test_fast_allele_parsing.py
+++ b/tests/test_fast_allele_parsing.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+from mhcgnomes.parser import Parser
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("HLA-A02:01", "HLA-A*02:01"),
+        ("Patr-A0101", "Patr-A*01:01"),
+        ("Mamu-A1:00101", "Mamu-A1*001:01"),
+        ("SLA-1:0101", "SLA-1*01:01"),
+        ("BoLA-1:00901", "BoLA-1*009:01"),
+        ("DLA-8803401", "DLA-88*034:01"),
+        ("Eqca-16:00101", "Eqca-16*001:01"),
+        ("Gogo-B0101", "Gogo-B*01:01"),
+    ],
+)
+def test_explicit_species_allele_fast_path_is_cross_species(monkeypatch, name, expected):
+    parser = Parser()
+
+    def fail_if_general_parser_runs(*args, **kwargs):
+        raise AssertionError("eligible allele unexpectedly used the general parser")
+
+    monkeypatch.setattr(parser, "parse_multiple_candidates", fail_if_general_parser_runs)
+
+    result = parser.parse(name)
+
+    assert result.to_string() == expected
+    assert result.raw_string == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "A*02:01",
+        "HLA-A2",
+        "BoLA-HD6",
+        "H-2-Db",
+        "Gaga-B11",
+        "Gaga-BF19",
+        "BoLA-DRA-DRB31501",
+        "HLA-DRA*01:01/DRB1*03:01",
+        "Caja-PS*02:01",
+    ],
+)
+def test_fast_path_defers_unprefixed_non_allele_and_complex_names(name):
+    assert Parser()._parse_explicit_species_allele_candidates(name) == []
+
+
+def test_fast_path_matches_general_parser_for_checked_in_netmhcpan_inventory():
+    inventory_path = Path(__file__).parents[1] / "evaluation" / "netmhcpan-4.1-alleles.txt"
+    with inventory_path.open() as inventory_file:
+        names = [line.split("\t", 1)[0].strip() for line in inventory_file if line.strip()]
+
+    fast_parser = Parser()
+    general_parser = Parser()
+    general_parser._parse_explicit_species_allele_candidates = lambda name: []
+
+    fast_results = [fast_parser.parse(name) for name in names]
+    general_results = [general_parser.parse(name) for name in names]
+
+    assert len(names) == 11_114
+    assert fast_results == general_results
+    assert [result.to_string() for result in fast_results] == [
+        result.to_string() for result in general_results
+    ]

--- a/tests/test_fast_allele_parsing.py
+++ b/tests/test_fast_allele_parsing.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 import pytest
 
+from mhcgnomes.allele import Allele
 from mhcgnomes.parser import Parser
+from mhcgnomes.serotype import Serotype
 
 
 @pytest.mark.parametrize(
@@ -48,6 +50,39 @@ def test_explicit_species_allele_fast_path_is_cross_species(monkeypatch, name, e
 )
 def test_fast_path_defers_unprefixed_non_allele_and_complex_names(name):
     assert Parser()._parse_explicit_species_allele_candidates(name) == []
+
+
+def test_fast_path_preserves_ambiguous_candidates_for_result_type_filters():
+    parser = Parser()
+
+    assert type(parser.parse("HLA-B3901")) is Allele
+    assert type(parser.parse("HLA-B3901", preferred_result_types=Serotype)) is Serotype
+    assert type(parser.parse("HLA-B3901", required_result_types=Serotype)) is Serotype
+
+
+@pytest.mark.parametrize(
+    "parse_kwargs",
+    [
+        {"preferred_result_types": Allele},
+        {"required_result_types": Allele},
+        {"only_class1": True},
+        {"only_class2": True, "raise_on_error": False},
+    ],
+)
+def test_fast_path_defers_to_general_parser_for_candidate_filters(monkeypatch, parse_kwargs):
+    parser = Parser()
+    general_parser_calls = []
+    parse_multiple_candidates = parser.parse_multiple_candidates
+
+    def track_general_parser(*args, **kwargs):
+        general_parser_calls.append((args, kwargs))
+        return parse_multiple_candidates(*args, **kwargs)
+
+    monkeypatch.setattr(parser, "parse_multiple_candidates", track_general_parser)
+
+    parser.parse("HLA-B3901", **parse_kwargs)
+
+    assert len(general_parser_calls) == 1
 
 
 def test_fast_path_matches_general_parser_for_checked_in_netmhcpan_inventory():


### PR DESCRIPTION
Closes #84.

## Summary

- add an automatic fast path for simple, explicitly species-prefixed alleles
- reuse the existing species ontology, gene lookup, allele-field parser, candidate transforms, and ranking instead of adding a name-based biological heuristic
- fall back to the complete parser unless every normalized direct candidate is a concrete allele with at least two numeric fields
- cover human, non-human primate, pig, cattle, dog, horse, and gorilla predictor formats, plus ambiguous and complex fallback cases
- bump the package version to 3.33.4

This speeds up existing `mhcgnomes.parse()` loops without requiring downstream callers to adopt a new bulk API. Unprefixed names, one-field or letter-valued alleles, haplotypes, named alleles, pairs, complex strings, and the Caja legacy alias continue through the general parser.

## Performance

The benchmark parses the first column of the checked-in netMHCpan 4.1 inventory (11,114 names) in a fresh process. Five runs of public PyPI 3.33.3 and this branch were alternated on the same Python 3.12 / Apple Silicon host.

| version | median cold parse | rate |
|---|---:|---:|
| 3.33.3 | 1.553888 s | ~7,152 names/s |
| this PR | 0.682066 s | ~16,294 names/s |

That is a **2.28x speedup**. The fast route handles 11,055 inventory entries; the remaining 59 use the full parser.

## Correctness and review

- all 11,114 inventory results match a fast-path-disabled parser as objects and normalized strings
- scanned 461 curated haplotype, serotype, heterodimer, and supertype names with zero fast/general mismatches
- regression coverage keeps `Gaga-B11` / `Gaga-BF19` as haplotypes and `BoLA-DRA-DRB31501` as a class-II pair
- no new regex or species-specific performance table

## Verification

- `./format.sh`
- `./lint.sh`
- `./test.sh` — 15,117 passed
- built the 3.33.4 sdist and wheel
- wheel-only cross-species and fallback smoke tests
- verified `tasks/` is absent from both artifacts
