### PR TITLE
Add IPD-MHC species and IMGT/HLA genes found missing by sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,16 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
   (#109); `Caau` pointed at a goldfish rather than the golden jackal IPD
   designates (#112). Existing tests can encode the same errors — check the
   authority before assuming a failing test means your change is wrong.
+- **An official designation is not the same as attested usage.** The naming
+  rule is mechanical, so several species can derive the same code, and only
+  one of them is usually the one that appears in print — the rest are
+  synthetic. Before handing a prefix to a species because a committee assigned
+  it, check whether anyone has actually published alleles under it. `Caau` is
+  designated to *Canis aureus*, which has no deposited sequences, while
+  `Caau-DAB` and `Caau-UFA` are in active use for *Carassius auratus*; giving
+  the designation the runtime prefix silently broke every goldfish parse.
+  Where they conflict, the attested side gets the prefix and the designation
+  is recorded as `context only prefixes`.
 - **Flag inconsistencies**: if code expresses a scientific model at odds with
   the literature, say so and file it rather than working around it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,5 +87,59 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
 - **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
 
 ## Scientific Domain Knowledge
-- **Read the literature**: if some code involves scientific or biological concepts, feel free to search for review papers and read those before changing code that expresses scientific concepts.
-- **Flag inconsistencies**: if code expresses a scientific model that's at odds with your understanding, note that inconsistency and ask for clarification.
+
+- **Read the literature. Always.** Before changing anything that expresses a
+  scientific claim — a gene's class, a species' prefix, a parent-child
+  relationship, a pseudogene flag — go and read the source. Do not reason from
+  the name, from what is already in the file, or from what sounds right.
+- **Do not guess.** If you cannot find a source, say so plainly and leave the
+  data alone. "I could not establish this" is a valid, useful answer. A
+  confident guess written into a curated ontology is worse than a gap, because
+  the next reader cannot tell it from a checked fact.
+- **Do not assume our existing curation is right.** It is a secondary source
+  and it has been wrong: Patr-AL was class Ia when the paper describing it is
+  titled "nonclassical" (#107); water buffalo is parented under `Bos sp.`
+  (#109); `Caau` pointed at a goldfish rather than the golden jackal IPD
+  designates (#112). Existing tests can encode the same errors — check the
+  authority before assuming a failing test means your change is wrong.
+- **Flag inconsistencies**: if code expresses a scientific model at odds with
+  the literature, say so and file it rather than working around it.
+
+### Authorities to check
+
+Check the primary source, not a summary of it. When a tool summarizes a page
+for you, re-read the specific claim verbatim before acting on it — summaries
+invent plausible entries (a summary of the IPD-MHC group list reported "CLA =
+cat" and "CeLA = deer"; both are wrong — CLA is goat, CeLA is cetacean).
+
+| resource | authoritative for | where |
+|---|---|---|
+| IPD-MHC | non-human species designations, prefixes, loci | `ebi.ac.uk/ipd/mhc/group/<CODE>/species` |
+| IMGT/HLA | human gene names and pseudogene status | `hla.alleles.org/genes/index.html` |
+| Comparative MHC Nomenclature Committee | official prefix assignments (via IPD-MHC) | `ebi.ac.uk/ipd/mhc/committee/` |
+| Klein et al. 1990 | the naming rule itself | Immunogenetics 31:217-219, PMID 2329006 |
+| de Groot et al. 2019/2020 | primate MHC nomenclature report | Immunogenetics 72:25-36 |
+| NCBI Taxonomy / GBIF | species synonymy and rank | for parent-child questions |
+
+The species prefix rule (Klein 1990, restated on every IPD-MHC nomenclature
+page) is **first two letters of the genus, last two of the species** — `Patr`
+for *Pan troglodytes*. It is mechanical, so a prefix can be checked by
+derivation, and a prefix that cannot be derived from a species' binomial does
+not belong to it.
+
+### Record the source
+
+**When you establish something from a source, cite it where the data lives** —
+a comment in `species.yaml` next to the entry, or in the code next to the rule.
+Include the PMID or URL and one line on what it establishes, so the next person
+does not have to redo the search. Follow the style already in `species.yaml`:
+
+```yaml
+    Ib:
+      # PMID 11564803 (Adams, Cooper & Parham, J Immunol 2001;167:3858) named
+      # AL a nonclassical class I molecule in its title: only three allotypes,
+      # present on ~50% of chimpanzee MHC haplotypes, low expression.
+      - AL
+```
+
+A finding that is not written down next to the data will be re-litigated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@ See @AGENTS.md for verification steps, workflow principles, and domain knowledge
 - Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
 - Use plan mode for verification steps, not just building
 
+### Scientific Claims
+- Before editing anything in `mhcgnomes/data/`, read the authority — see
+  "Scientific Domain Knowledge" in @AGENTS.md. Use WebFetch/WebSearch on
+  IPD-MHC, IMGT/HLA and the primary literature; do not answer from memory.
+- Re-read any specific claim verbatim before acting on it. Summarized pages
+  routinely invent plausible rows.
+- Cite what you find in the YAML or code next to the change, with a PMID or URL.
+
 ### Subagent Strategy
 - Use subagents liberally to keep main context window clean
 - Offload research, exploration, and parallel analysis to subagents

--- a/mhcgnomes/data/gene_aliases.yaml
+++ b/mhcgnomes/data/gene_aliases.yaml
@@ -10,6 +10,10 @@ Gnathostomata sp.:
   ABCB9: TAP-L
   TAPL: TAP-L
 HLA:
+  # Legacy names for the immunoproteasome subunits, the same shape as the
+  # RING4/RING11 aliases for TAP1/TAP2 above.
+  LMP7: PSMB8
+  LMP2: PSMB9
   Cw: C
   DPw: DP
   # unclear if there are any other DRA genes besides DRA1

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -447,7 +447,8 @@ Homo sapiens:
     Ic:
       - MICA
       - MICB
-      # MICC/D/E are pseudogenes of the MIC family, curated by IMGT/HLA
+      # MICC/D/E are pseudogenes of the MIC family, named by IMGT/HLA:
+      # https://hla.alleles.org/genes/index.html
       - MICC
       - MICD
       - MICE
@@ -462,7 +463,8 @@ Homo sapiens:
     I:
       # pseudogenes
       #
-      # IMGT/HLA also names the class I gene fragments N, R, S, T, U, W, X, Y
+      # IMGT/HLA (https://hla.alleles.org/genes/index.html) also names the
+      # class I gene fragments N, R, S, T, U, W, X, Y
       # and Z. They are deliberately not listed here: every one is a single
       # letter, and adding them flips bare "n", "s", "t", "u" and "w" from the
       # mouse/rat haplotype shorthand they resolve to today into human gene
@@ -908,7 +910,9 @@ Rattus villosissimus:
 #
 ############################
 # Canidae is a real taxonomic rank, the same shape as Cetacea sp. and
-# Galliformes sp. above, and it is what IPD-MHC's "Canids" group covers.
+# Galliformes sp. above, and it is what IPD-MHC's "Canids" group covers:
+# https://www.ebi.ac.uk/ipd/mhc/group/DLA/species lists Cuon alpinus and
+# Lycaon pictus alongside the Canis species.
 # Cuon and Lycaon are canids but not Canis, so they hang here rather than
 # under Canis sp., which would hand them the DLA prefix and the Canis gene
 # list on no evidence -- the mistake described in issue #109.
@@ -1264,10 +1268,13 @@ Hippocampus abdominalis:
   name: Pot-bellied seahorse
 Carassius auratus:
   parent: Cyprinidae sp.
-  # Caau is the Klein 2+2 code for both Carassius auratus and Canis aureus,
-  # and IPD-MHC assigns it to Canis aureus. Keep Caau as a context-only rescue
-  # alias for species= records and use CaraAura as the runtime prefix, the same
-  # way Hypophthalmichthys molitrix yields Hymo to Hylobates moloch.
+  # Both Carassius auratus and Canis aureus derive Caau under the Klein 2+2
+  # rule (Immunogenetics 1990;31:217-219, PMID 2329006), so this is a genuine
+  # namespace collision rather than a bad alias. IPD-MHC designates Caau to
+  # Canis aureus (https://www.ebi.ac.uk/ipd/mhc/group/DLA/species), so the
+  # global prefix goes there; Caau stays here as a context-only rescue alias
+  # for species= records, the same way Hypophthalmichthys molitrix yields Hymo
+  # to Hylobates moloch.
   prefix: CaraAura
   other prefixes:
     - Caur
@@ -1550,8 +1557,10 @@ Carassius langsdorfii:
   name: Ginbuna
 Hybognathus amarus:
   parent: Actinopterygii sp.
-  # Hyam collides with Hyperoodon ampullatus, which IPD-MHC designates Hyam.
-  # Context-only for the same reason as Carassius auratus above.
+  # Both this species and Hyperoodon ampullatus derive Hyam under the Klein
+  # 2+2 rule (PMID 2329006). IPD-MHC designates Hyam to Hyperoodon ampullatus
+  # (https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species), so context-only here
+  # for the same reason as Carassius auratus above.
   prefix: HyboAmar
   context only prefixes:
     - Hyam
@@ -2688,7 +2697,9 @@ Equus burchelli:
 #
 ################################################################################
 # Suidae for the same reason as Canidae above: Phacochoerus is a suid but
-# not a Sus, and IPD-MHC's SLA group covers the family.
+# not a Sus, and IPD-MHC's SLA group covers the family --
+# https://www.ebi.ac.uk/ipd/mhc/group/SLA/species lists Phacochoerus africanus
+# alongside Sus domesticus and Sus scrofa.
 Suidae sp.:
   prefix: Suidae
   name: Suid
@@ -5187,6 +5198,10 @@ Saimiri sciureus:
 Semnopithecus entellus:
   parent: Primata sp.
   prefix: Seen
+  # Pren = Pr(esbytis) + en(tellus) under the Klein 1990 rule (PMID 2329006).
+  # Presbytis entellus is the former name of this species, so it is the only
+  # species the prefix can derive from. IPD-MHC designates it Seen:
+  # https://www.ebi.ac.uk/ipd/mhc/group/NHP/species
   old prefix: Pren
   name: Northern Plains Gray Langur
   genes:
@@ -5199,9 +5214,19 @@ Semnopithecus entellus:
 Theropithecus gelada:
   parent: Primata sp.
   prefix: Thge
-  # No 'old prefix: Pren' here. Pren is Presbytis entellus, the former name of
-  # Semnopithecus entellus, which carries it below. Theropithecus was never in
-  # Presbytis, and IPD-MHC lists this species only as Thge.
+  # No 'old prefix: Pren' here, deliberately.
+  #
+  # The species prefix is mechanical: first two letters of the genus, last two
+  # of the species (Klein et al., Immunogenetics 1990;31:217-219, PMID 2329006;
+  # restated at https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature/).
+  # Theropithecus gelada gives Th+ge = Thge, and no derivation of it produces
+  # Pren. Pren is Pr(esbytis) + en(tellus), the former name of Semnopithecus
+  # entellus, which carries it below. IPD-MHC lists this species only as Thge:
+  # https://www.ebi.ac.uk/ipd/mhc/group/NHP/species
+  #
+  # The 2019 primate nomenclature report (de Groot et al., Immunogenetics
+  # 2020;72:25-36) covers neither this species nor the langur, so there is no
+  # published Pren- allele designation for either.
   name: Gelada
   genes:
     IIa:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -464,9 +464,9 @@ Homo sapiens:
       # pseudogenes
       #
       # IMGT/HLA (https://hla.alleles.org/genes/index.html) also names the
-      # class I gene fragments N, R, S, T, U, W, X, Y
-      # and Z. They are deliberately not listed here: every one is a single
-      # letter, and adding them flips bare "n", "s", "t", "u" and "w" from the
+      # class I gene fragments N, R, S, T, U, W, X, Y and Z. They are
+      # deliberately not listed here: every one is a single letter, and
+      # adding them flips bare "n", "s", "t", "u" and "w" from the
       # mouse/rat haplotype shorthand they resolve to today into human gene
       # fragments, and lets allele-less fragments accept allele fields
       # ("Z*01:01"). The same shadowing already affects H/J/K/L/P/V versus

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -447,6 +447,10 @@ Homo sapiens:
     Ic:
       - MICA
       - MICB
+      # MICC/D/E are pseudogenes of the MIC family, curated by IMGT/HLA
+      - MICC
+      - MICD
+      - MICE
       - BTN3A1
     Id:
       - CD1a
@@ -457,6 +461,14 @@ Homo sapiens:
       - MR1
     I:
       # pseudogenes
+      #
+      # IMGT/HLA also names the class I gene fragments N, R, S, T, U, W, X, Y
+      # and Z. They are deliberately not listed here: every one is a single
+      # letter, and adding them flips bare "n", "s", "t", "u" and "w" from the
+      # mouse/rat haplotype shorthand they resolve to today into human gene
+      # fragments, and lets allele-less fragments accept allele fields
+      # ("Z*01:01"). The same shadowing already affects H/J/K/L/P/V versus
+      # H2-k and friends, which needs resolving first. See issue #113.
       - H
       - J
       - K
@@ -471,6 +483,7 @@ Homo sapiens:
         - DRB4
         - DRB5
         # DR beta-family pseudogenes still belong to the DR class II locus family.
+        - DRB2
         - DRB6
         - DRB7
         - DRB8
@@ -478,11 +491,17 @@ Homo sapiens:
       DP:
         - DPA1
         - DPB1
+        # DP pseudogenes
+        - DPA2
+        - DPA3
+        - DPB2
       DQ:
         - DQA1
         - DQA2
         - DQB1
         - DQB2
+        # DQ pseudogene
+        - DQB3
     IIb:
       DO:
         - DOA
@@ -490,6 +509,13 @@ Homo sapiens:
       DM:
         - DMA
         - DMB
+    other:
+      # Immunoproteasome subunits in the MHC class II region, historically
+      # LMP7 and LMP2. Kept on Homo sapiens because IMGT/HLA curates the HLA-
+      # prefixed forms; they are conserved across jawed vertebrates and could
+      # move up to the root alongside TAP1/TAP2 given a per-clade review.
+      - PSMB8
+      - PSMB9
   # Source: https://www.ebi.ac.uk/ipd/imgt/hla/about/statistics/
   gene properties:
     G: {pseudogene: false}
@@ -499,10 +525,18 @@ Homo sapiens:
     L: {pseudogene: true}
     P: {pseudogene: true}
     V: {pseudogene: true}
+    DRB2: {pseudogene: true}
     DRB6: {pseudogene: true}
     DRB7: {pseudogene: true}
     DRB8: {pseudogene: true}
     DRB9: {pseudogene: true}
+    DQB3: {pseudogene: true}
+    DPA2: {pseudogene: true}
+    DPA3: {pseudogene: true}
+    DPB2: {pseudogene: true}
+    MICC: {pseudogene: true}
+    MICD: {pseudogene: true}
+    MICE: {pseudogene: true}
 ######################################################
 #
 # Mouse
@@ -873,7 +907,25 @@ Rattus villosissimus:
 # - https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
 #
 ############################
+# Canidae is a real taxonomic rank, the same shape as Cetacea sp. and
+# Galliformes sp. above, and it is what IPD-MHC's "Canids" group covers.
+# Cuon and Lycaon are canids but not Canis, so they hang here rather than
+# under Canis sp., which would hand them the DLA prefix and the Canis gene
+# list on no evidence -- the mistake described in issue #109.
+# The prefix is taxonomic, so descendants do not inherit it as an alias.
+Canidae sp.:
+  prefix: Canidae
+  name: Canid
+Cuon alpinus:
+  parent: Canidae sp.
+  prefix: Cual
+  name: Dhole
+Lycaon pictus:
+  parent: Canidae sp.
+  prefix: Lypi
+  name: African wild dog
 Canis sp.:
+  parent: Canidae sp.
   prefix: DLA
   name: Canine
   genes:
@@ -920,6 +972,14 @@ Canis aureus:
   parent: Canis sp.
   prefix: Caau
   name: Golden Jackal
+Canis adustus:
+  parent: Canis sp.
+  prefix: Caad
+  name: Side-striped jackal
+Canis mesomelas:
+  parent: Canis sp.
+  prefix: Came
+  name: Black-backed jackal
 ############################
 #
 # Felidae
@@ -2463,6 +2523,57 @@ Ziphius cavirostris:
   parent: Cetacea sp.
   prefix: Zica
   name: Cuvier's beaked whale
+############################
+#
+# Remaining cetaceans designated by IPD-MHC.
+#
+# Source: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+#
+############################
+Balaenoptera musculus brevicauda:
+  parent: Cetacea sp.
+  prefix: Bamubr
+  name: Pygmy blue whale
+Balaenoptera ricei:
+  parent: Cetacea sp.
+  prefix: Bari
+  name: Rice's whale
+Eschrichtius robustus:
+  parent: Cetacea sp.
+  prefix: Esro
+  name: Gray whale
+Eubalaena glacialis:
+  parent: Cetacea sp.
+  prefix: Eugl
+  name: North Atlantic right whale
+Inia geoffrensis:
+  parent: Cetacea sp.
+  prefix: Inge
+  name: Amazon river dolphin
+Kogia sima:
+  parent: Cetacea sp.
+  prefix: Kosi
+  name: Dwarf sperm whale
+Lagenorhynchus albirostris:
+  parent: Cetacea sp.
+  prefix: Laal
+  name: White-beaked dolphin
+Lipotes vexillifer:
+  parent: Cetacea sp.
+  prefix: Live
+  name: Baiji
+Monodon monoceros:
+  parent: Cetacea sp.
+  prefix: Momo
+  name: Narwhal
+Phocoena phocoena:
+  parent: Cetacea sp.
+  prefix: Phph
+  name: Harbor porpoise
+Phocoena sinus:
+  parent: Cetacea sp.
+  prefix: Phsi
+  name: Vaquita
 Caperea marginata:
   parent: Cetacea sp.
   prefix: CapeMarg
@@ -2576,7 +2687,17 @@ Equus burchelli:
 # - https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
 #
 ################################################################################
+# Suidae for the same reason as Canidae above: Phacochoerus is a suid but
+# not a Sus, and IPD-MHC's SLA group covers the family.
+Suidae sp.:
+  prefix: Suidae
+  name: Suid
+Phacochoerus africanus:
+  parent: Suidae sp.
+  prefix: Phaf
+  name: Common warthog
 Sus sp.:
+  parent: Suidae sp.
   prefix: SLA
   name:
     - Pig
@@ -4338,6 +4459,54 @@ Cebus apella:
       DR:
         - DRA
         - DRB
+############################
+#
+# Remaining capuchins designated by IPD-MHC. Loci are not yet curated for
+# these; only the official species designations are recorded.
+#
+# Source: https://www.ebi.ac.uk/ipd/mhc/group/NHP/species
+#
+############################
+Cebus albifrons:
+  parent: Primata sp.
+  prefix: Ceal
+  name: White-fronted capuchin
+Cebus capucinus:
+  parent: Primata sp.
+  prefix: Ceca
+  name: White-faced capuchin
+Cebus imitator:
+  parent: Primata sp.
+  prefix: Ceim
+  name: Panamanian white-faced capuchin
+Cebus kaapori:
+  parent: Primata sp.
+  prefix: Ceka
+  name: Kaapori capuchin
+Cebus olivaceus:
+  parent: Primata sp.
+  prefix: Ceol
+  name: Wedge-capped capuchin
+Sapajus cay:
+  parent: Primata sp.
+  prefix: Saca
+  name: Hooded capuchin
+Sapajus libidinosus:
+  parent: Primata sp.
+  prefix: Sali
+  name: Black-striped capuchin
+Sapajus apella macrocephalus:
+  parent: Primata sp.
+  prefix: Sama
+  name: Large-headed capuchin
+Sapajus nigritus:
+  parent: Primata sp.
+  prefix: Sani
+  name: Black capuchin
+Sapajus xanthosternos:
+  parent: Primata sp.
+  prefix: Saxa
+  name: Golden-bellied capuchin
 Cercocebus atys:
   parent: Primata sp.
   prefix: Ceat

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -974,7 +974,16 @@ Canis simensis:
   name: Ethiopian Wolf
 Canis aureus:
   parent: Canis sp.
-  prefix: Caau
+  # IPD-MHC designates this species Caau
+  # (https://www.ebi.ac.uk/ipd/mhc/group/DLA/species) but holds no allele
+  # sequences for it, while Caau-* is in active use for Carassius auratus in
+  # the cyprinid MHC literature. So the designation is recorded as context-only
+  # -- reachable when the caller supplies the species -- and the collision-free
+  # CaniAure is the runtime prefix. Same shape as Monopterus albus / Moal.
+  # Revisit if Caau- canid alleles are ever published.
+  prefix: CaniAure
+  context only prefixes:
+    - Caau
   name: Golden Jackal
 Canis adustus:
   parent: Canis sp.
@@ -1269,17 +1278,18 @@ Hippocampus abdominalis:
 Carassius auratus:
   parent: Cyprinidae sp.
   # Both Carassius auratus and Canis aureus derive Caau under the Klein 2+2
-  # rule (Immunogenetics 1990;31:217-219, PMID 2329006), so this is a genuine
-  # namespace collision rather than a bad alias. IPD-MHC designates Caau to
-  # Canis aureus (https://www.ebi.ac.uk/ipd/mhc/group/DLA/species), so the
-  # global prefix goes there; Caau stays here as a context-only rescue alias
-  # for species= records, the same way Hypophthalmichthys molitrix yields Hymo
-  # to Hylobates moloch.
+  # rule (Immunogenetics 1990;31:217-219, PMID 2329006), so the code is a
+  # genuine collision. It resolves here because this is the side actually used
+  # in print: Caau-DAB and Caau-UFA appear in the cyprinid MHC literature
+  # (Ottova et al., Mol Immunol 2005 on cyprinid class IIb; Wu et al., Fish
+  # Shellfish Immunol 2023 on Carassius auratus class I). IPD-MHC designates
+  # Caau to Canis aureus but holds no allele sequences for that species, so
+  # the designation is reserved rather than used -- see the context-only entry
+  # on Canis aureus.
   prefix: CaraAura
   other prefixes:
-    - Caur
-  context only prefixes:
     - Caau
+    - Caur
   name: Goldfish
 Clarias magur:
   parent: Actinopterygii sp.
@@ -1557,12 +1567,13 @@ Carassius langsdorfii:
   name: Ginbuna
 Hybognathus amarus:
   parent: Actinopterygii sp.
-  # Both this species and Hyperoodon ampullatus derive Hyam under the Klein
-  # 2+2 rule (PMID 2329006). IPD-MHC designates Hyam to Hyperoodon ampullatus
-  # (https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species), so context-only here
-  # for the same reason as Carassius auratus above.
+  # Hyam collides with Hyperoodon ampullatus under the Klein 2+2 rule
+  # (PMID 2329006). Kept here for the same reason as Carassius auratus above:
+  # Hyam-* parses this species' genes today and IPD-MHC holds no allele
+  # sequences for the whale, so its designation is reserved as context-only
+  # on that entry rather than taking the runtime prefix.
   prefix: HyboAmar
-  context only prefixes:
+  other prefixes:
     - Hyam
   name: Rio Grande silvery minnow
 Megalobrama amblycephala:
@@ -2526,7 +2537,13 @@ Tursiops truncatus:
   name: Bottlenose dolphin
 Hyperoodon ampullatus:
   parent: Cetacea sp.
-  prefix: Hyam
+  # IPD-MHC designates this species Hyam
+  # (https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species) but holds no allele
+  # sequences for it, and Hyam-* already parses Hybognathus amarus genes.
+  # Context-only for the same reason as Canis aureus above.
+  prefix: HypeAmpu
+  context only prefixes:
+    - Hyam
   name: Northern bottlenose whale
 Ziphius cavirostris:
   parent: Cetacea sp.

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.36.0"
+__version__ = "3.37.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,93 +1,58 @@
-# Species inference for ambiguous and degenerate inputs
+# IPD-MHC and IMGT/HLA coverage gaps
 
-Tracking issues: #102, #103, #105, #106, #107, #110, #112
+Tracking issues: #111, #113
+
+Found by sweeping every IPD-MHC group species listing and the IMGT/HLA gene
+list against `species.yaml`. That sweep found zero prefix mismatches across the
+125 IPD species we already carried — everything below is absence, not error.
 
 ## Specification
 
-- [x] Stop a bare species prefix from resolving to an arbitrary descendant
-      species. A prefix is inherited by every descendant, so `BoLA` matches
-      `Bos sp.` and also `Bubalus bubalis`; resolve it with the ladder
-      `Species.get` already implements rather than letting the result sort
-      order decide.
-- [x] Rank ambiguous unprefixed gene symbols by whether a species declares the
-      gene in its own ontology entry, not by how many genes it can see. A gene
-      defined on a broad parent group is visible to every species beneath it.
-- [x] Handle the case-normalized gene-name collision (`Ia1` vs `IA1`) so the
-      species spelling the gene the caller's way wins.
-- [x] Reject punctuation-only strings and the `n/a` family instead of falling
-      through to the default species.
-- [x] Keep explicit descendant prefixes, bare haplotype shorthand, and the
-      existing bare-gene answers for model organisms working.
-- [x] Measure the change against the bundled allele corpora rather than
-      assuming a tie-break is inert.
-- [x] Reclassify Patr-AL from `Ia` to `Ib`, with the primary literature cited
-      in the ontology next to the gene.
-- [x] Remove the duplicate `old prefix: Pren`, and give the two Klein-code
-      collisions to the species IPD-MHC designates.
+- [x] Add the 26 remaining IPD-MHC species (2 of the 28 shipped in #108
+      because they owned prefixes that were resolving to the wrong animal).
+- [x] Keep out-of-genus species off the genus nodes, so they do not inherit a
+      prefix and gene list that is not theirs.
+- [x] Add the IMGT/HLA genes that can be added without regressing existing
+      behaviour, with pseudogene status and legacy aliases.
+- [x] Establish which IMGT/HLA genes cannot be added yet, and say why in the
+      ontology rather than leaving it to be rediscovered.
 - [x] Bump the version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
 - [x] Review the final diff and document the result below.
 
 ## Review
 
-- **#103** is fixed in `Parser.parse_multiple_candidates` at the point the
-  species prefix is matched, by deferring to `Species.get`, which already
-  resolves exact latin name, then exact prefix owner, then non-descendant.
-  An earlier attempt added a species-depth term to the global `sort_key`
-  instead; that worked but made one ambiguity's tie-break a rule governing
-  every result comparison in the library, and raw tree depth is not
-  comparable across clades. Fixing it where the ambiguity is created is
-  narrower and leaves `result_sorting.py` untouched.
-- Eight prefixes were affected, not just BoLA: `RT1 class I` was
-  *Rattus villosissimus*, `NHP class I` was *Saimiri sciureus*.
-- **#105** is fixed with `Species.declares_gene()`, collected inside the
-  loader's existing validated gene walk so it cannot drift from `gene_names`.
-  A first attempt ranked by the *size* of a species' own gene block, which
-  fixed `BLB2` only by coincidence and regressed `DAB1`, `DBB1` and `Ia1`.
-  Declaring the specific gene is the property that actually matters.
-- Verified across all 315 ambiguous digit-containing gene symbols: there is
-  now no case where the winner fails to declare the gene while some candidate
-  does.
-- **#102** turned out wider than reported: 254 punctuation-only strings
-  returned *Homo sapiens*, and 14 of 69 common null markers returned a
-  confident result. Both are zero now. Bare haplotype shorthand (`b/d`, `d`,
-  `n`) is deliberately preserved.
-- Blast radius: 1 of 11,558 names in the bundled netMHCpan/netMHCIIpan/IEDB
-  corpora changes (`B12 class I`, crab-eating macaque to genus-level
-  *Macaca sp.*). 206 bare gene symbols reachable through the API change, all
-  from an inheriting species to a declaring one.
-- Cold parse throughput unchanged (~0.067 ms/name). Results are now stable
-  across `PYTHONHASHSEED` values.
-- Filed #109 (water buffalo is parented under `Bos sp.`, a different genus)
-  and #110 (`Pren class I` silently picks a winner for a colliding prefix).
-  Left #104 open: its premise is wrong, `Mamu-I` and `H2-i` are real entities.
-- **#107** asked whether Patr-AL is really `Ia`. It is not. The paper that
-  described the locus is titled "A Novel, Nonclassical MHC Class I Molecule
-  Specific to the Common Chimpanzee" (Adams, Cooper & Parham, J Immunol
-  2001;167:3858, PMID 11564803): three allotypes differing at two residues,
-  present on ~50% of chimpanzee MHC haplotypes, expressed at low level, and
-  diverged from classical MHC-A >20 Mya. Gleimer et al. (J Immunol
-  2011;186:1575, PMID 21301043) restate it as non-classical and group it with
-  HLA-E/F/G. Moved to `Ib`, which is where the ontology already puts that
-  family. hitlist and IEDB were right.
-- **#106** is a duplicate of #103 describing the same eight prefixes; fixed by
-  the same change.
-- **#110** turned out to be a data fix, not a parser one. `Pren` is
-  *Presbytis entellus*, the former name of *Semnopithecus entellus*;
-  *Theropithecus gelada* also carried it as an `old prefix`, which is what made
-  the prefix ambiguous. Auditing every prefix claim across all 641 species
-  found `Pren` was the only one claimed twice. Removed the stray line, and
-  added a whole-ontology test so no prefix can be claimed twice again.
-- **#112** was misdiagnosed in the issue as auto-generated prefixes squatting.
-  They are curated `other prefixes`, and both sides derive legitimately under
-  the Klein 2+2 scheme: `Caau` is *Canis aureus* and *Carassius auratus*,
-  `Hyam` is *Hyperoodon ampullatus* and *Hybognathus amarus*. The repo already
-  had the right mechanism -- `Hymo` gives the global prefix to IPD's
-  *Hylobates moloch* and leaves the silver carp a `context only prefixes`
-  entry. Applied the same shape: added the two IPD species, moved the fish
-  aliases to context-only. Two existing tests encoded the losing resolution
-  and were updated to address each fish by its own prefix.
-- Bumped 3.33.6 to 3.36.0. Minor rather than patch because bare gene symbols
-  and class-only strings change species for downstream callers.
+- **#111**, 26 species added: 10 capuchins (*Cebus*/*Sapajus*) under
+  `Primata sp.`, 11 cetaceans under `Cetacea sp.`, and 2 jackals under
+  `Canis sp.` Prefixes are the official Comparative MHC Nomenclature Committee
+  designations; loci are not curated for any of them, so only the species
+  designations are recorded.
+- Three of the 26 are not in the genus of the group that lists them —
+  *Cuon alpinus* and *Lycaon pictus* are canids but not *Canis*, and
+  *Phacochoerus africanus* is a suid but not *Sus*. Filing them under
+  `Canis sp.`/`Sus sp.` would hand them the DLA/SLA prefix and those genera's
+  gene lists on no evidence, which is exactly the water buffalo problem in
+  #109. Added `Canidae sp.` and `Suidae sp.` instead — real taxonomic ranks,
+  the same shape as the existing `Cetacea sp.` and `Galliformes sp.` nodes,
+  and what IPD-MHC's "Canids" and "Suids" groups actually cover. Their
+  prefixes are taxonomic, so descendants do not inherit them: `DLA` still
+  resolves to `Canis sp.` and `SLA` to `Sus sp.`
+- **#113**, 10 of 19 genes added: class II pseudogenes DRB2, DQB3, DPA2, DPA3
+  and DPB2; MIC pseudogenes MICC, MICD and MICE; and the immunoproteasome
+  subunits PSMB8 and PSMB9, with LMP7/LMP2 as aliases in the same shape as the
+  existing RING4/RING11 aliases for TAP1/TAP2. All eight pseudogenes carry
+  `pseudogene: true`.
+- The other 9 are **deliberately held back**. IMGT/HLA names the class I gene
+  fragments N, R, S, T, U, W, X, Y and Z, and adding them regresses two things:
+  bare `n`, `s`, `t`, `u` and `w` stop resolving to the mouse and rat haplotype
+  shorthand they mean today and become human gene fragments, and allele-less
+  fragments start accepting allele fields, so `Z*01:01` parses. Three existing
+  tests assert `HLA-X` and `HLA-Z*01:01` are invalid. The same shadowing
+  already affects H/J/K/L/P/V against H2-k and friends, so this wants deciding
+  once for the whole letter series rather than being extended quietly. The
+  reasoning is recorded next to the gene list in `species.yaml` and on #113.
+- Verified against the bundled netMHCpan/netMHCIIpan/IEDB corpora: no change
+  beyond the single `B12 class I` correction that shipped in #108.
+- Bumped 3.36.0 to 3.37.0.
 - `./format.sh`: passed.
 - `./lint.sh`: passed.
-- `./test.sh`: passed (15,231 tests; 91% statement coverage).
+- `./test.sh`: passed (15,388 tests; 91% statement coverage).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # IPD-MHC and IMGT/HLA coverage gaps
 
-Tracking issues: #111, #113
+Tracking issues: #111, #112, #113
 
 Found by sweeping every IPD-MHC group species listing and the IMGT/HLA gene
 list against `species.yaml`. That sweep found zero prefix mismatches across the
@@ -50,6 +50,19 @@ list against `species.yaml`. That sweep found zero prefix mismatches across the
   already affects H/J/K/L/P/V against H2-k and friends, so this wants deciding
   once for the whole letter series rather than being extended quietly. The
   reasoning is recorded next to the gene list in `species.yaml` and on #113.
+- **Corrected #112 from the previous PR.** That fix gave `Caau` and `Hyam` to
+  the species IPD-MHC designates, on the assumption that an official
+  designation outranks a curated alias. It does not. The naming rule is
+  mechanical, so several species derive the same code and only one is usually
+  the one in print. `Caau-DAB` and `Caau-UFA` are published *Carassius
+  auratus* designations, while IPD holds no allele sequences for *Canis
+  aureus* at all — so the change broke `Caau-DAB1`, `Caau-UBA`, `Caau-DAB3`,
+  `Hyam-DAB1` and `Hyam-UBA`, all of which parsed before. Reversed it: the
+  attested species keeps the runtime prefix and the designation is recorded as
+  `context only prefixes` on the species IPD names, which stays reachable by
+  its own `CaniAure`/`HypeAmpu` prefix. The two existing tests that the
+  previous PR rewrote are restored to their original assertions, which were
+  right.
 - Verified against the bundled netMHCpan/netMHCIIpan/IEDB corpora: no change
   beyond the single `B12 class I` correction that shipped in #108.
 - Bumped 3.36.0 to 3.37.0.

--- a/tests/test_batch_species.py
+++ b/tests/test_batch_species.py
@@ -34,9 +34,7 @@ BATCH_SPECIES = [
     ("Gaac", "Gasterosteus aculeatus"),
     ("Icpu", "Ictalurus punctatus"),
     ("Hiab", "Hippocampus abdominalis"),
-    # Caau now belongs to Canis aureus, which is what IPD-MHC designates it;
-    # the goldfish keeps Caau as a context-only alias (see #112).
-    ("CaraAura", "Carassius auratus"),
+    ("Caau", "Carassius auratus"),
     ("Clma", "Clarias magur"),
     # Amphibians
     ("Lica", "Lithobates catesbeianus"),

--- a/tests/test_ipd_imgt_coverage.py
+++ b/tests/test_ipd_imgt_coverage.py
@@ -40,7 +40,6 @@ CETACEANS = [
     ("Bari", "Balaenoptera ricei"),
     ("Esro", "Eschrichtius robustus"),
     ("Eugl", "Eubalaena glacialis"),
-    ("Hyam", "Hyperoodon ampullatus"),
     ("Inge", "Inia geoffrensis"),
     ("Kosi", "Kogia sima"),
     ("Laal", "Lagenorhynchus albirostris"),
@@ -53,7 +52,6 @@ CETACEANS = [
 # https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
 CANIDS = [
     ("Caad", "Canis adustus"),
-    ("Caau", "Canis aureus"),
     ("Caba", "Canis lupus baileyi"),
     ("Cala", "Canis latrans"),
     ("Calu", "Canis lupus"),
@@ -84,6 +82,25 @@ def test_ipd_prefix_resolves_to_its_species(prefix, latin_name):
 @pytest.mark.parametrize("prefix,latin_name", IPD_SPECIES)
 def test_ipd_species_reachable_by_latin_name(prefix, latin_name):
     eq_(Species.get_by_latin_name(latin_name).prefix, prefix)
+
+
+# Two IPD designations collide with a code already in published use by another
+# species, and IPD holds no allele sequences for either of them. Their species
+# are present and their designations recorded, but reserved rather than global.
+RESERVED_DESIGNATIONS = [
+    ("Caau", "Canis aureus", "Carassius auratus"),
+    ("Hyam", "Hyperoodon ampullatus", "Hybognathus amarus"),
+]
+
+
+@pytest.mark.parametrize("prefix,ipd_species,attested_species", RESERVED_DESIGNATIONS)
+def test_reserved_designation_species_is_present(prefix, ipd_species, attested_species):
+    assert Species.get_by_latin_name(ipd_species) is not None
+
+
+@pytest.mark.parametrize("prefix,ipd_species,attested_species", RESERVED_DESIGNATIONS)
+def test_reserved_designation_does_not_take_the_prefix(prefix, ipd_species, attested_species):
+    eq_(Species.get(prefix).name, attested_species)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ipd_imgt_coverage.py
+++ b/tests/test_ipd_imgt_coverage.py
@@ -1,0 +1,181 @@
+"""
+Coverage of the two authorities that assign MHC names.
+
+Species designations come from the Comparative MHC Nomenclature Committee via
+IPD-MHC group listings; human gene names come from IMGT/HLA. These tests pin
+the entries added from a sweep of both against the ontology.
+
+https://github.com/pirl-unc/mhcgnomes/issues/111
+https://github.com/pirl-unc/mhcgnomes/issues/113
+"""
+
+import pytest
+
+from mhcgnomes import Species, parse
+
+from .common import eq_
+
+# ---------------------------------------------------------------------------
+# IPD-MHC species designations
+# ---------------------------------------------------------------------------
+
+# (IPD prefix, latin name) — https://www.ebi.ac.uk/ipd/mhc/group/NHP/species
+CAPUCHINS = [
+    ("Ceal", "Cebus albifrons"),
+    ("Ceap", "Cebus apella"),
+    ("Ceca", "Cebus capucinus"),
+    ("Ceim", "Cebus imitator"),
+    ("Ceka", "Cebus kaapori"),
+    ("Ceol", "Cebus olivaceus"),
+    ("Saca", "Sapajus cay"),
+    ("Sali", "Sapajus libidinosus"),
+    ("Sama", "Sapajus apella macrocephalus"),
+    ("Sani", "Sapajus nigritus"),
+    ("Saxa", "Sapajus xanthosternos"),
+]
+
+# https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+CETACEANS = [
+    ("Bamubr", "Balaenoptera musculus brevicauda"),
+    ("Bari", "Balaenoptera ricei"),
+    ("Esro", "Eschrichtius robustus"),
+    ("Eugl", "Eubalaena glacialis"),
+    ("Hyam", "Hyperoodon ampullatus"),
+    ("Inge", "Inia geoffrensis"),
+    ("Kosi", "Kogia sima"),
+    ("Laal", "Lagenorhynchus albirostris"),
+    ("Live", "Lipotes vexillifer"),
+    ("Momo", "Monodon monoceros"),
+    ("Phph", "Phocoena phocoena"),
+    ("Phsi", "Phocoena sinus"),
+]
+
+# https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+CANIDS = [
+    ("Caad", "Canis adustus"),
+    ("Caau", "Canis aureus"),
+    ("Caba", "Canis lupus baileyi"),
+    ("Cala", "Canis latrans"),
+    ("Calu", "Canis lupus"),
+    ("Came", "Canis mesomelas"),
+    ("Caru", "Canis rufus"),
+    ("Casi", "Canis simensis"),
+    ("Cual", "Cuon alpinus"),
+    ("Lypi", "Lycaon pictus"),
+]
+
+# https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
+SUIDS = [
+    ("Phaf", "Phacochoerus africanus"),
+    ("Sudo", "Sus domesticus"),
+    ("Susc", "Sus scrofa"),
+]
+
+IPD_SPECIES = CAPUCHINS + CETACEANS + CANIDS + SUIDS
+
+
+@pytest.mark.parametrize("prefix,latin_name", IPD_SPECIES)
+def test_ipd_prefix_resolves_to_its_species(prefix, latin_name):
+    species = Species.get(prefix)
+    assert species is not None, f"Species.get({prefix!r}) returned None"
+    eq_(species.name, latin_name)
+
+
+@pytest.mark.parametrize("prefix,latin_name", IPD_SPECIES)
+def test_ipd_species_reachable_by_latin_name(prefix, latin_name):
+    eq_(Species.get_by_latin_name(latin_name).prefix, prefix)
+
+
+# ---------------------------------------------------------------------------
+# Genus boundaries
+#
+# Cuon, Lycaon and Phacochoerus are canids and suids but not Canis or Sus, so
+# they must not inherit the DLA/SLA prefix or those genera's gene lists. That
+# is the failure described in issue #109 for water buffalo under Bos sp.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "latin_name,family_node",
+    [
+        ("Cuon alpinus", "Canidae sp."),
+        ("Lycaon pictus", "Canidae sp."),
+        ("Phacochoerus africanus", "Suidae sp."),
+    ],
+)
+def test_out_of_genus_species_hang_off_the_family_not_the_genus(latin_name, family_node):
+    eq_(Species.get_by_latin_name(latin_name).parent_species.name, family_node)
+
+
+@pytest.mark.parametrize("prefix", ["Cual", "Lypi"])
+def test_non_canis_canids_do_not_answer_to_DLA(prefix):
+    species = Species.get(prefix)
+    assert "DLA" not in {p.upper() for p in species.all_mhc_prefixes}
+
+
+def test_warthog_does_not_answer_to_SLA():
+    species = Species.get("Phaf")
+    assert "SLA" not in {p.upper() for p in species.all_mhc_prefixes}
+
+
+@pytest.mark.parametrize("prefix,owner", [("DLA", "Canis sp."), ("SLA", "Sus sp.")])
+def test_family_node_does_not_take_over_the_group_prefix(prefix, owner):
+    """A taxonomic prefix is not inherited, so DLA and SLA keep their owners."""
+    eq_(Species.get(prefix).name, owner)
+
+
+def test_existing_group_alleles_are_unaffected():
+    eq_(parse("DLA-DRB1*001:01").species.name, "Canis sp.")
+    eq_(parse("SLA-1*01:01").species.name, "Sus sp.")
+
+
+# ---------------------------------------------------------------------------
+# IMGT/HLA gene names
+# ---------------------------------------------------------------------------
+
+IMGT_HLA_GENES_ADDED = [
+    "DRB2",
+    "DQB3",
+    "DPA2",
+    "DPA3",
+    "DPB2",
+    "MICC",
+    "MICD",
+    "MICE",
+    "PSMB8",
+    "PSMB9",
+]
+
+
+@pytest.mark.parametrize("gene_name", IMGT_HLA_GENES_ADDED)
+def test_imgt_hla_gene_parses(gene_name):
+    result = parse(f"HLA-{gene_name}", raise_on_error=False)
+    assert result is not None, f"HLA-{gene_name} did not parse"
+    eq_(result.species.name, "Homo sapiens")
+    eq_(result.name, gene_name)
+
+
+@pytest.mark.parametrize(
+    "gene_name",
+    ["DRB2", "DQB3", "DPA2", "DPA3", "DPB2", "MICC", "MICD", "MICE"],
+)
+def test_added_imgt_pseudogenes_are_marked_as_such(gene_name):
+    assert parse(f"HLA-{gene_name}").is_pseudogene
+
+
+def test_proteasome_subunits_keep_their_legacy_names():
+    """LMP7/LMP2 are to PSMB8/PSMB9 what RING4/RING11 are to TAP1/TAP2."""
+    eq_(parse("HLA-LMP7").name, "PSMB8")
+    eq_(parse("HLA-LMP2").name, "PSMB9")
+
+
+def test_single_letter_haplotype_shorthand_is_not_shadowed():
+    """
+    IMGT/HLA also names the class I fragments N, R, S, T, U, W, X, Y, Z. They
+    are deliberately not in the ontology: adding them turns bare mouse and rat
+    haplotype shorthand into human gene fragments. See issue #113.
+    """
+    eq_(parse("n").to_string(), "RT1-n")
+    eq_(parse("u").to_string(), "H2-u")
+    eq_(parse("s").to_string(), "H2-s")
+    assert parse("HLA-Z*01:01", raise_on_error=False) is None

--- a/tests/test_new_species_v3_22.py
+++ b/tests/test_new_species_v3_22.py
@@ -131,9 +131,7 @@ def test_new_fish_species_parseable(prefix, latin):
 
 
 def test_hybognathus_amarus_inherits_DAB1():
-    # Addressed by its own prefix: Hyam is Hyperoodon ampullatus in IPD-MHC,
-    # and the minnow keeps Hyam only as a context-only alias (see #112).
-    eq_(parse("HyboAmar-DAB1"), Gene.get("HyboAmar", "DAB1"))
+    eq_(parse("Hyam-DAB1"), Gene.get("Hyam", "DAB1"))
 
 
 def test_megalobrama_inherits_UA():

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -428,45 +428,56 @@ def test_default_species_accepts_latin_name():
 # https://github.com/pirl-unc/mhcgnomes/issues/112
 # ---------------------------------------------------------------------------
 
-# (prefix, species IPD-MHC designates, species that keeps it context-only)
-IPD_DESIGNATED_PREFIX_COLLISIONS = [
+# (prefix, species that resolves it globally, species holding it context-only)
+#
+# The global prefix goes to whichever side is actually used in print, not
+# automatically to whichever side IPD-MHC designates. Caau-DAB and Caau-UFA
+# appear in the cyprinid MHC literature while IPD holds no allele sequences
+# for Canis aureus, so the goldfish resolves and the jackal's designation is
+# reserved.
+PREFIX_COLLISIONS = [
     ("Hymo", "Hylobates moloch", "Hypophthalmichthys molitrix"),
-    ("Caau", "Canis aureus", "Carassius auratus"),
-    ("Hyam", "Hyperoodon ampullatus", "Hybognathus amarus"),
+    ("Caau", "Carassius auratus", "Canis aureus"),
+    ("Hyam", "Hybognathus amarus", "Hyperoodon ampullatus"),
 ]
 
 
-@pytest.mark.parametrize("prefix,ipd_species,context_only", IPD_DESIGNATED_PREFIX_COLLISIONS)
-def test_ipd_designated_species_owns_the_prefix(prefix, ipd_species, context_only):
+@pytest.mark.parametrize("prefix,resolves_to,reserved_for", PREFIX_COLLISIONS)
+def test_colliding_prefix_resolves_to_the_attested_species(prefix, resolves_to, reserved_for):
     species = Species.get(prefix)
     assert species is not None, prefix
-    eq_(species.name, ipd_species)
+    eq_(species.name, resolves_to)
 
 
-@pytest.mark.parametrize("prefix,ipd_species,context_only", IPD_DESIGNATED_PREFIX_COLLISIONS)
-def test_colliding_species_keeps_prefix_as_context_only(prefix, ipd_species, context_only):
+@pytest.mark.parametrize("prefix,resolves_to,reserved_for", PREFIX_COLLISIONS)
+def test_losing_side_keeps_prefix_as_context_only(prefix, resolves_to, reserved_for):
     from mhcgnomes.species import find_matching_context_only_species_objects
 
     names = {s.name for s in find_matching_context_only_species_objects(prefix)}
-    assert context_only in names, (prefix, names)
+    assert reserved_for in names, (prefix, names)
 
 
-@pytest.mark.parametrize("prefix,ipd_species,context_only", IPD_DESIGNATED_PREFIX_COLLISIONS)
-def test_context_only_species_still_reachable_by_its_own_prefix(prefix, ipd_species, context_only):
-    species = Species.get_by_latin_name(context_only)
+@pytest.mark.parametrize("prefix,resolves_to,reserved_for", PREFIX_COLLISIONS)
+def test_reserved_species_still_reachable_by_its_own_prefix(prefix, resolves_to, reserved_for):
+    species = Species.get_by_latin_name(reserved_for)
     assert species is not None
-    eq_(Species.get(species.prefix).name, context_only)
+    eq_(Species.get(species.prefix).name, reserved_for)
 
 
-def test_caau_is_the_golden_jackal_not_a_goldfish():
-    """IPD-MHC assigns Caau to Canis aureus; it used to resolve to Carassius auratus."""
-    eq_(Species.get("Caau").name, "Canis aureus")
-    eq_(parse("Caau-DRB1").species.name, "Canis aureus")
+def test_published_goldfish_designations_still_parse():
+    """
+    Caau-DAB and Caau-UFA are published Carassius auratus designations, so
+    Caau-* must keep resolving to the goldfish even though IPD-MHC designates
+    Caau to Canis aureus.
+    """
+    eq_(Species.get("Caau").name, "Carassius auratus")
+    for gene_name in ["DAB1", "DAB3", "UBA"]:
+        eq_(parse(f"Caau-{gene_name}").species.name, "Carassius auratus")
 
 
-def test_hyam_is_the_bottlenose_whale_not_a_minnow():
-    """IPD-MHC assigns Hyam to Hyperoodon ampullatus."""
-    eq_(Species.get("Hyam").name, "Hyperoodon ampullatus")
+def test_minnow_designations_still_parse():
+    eq_(Species.get("Hyam").name, "Hybognathus amarus")
+    eq_(parse("Hyam-DAB1").species.name, "Hybognathus amarus")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #111, corrects #112, and partially addresses #113.

Both come from sweeping every IPD-MHC group species listing and the IMGT/HLA gene list against `species.yaml`. Worth stating the sweep's main result first: across the **125 IPD-MHC species already carried, there were zero prefix mismatches** — every official Comparative MHC Nomenclature Committee designation was correct. Everything in this PR is absence, not error.

## Species (#111) — 26 added

| clade | count | parent |
|---|---:|---|
| Capuchins (*Cebus* / *Sapajus*) | 10 | `Primata sp.` |
| Cetaceans | 11 | `Cetacea sp.` |
| Jackals (*Canis adustus*, *C. mesomelas*) | 2 | `Canis sp.` |
| *Cuon alpinus*, *Lycaon pictus* | 2 | `Canidae sp.` **(new)** |
| *Phacochoerus africanus* | 1 | `Suidae sp.` **(new)** |

The other 2 of the 28 shipped in #108, because they owned prefixes that were resolving to the wrong animal (`Caau`, `Hyam`).

Prefixes are the official IPD-MHC designations. No loci are curated for any of these species, so only the designations are recorded — a gene review is a separate piece of work per clade.

### Two new family nodes, and why

Three of the 26 are **not in the genus of the group that lists them**. *Cuon* and *Lycaon* are canids but not *Canis*; *Phacochoerus* is a suid but not *Sus*.

Filing them under `Canis sp.`/`Sus sp.` would hand them the `DLA`/`SLA` prefix and those genera's whole gene lists on no evidence — precisely the water buffalo problem in #109, where `Bubalus bubalis` sits under `Bos sp.` and consequently answers to `BoLA` while declaring 3 genes of its own.

So this adds `Canidae sp.` and `Suidae sp.`: real taxonomic ranks, the same shape as the existing `Cetacea sp.` and `Galliformes sp.` nodes, and what IPD-MHC's "Canids" and "Suids" groups actually cover. Both take taxonomic prefixes, which the loader does not pass down to descendants, so nothing leaks:

```
Species.get("DLA")            -> Canis sp.      (unchanged)
Species.get("SLA")            -> Sus sp.        (unchanged)
parse("DLA-DRB1*001:01")      -> Canis sp.      (unchanged)
Cual / Lypi answer to DLA?    -> no
Cuon inherits the Canis gene list? -> no
```

## Genes (#113) — 10 of 19 added

Added, all with `pseudogene: true` where applicable:

```
class II pseudogenes   DRB2  DQB3  DPA2  DPA3  DPB2
MIC pseudogenes        MICC  MICD  MICE
proteasome subunits    PSMB8  PSMB9
```

`LMP7` and `LMP2` are registered as aliases for `PSMB8`/`PSMB9`, the same shape as the existing `RING4`/`RING11` aliases for `TAP1`/`TAP2`.

### Nine genes deliberately held back

IMGT/HLA also names the class I gene fragments **N, R, S, T, U, W, X, Y, Z**. I verified they are genuinely on the official gene list, then found that adding them regresses two things:

1. **It shadows haplotype shorthand.** Bare `n`, `s`, `t`, `u` and `w` resolve today to mouse and rat haplotypes (`RT1-n`, `H2-s`, `H2-u`) and would become human gene fragments.
2. **It manufactures alleles for allele-less fragments.** `Z*01:01` and `HLA-Z99` start parsing. Three existing tests assert `HLA-X` and `HLA-Z*01:01` are invalid.

Notably `H`, `J`, `K`, `L`, `P` and `V` are already in the ontology and already shadow `H2-k` and friends — so the letter series is *already* inconsistent, and this wants deciding once for the whole series rather than being quietly extended. The reasoning sits next to the gene list in `species.yaml` and on #113, so #113 stays open.

## Correction to #112

The #112 fix that shipped in #108 was wrong and is reversed here.

It handed `Caau` and `Hyam` to the species IPD-MHC designates, assuming an official designation outranks a curated alias. It does not. The naming rule is mechanical, so several species derive the same code and usually only one is the side that appears in print — the rest are synthetic:

| code | attested in print | IPD designation |
|---|---|---|
| `Caau` | *Carassius auratus* — `Caau-DAB`, `Caau-UFA` in the cyprinid MHC literature | *Canis aureus*, **no deposited sequences** |
| `Hyam` | *Hybognathus amarus* — parses today | *Hyperoodon ampullatus*, **no deposited sequences** |

So that change silently broke five parses that worked before it:

```
Caau-DAB1   CaraAura-DAB1  ->  None
Caau-UBA    CaraAura-UBA   ->  None
Caau-DAB3   CaraAura-DAB3  ->  None
Hyam-DAB1   HyboAmar-DAB1  ->  None
Hyam-UBA    HyboAmar-UBA   ->  None
```

Reversed: the attested species keeps the runtime prefix, and the IPD designation is recorded as `context only prefixes` on the species IPD names — which stays present and reachable by its own `CaniAure`/`HypeAmpu` prefix. Both sides and the reason are cited in `species.yaml`.

The two existing tests the previous PR rewrote are **restored to their original assertions**. They were right; rewriting a failing test to match a change is the failure mode this PR's own guidance now warns against.

## Guidance and citations

`AGENTS.md` gains a rewritten **Scientific Domain Knowledge** section and `CLAUDE.md` points at it: read the literature before changing a scientific claim, don't guess, don't assume our own curation *or our own tests* are right, and check the primary source rather than a summary of it — with the concrete example that a summarized IPD-MHC page reported "CLA = cat" and "CeLA = deer", both wrong. It names the authorities with where to look, states the prefix rule so designations can be checked by derivation, and adds the lesson above: an official designation is not the same as attested usage.

It also asks for sources to be recorded next to the data, which this PR does throughout — Klein 1990 (PMID 2329006) for the prefix decisions, the IPD-MHC group listings behind `Canidae sp.`/`Suidae sp.`, and the IMGT/HLA gene list behind the MIC pseudogenes and the held-back fragments.

## Verification

- 15,388 tests pass.
- New tests pin every added designation, the genus boundaries, the reserved-designation model, and the held-back class I fragments.
- Bundled netMHCpan/netMHCIIpan/IEDB corpora: no change beyond the single `B12 class I` correction that already shipped in #108.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH

