### PR TITLE
Normalize DLA-88 allele field widths

### DIFF
--- a/mhcgnomes/data.py
+++ b/mhcgnomes/data.py
@@ -54,6 +54,10 @@ allele_aliases = load(
     "allele_aliases.yaml", normalize_first_level_keys=True, normalize_second_level_keys=True
 )
 
+# Curated minimum width of the first allele field, keyed by species and gene.
+# These entries override widths inferred from canonical allele-alias targets.
+first_allele_field_widths = load("first_allele_field_widths.yaml")
+
 # Dictionary mapping species -> gene -> list of known allele names
 known_alleles = load(
     "known_alleles.yaml", normalize_first_level_keys=True, normalize_second_level_keys=True
@@ -115,6 +119,9 @@ def _compute_min_first_field_widths():
         for key, counter in counters.items():
             # Use the most common width as the canonical minimum
             widths[key] = counter.most_common(1)[0][0]
+    for species_prefix, genes in first_allele_field_widths.items():
+        for gene_name, width in genes.items():
+            widths[(species_prefix, str(gene_name))] = int(width)
     return widths
 
 

--- a/mhcgnomes/data/first_allele_field_widths.yaml
+++ b/mhcgnomes/data/first_allele_field_widths.yaml
@@ -1,0 +1,6 @@
+# Curated minimum width of the first allele field for genes whose official
+# nomenclature differs from the two-digit default. IPD-MHC is the authoritative
+# source for non-human MHC names:
+# https://www.ebi.ac.uk/ipd/mhc/group/DLA/
+DLA:
+  "88": 3

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.33.5"
+__version__ = "3.33.6"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,37 +1,33 @@
-# CLI version and locale-independent data loading
+# Canonical DLA-88 allele-field width
 
-Tracking issues: #95, #96
+Tracking issues: #2, #99
 
 ## Specification
 
-- [x] Add a conventional `mhcgnomes --version` flag backed by the package's existing
-      `mhcgnomes.version.__version__` source of truth.
-- [x] Add a regression test proving the module CLI prints the program name and package version,
-      exits successfully, and does not require an MHC name.
-- [x] Decode bundled YAML package data explicitly as UTF-8 so imports do not depend on the host
-      locale.
-- [x] Add a regression test that imports `mhcgnomes` successfully with UTF-8 mode disabled under
-      the C/ASCII locale.
-- [x] Bump the patch version for the PR.
-- [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
-- [x] Review the final diff for minimal scope and document results below.
-- [x] Strengthen the locale regression into an end-to-end CLI parse using bundled data and JSON
-      output, without monkeypatching runtime behavior.
+- [x] Add a small curated data source for gene-specific first allele-field widths,
+      independent of incidental aliases.
+- [x] Record the official three-digit DLA-88 first-field convention from IPD-MHC.
+- [x] Normalize historical two-digit DLA-88 inputs to the same canonical allele as
+      three-digit inputs, with focused parser regressions.
+- [x] Preserve wider DLA-88 allele families such as `501` unchanged.
+- [x] Make `test.sh` execute pytest through the same Python interpreter used to
+      detect optional xdist support, with a regression test for mismatched PATHs.
+- [x] Bump the patch version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
+- [x] Review the final diff and document the result below.
 
 ## Review
 
-- Added argparse's standard version action using the existing package version source of truth.
-- Made the bundled YAML loader decode UTF-8 explicitly; `species.yaml` was the first failing file
-  under the C/ASCII locale because it contains UTF-8 box-drawing characters in comments.
-- Audited all eight runtime YAML files: non-ASCII text is limited to existing comments in
-  `species.yaml`, `gene_aliases.yaml`, and `known_alleles.yaml`; all YAML values are currently
-  ASCII, and every file decodes cleanly as UTF-8.
-- Added focused regressions for `--version` and an end-to-end CLI parse with UTF-8 mode disabled
-  under the C/ASCII locale. The locale test loads bundled ontology data, parses and normalizes a
-  real HLA allele, renders JSON, and validates the public result without monkeypatching.
-- Bumped the package from 3.33.4 to 3.33.5.
-- Verified `python -m mhcgnomes --version` and the project virtualenv's `mhcgnomes --version` both
-  print `mhcgnomes 3.33.5`.
-- `./format.sh`: passed (133 files unchanged).
+- Added an explicit, package-data-backed gene-width table instead of encoding
+  DLA nomenclature as a synthetic allele alias. Curated entries override the
+  widths inferred from real canonical alias targets.
+- Verified against the official IPD-MHC DLA catalog, which names the family
+  `DLA-88*001:01` and consistently uses three-digit first fields.
+- Historical `DLA-88*01:01` now equals and renders as `DLA-88*001:01`; an
+  independent regression proves `DLA-88*501:01` is not modified.
+- Fixed issue #99 by executing pytest as a module of the same Python used for
+  optional xdist detection; the regression supplies deliberately mismatched
+  `python` and `pytest` executables on PATH.
+- Bumped 3.33.5 to 3.33.6.
+- `./format.sh`: passed.
 - `./lint.sh`: passed.
-- `./test.sh`: passed (15,124 tests, 91.17% statement coverage).
+- `./test.sh`: passed (15,127 tests; 91% statement coverage).

--- a/test.sh
+++ b/test.sh
@@ -105,4 +105,4 @@ else
     log "→ exec pytest --cov=mhcgnomes/ --cov-report=term-missing tests $*"
 fi
 
-exec pytest "${XDIST_FLAGS[@]}" --cov=mhcgnomes/ --cov-report=term-missing tests "$@"
+exec python -m pytest "${XDIST_FLAGS[@]}" --cov=mhcgnomes/ --cov-report=term-missing tests "$@"

--- a/tests/test_dog.py
+++ b/tests/test_dog.py
@@ -47,6 +47,18 @@ def test_parse_dog_class1_allele_dla_88_508_01():
     eq_(parsed, expected)
 
 
+def test_dla_88_first_field_uses_official_three_digit_width():
+    historical = parse("DLA-88*01:01")
+    canonical = parse("DLA-88*001:01")
+
+    eq_(historical, canonical)
+    eq_(historical.to_string(), "DLA-88*001:01")
+
+
+def test_dla_88_wider_first_field_is_preserved():
+    eq_(parse("DLA-88*501:01").to_string(), "DLA-88*501:01")
+
+
 def test_compact_string_dog_class1_allele_dla_88_508_01():
     eq_(parse("DLA-88*50801").compact_string(), "88*50801")
 

--- a/tests/test_standard_format.py
+++ b/tests/test_standard_format.py
@@ -24,9 +24,9 @@ def test_parse_standard_allele_format_HLA_A_02_01_01_02L():
     eq_(result, Allele.get("HLA", "A", "02", "01", "01", "02", annotation="L"))
 
 
-def test_parse_standard_allele_format_DLA_88_021_01():
+def test_parse_standard_allele_format_DLA_88_001_01():
     result = parse_standard_allele_format(seq="DLA-88*01:01")
-    eq_(result, Allele.get("DLA", "88", "01", "01"))
+    eq_(result, Allele.get("DLA", "88", "001", "01"))
 
 
 def test_parse_standard_allele_format_A_02_01():

--- a/tests/test_test_script.py
+++ b/tests/test_test_script.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_test_sh_uses_python_module_for_pytest(tmp_path):
+    marker = tmp_path / "python-pytest-called"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "-c" ]; then exit 1; fi\n'
+        'if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then\n'
+        '  touch "$MHCGENOMES_TEST_MARKER"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 2\n"
+    )
+    fake_python.chmod(0o755)
+
+    fake_pytest = fake_bin / "pytest"
+    fake_pytest.write_text("#!/bin/sh\nexit 97\n")
+    fake_pytest.chmod(0o755)
+
+    repo_dir = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join((str(fake_bin), env["PATH"]))
+    env["MHCGENOMES_TEST_MARKER"] = str(marker)
+    result = subprocess.run(
+        ["bash", "test.sh", "--collect-only"],
+        cwd=repo_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert marker.exists()


### PR DESCRIPTION
## Summary

- add a curated gene-specific first-field width table
- normalize historical DLA-88 two-digit inputs to official three-digit names
- preserve already canonical and wider DLA-88 fields
- make test.sh use the same Python interpreter for xdist detection and pytest execution
- bump mhcgnomes to 3.33.6

Closes #2.
Closes #99.

## Scientific provenance

The official IPD-MHC DLA catalog uses three-digit first allele fields for DLA-88, including DLA-88*001:01: https://www.ebi.ac.uk/ipd/mhc/group/DLA/

## Verification

- ./format.sh
- ./lint.sh
- ./test.sh: 15,127 passed; 91% statement coverage