### PR TITLE
Add CLI version and locale-safe data loading

### DIFF
--- a/mhcgnomes/cli.py
+++ b/mhcgnomes/cli.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from .errors import ParseError
 from .function_api import parse
+from .version import __version__
 
 COLUMN_NAMES = (
     "input",
@@ -111,6 +112,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "names",
         nargs="*",
         help="MHC names to parse. If omitted, non-empty lines are read from stdin.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument(
         "--default-species",

--- a/mhcgnomes/data.py
+++ b/mhcgnomes/data.py
@@ -26,7 +26,7 @@ def get_path(yaml_filename):
 
 def load(yaml_filename, normalize_first_level_keys=False, normalize_second_level_keys=False):
     path = get_path(yaml_filename)
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         result = yaml.safe_load(f)
 
     if normalize_second_level_keys:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.33.4"
+__version__ = "3.33.5"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,31 @@
+# CLI version and locale-independent data loading
+
+Tracking issues: #95, #96
+
+## Specification
+
+- [x] Add a conventional `mhcgnomes --version` flag backed by the package's existing
+      `mhcgnomes.version.__version__` source of truth.
+- [x] Add a regression test proving the module CLI prints the program name and package version,
+      exits successfully, and does not require an MHC name.
+- [x] Decode bundled YAML package data explicitly as UTF-8 so imports do not depend on the host
+      locale.
+- [x] Add a regression test that imports `mhcgnomes` successfully with UTF-8 mode disabled under
+      the C/ASCII locale.
+- [x] Bump the patch version for the PR.
+- [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
+- [x] Review the final diff for minimal scope and document results below.
+
+## Review
+
+- Added argparse's standard version action using the existing package version source of truth.
+- Made the bundled YAML loader decode UTF-8 explicitly; `species.yaml` was the first failing file
+  under the C/ASCII locale because it contains UTF-8 box-drawing characters in comments.
+- Added focused regressions for `--version` and package import with UTF-8 mode disabled under the
+  C/ASCII locale.
+- Bumped the package from 3.33.4 to 3.33.5.
+- Verified `python -m mhcgnomes --version` and the project virtualenv's `mhcgnomes --version` both
+  print `mhcgnomes 3.33.5`.
+- `./format.sh`: passed (133 files unchanged).
+- `./lint.sh`: passed.
+- `./test.sh`: passed (15,124 tests, 91% coverage).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,17 +15,23 @@ Tracking issues: #95, #96
 - [x] Bump the patch version for the PR.
 - [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
 - [x] Review the final diff for minimal scope and document results below.
+- [x] Strengthen the locale regression into an end-to-end CLI parse using bundled data and JSON
+      output, without monkeypatching runtime behavior.
 
 ## Review
 
 - Added argparse's standard version action using the existing package version source of truth.
 - Made the bundled YAML loader decode UTF-8 explicitly; `species.yaml` was the first failing file
   under the C/ASCII locale because it contains UTF-8 box-drawing characters in comments.
-- Added focused regressions for `--version` and package import with UTF-8 mode disabled under the
-  C/ASCII locale.
+- Audited all eight runtime YAML files: non-ASCII text is limited to existing comments in
+  `species.yaml`, `gene_aliases.yaml`, and `known_alleles.yaml`; all YAML values are currently
+  ASCII, and every file decodes cleanly as UTF-8.
+- Added focused regressions for `--version` and an end-to-end CLI parse with UTF-8 mode disabled
+  under the C/ASCII locale. The locale test loads bundled ontology data, parses and normalizes a
+  real HLA allele, renders JSON, and validates the public result without monkeypatching.
 - Bumped the package from 3.33.4 to 3.33.5.
 - Verified `python -m mhcgnomes --version` and the project virtualenv's `mhcgnomes --version` both
   print `mhcgnomes 3.33.5`.
 - `./format.sh`: passed (133 files unchanged).
 - `./lint.sh`: passed.
-- `./test.sh`: passed (15,124 tests, 91% coverage).
+- `./test.sh`: passed (15,124 tests, 91.17% statement coverage).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ import json
 import subprocess
 import sys
 
+from mhcgnomes.version import __version__
+
 
 def run_cli(*args):
     return subprocess.run(
@@ -29,6 +31,14 @@ def test_cli_help():
     assert "usage:" in result.stdout.lower()
     assert "mhcgnomes" in result.stdout.lower()
     assert "mhcgnomes data" in result.stdout
+
+
+def test_cli_version():
+    result = run_cli("--version")
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == f"mhcgnomes {__version__}"
+    assert result.stderr == ""
 
 
 def test_data_command_lists_sources_by_default():

--- a/tests/test_data_encoding.py
+++ b/tests/test_data_encoding.py
@@ -1,9 +1,10 @@
+import json
 import os
 import subprocess
 import sys
 
 
-def test_package_import_succeeds_under_ascii_locale():
+def test_cli_parses_bundled_data_under_ascii_locale():
     env = os.environ.copy()
     env.update(
         {
@@ -15,7 +16,14 @@ def test_package_import_succeeds_under_ascii_locale():
     )
 
     result = subprocess.run(
-        [sys.executable, "-c", "import mhcgnomes"],
+        [
+            sys.executable,
+            "-m",
+            "mhcgnomes",
+            "--format",
+            "json",
+            "HLA-A*02:01",
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -23,3 +31,13 @@ def test_package_import_succeeds_under_ascii_locale():
     )
 
     assert result.returncode == 0, result.stderr
+    rows = json.loads(result.stdout)
+    assert len(rows) == 1
+    assert rows[0]["input"] == "HLA-A*02:01"
+    assert rows[0]["type"] == "Allele"
+    assert rows[0]["normalized"] == "HLA-A*02:01"
+    assert rows[0]["compact"] == "A0201"
+    assert rows[0]["species"] == "HLA"
+    assert rows[0]["gene"] == "A"
+    assert rows[0]["mhc_class"] == "Ia"
+    assert "species_name=Homo sapiens" in rows[0]["properties"]

--- a/tests/test_data_encoding.py
+++ b/tests/test_data_encoding.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+import sys
+
+
+def test_package_import_succeeds_under_ascii_locale():
+    env = os.environ.copy()
+    env.update(
+        {
+            "LANG": "C",
+            "LC_ALL": "C",
+            "PYTHONCOERCECLOCALE": "0",
+            "PYTHONUTF8": "0",
+        }
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import mhcgnomes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- add a conventional `mhcgnomes --version` flag backed by `mhcgnomes.__version__`
- decode bundled YAML package data explicitly as UTF-8 so imports are independent of the host
  locale
- add regressions for the version flag and C/ASCII-locale imports
- bump the package version to 3.33.5

## Root cause and impact

The CLI parser never registered argparse's version action even though the package already had a
single version source of truth.

Separately, `mhcgnomes/data.py` called `open(path)` without an encoding. Under `LC_ALL=C` with
Python UTF-8 mode disabled, importing `mhcgnomes` failed while reading `species.yaml` at its first
UTF-8 box-drawing character. No package file requires a non-UTF-8 encoding; the loader was
incorrectly relying on the platform default. This could prevent downstream CLIs such as Vaxrank
from starting on non-UTF-8 systems.

An audit of all eight runtime YAML files found that their values are currently ASCII. Existing
comments in `species.yaml`, `gene_aliases.yaml`, and `known_alleles.yaml` contain valid UTF-8 tree
drawing characters, arrows, an em dash, and beta. The PR does not modify those data files; it makes
their encoding contract explicit.

## Validation

- `./format.sh`
- `./lint.sh`
- `./test.sh` — 15,124 passed, 91.17% statement coverage
- `python -m mhcgnomes --version` → `mhcgnomes 3.33.5`
- end-to-end CLI parse under `LC_ALL=C`, `PYTHONUTF8=0`, and `PYTHONCOERCECLOCALE=0`, validating
  bundled-data loading, HLA allele parsing and normalization, and JSON output

Fixes #95
Fixes #96
