### PR TITLE
Expose species provenance, document untrusted parsing and the species tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,80 @@ preferentially interpreted as an [`Allele`](https://github.com/pirl-unc/mhcgnome
 than a [`Serotype`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/serotype.py)
 or [`Haplotype`](https://github.com/pirl-unc/mhcgnomes/blob/main/mhcgnomes/haplotype.py).
 
+## Parsing untrusted input
+
+`parse` accepts anything that looks like MHC nomenclature, which is the right
+default for a known-good allele list and the wrong one for free text. Scanning
+curator notes or a spreadsheet column, "it parsed" is not the same as "this is
+an MHC molecule": a stray `HLA class I` is a valid `MhcClass`, and a bare `d`
+is a valid mouse `Haplotype`.
+
+Say what you will accept, and let anything else come back as `None`:
+
+```python
+from mhcgnomes import parse, Allele, Gene, Pair
+
+result = parse(token, required_result_types=(Allele, Gene, Pair), raise_on_error=False)
+if result is None:
+    continue  # not an MHC molecule
+```
+
+```
+HLA-A*02:01                -> Allele        n/a                 -> None
+H2-K*b                     -> Allele        -                   -> None
+Patr-AL                    -> Gene          HLA class I         -> None
+HLA-DPB1*06:01/DPA1*01:03  -> Pair          d                   -> None
+```
+
+This is more robust than filtering on the returned type yourself, since it also
+prevents a lower-ranked interpretation from being chosen in the first place.
+
+### Which result type means what
+
+Several result types are legitimate MHC designations without being molecules,
+which is why `HLA-DR15` and `BoLA-DR` parse cleanly but yield no allele:
+
+| Type | Means | Example |
+| --- | --- | --- |
+| `Allele` | A specific allele | `HLA-A*02:01` |
+| `Gene` | A locus, no allele given | `Patr-AL` |
+| `Pair` | Class II alpha/beta pairing | `HLA-DPA1*01:03/DPB1*06:01` |
+| `AlleleWithoutGene` | Allele name whose gene is unknown | `BoLA-D18.4` |
+| `Class2Locus` | A class II locus family | `BoLA-DR` |
+| `Serotype` | Serological group, may cover many alleles | `HLA-DR15` |
+| `Haplotype` | Named haplotype | `H2-b` |
+| `Supertype` | Functional grouping of alleles | `HLA-A02` |
+| `MhcClass` | Just a class, with or without species | `HLA class I` |
+| `Species` | Only a species was named | `HLA` |
+
+### Was the species stated, or guessed?
+
+Species inference is right most of the time and load-bearing when it is wrong.
+A bare gene symbol can carry a species you never supplied, and the default
+species means a deliberately generic string still comes back with one:
+
+```python
+>>> parse("Gaga-BLB2*02").species_source
+'stated'
+>>> parse("BLB2*02").species_source     # inferred from the gene name
+'inferred'
+>>> parse("MHC class II").species_source  # fell back to default_species
+'default'
+```
+
+`result.species_inferred` is the boolean form, true for both `inferred` and
+`default`. To reject anything you did not name outright — the right rule when
+validating curated data — ask for it at parse time:
+
+```python
+>>> parse("BLB2*02", require_stated_species=True, raise_on_error=False) is None
+True
+```
+
+Provenance is not part of a result's identity: two alleles that differ only in
+how their species was determined still compare equal and hash the same. It is
+also computed only when asked, so it costs nothing if you never look.
+
 ## How many digits per field?
 
 Originally alleles for many genes were numbered with two digits:
@@ -255,6 +329,39 @@ in YAML data files under `mhcgnomes/data/`. The key files are:
 | `gene_aliases.yaml` | Alternative gene spellings that normalize to canonical genes |
 | `allele_aliases.yaml` | Retired or shorthand allele names that normalize to canonical alleles |
 | `known_alleles.yaml` | Curated known allele labels per species/gene |
+
+### The species tree
+
+Species entries form a tree through their `parent` links, and it is
+**nomenclature-shaped rather than taxonomic**. Two things follow that are easy
+to get wrong:
+
+**`Gnathostomata sp.` is a universal root.** Every species descends from it, so
+"do these two share a common ancestor?" is true for any pair and useless as a
+compatibility test — worse, it fails open. Only a direct ancestor or descendant
+relation is meaningful. `Species.compatible_with` implements that rule:
+
+```python
+>>> Species.get("Bos taurus").compatible_with("Bos sp.")
+True                     # less specific, not contradictory
+>>> Species.get("Macaca mulatta").compatible_with("Macaca fascicularis")
+False                    # siblings
+```
+
+This is what you want when checking a declared species against the species
+mhcgnomes derives from an allele, since the two legitimately differ in
+specificity: `BoLA` belongs to the genus-level `Bos sp.`, so a `BoLA-N*013:01`
+allele on a sample curated as *Bos taurus* is compatible.
+
+**The tree is shallow where a species owns its own MHC system.** `Homo sapiens`
+attaches directly to the root, so `Primata sp.` is *not* an ancestor of human,
+while `Saimiri sciureus` -> `Primata sp.` -> `Gnathostomata sp.` is. HLA is its
+own system rather than a generic primate one, and the tree reflects that. A
+caller reasoning purely taxonomically will guess wrong.
+
+An `X sp.` node is a group entry: it holds the prefix and the genes shared by
+everything beneath it. `Bos sp.` owns `BoLA` and the cattle gene list; `Bos
+taurus` inherits both.
 
 ### Species prefix conventions
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ which is why `HLA-DR15` and `BoLA-DR` parse cleanly but yield no allele:
 | `MhcClass` | Just a class, with or without species | `HLA class I` |
 | `Species` | Only a species was named | `HLA` |
 
-### Was the species stated, or guessed?
+### Was the species explicit, or guessed?
 
 Species inference is right most of the time and load-bearing when it is wrong.
 A bare gene symbol can carry a species you never supplied, and the default
@@ -248,7 +248,7 @@ species means a deliberately generic string still comes back with one:
 
 ```python
 >>> parse("Gaga-BLB2*02").species_source
-'stated'
+'explicit'
 >>> parse("BLB2*02").species_source     # inferred from the gene name
 'inferred'
 >>> parse("MHC class II").species_source  # fell back to default_species
@@ -260,7 +260,7 @@ species means a deliberately generic string still comes back with one:
 validating curated data — ask for it at parse time:
 
 ```python
->>> parse("BLB2*02", require_stated_species=True, raise_on_error=False) is None
+>>> parse("BLB2*02", require_explicit_species=True, raise_on_error=False) is None
 True
 ```
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ species means a deliberately generic string still comes back with one:
 'default'
 ```
 
-`result.species_inferred` is the boolean form, true for both `inferred` and
-`default`. To reject anything you did not name outright — the right rule when
+`result.species_from_input` is the boolean form, true only for `explicit` — it
+answers the question a caller actually has: did I supply this species, or did
+the parser? To reject anything you did not name outright — the right rule when
 validating curated data — ask for it at parse time:
 
 ```python

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -637,7 +637,7 @@ def parse(
         species was inferred from a gene name, or came from default_species,
         treat the string as unparsed. Useful for validating curated data,
         where a confident but inferred species is worse than no answer.
-        See Result.species_source.
+        See Result.species_source and Result.species_from_input.
 
     Returns
     -------

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -573,7 +573,7 @@ def parse(
     only_class2: bool = False,
     verbose: bool = False,
     raise_on_error: bool = True,
-    require_stated_species: bool = False,
+    require_explicit_species: bool = False,
 ) -> Optional[Result]:
     """
     Parse MHC alleles into a structured representation.
@@ -632,7 +632,7 @@ def parse(
         Raise an exception if string can't be parsed. If False, return None
         instead.
 
-    require_stated_species : bool
+    require_explicit_species : bool
         Only accept a result whose species the input actually named. When the
         species was inferred from a gene name, or came from default_species,
         treat the string as unparsed. Useful for validating curated data,
@@ -696,7 +696,7 @@ def parse(
             only_class1=only_class1,
             only_class2=only_class2,
             max_allele_fields=max_allele_fields,
-            require_stated_species=require_stated_species,
+            require_explicit_species=require_explicit_species,
         )
     except ParseError as error:
         parser_error = error

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -573,6 +573,7 @@ def parse(
     only_class2: bool = False,
     verbose: bool = False,
     raise_on_error: bool = True,
+    require_stated_species: bool = False,
 ) -> Optional[Result]:
     """
     Parse MHC alleles into a structured representation.
@@ -631,6 +632,13 @@ def parse(
         Raise an exception if string can't be parsed. If False, return None
         instead.
 
+    require_stated_species : bool
+        Only accept a result whose species the input actually named. When the
+        species was inferred from a gene name, or came from default_species,
+        treat the string as unparsed. Useful for validating curated data,
+        where a confident but inferred species is worse than no answer.
+        See Result.species_source.
+
     Returns
     -------
     Result
@@ -688,6 +696,7 @@ def parse(
             only_class1=only_class1,
             only_class2=only_class2,
             max_allele_fields=max_allele_fields,
+            require_stated_species=require_stated_species,
         )
     except ParseError as error:
         parser_error = error

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -218,7 +218,7 @@ class Parser:
         default_species: Union[Species, str, None] = DEFAULT_SPECIES_PREFIX,
     ):
         """
-        Returns "stated", "inferred", "default", or None -- see
+        Returns "explicit", "inferred", "default", or None -- see
         Result.species_source.
         """
         return classify_species_source(name, self._species_of(result), default_species)
@@ -2280,12 +2280,12 @@ class Parser:
         only_class2: bool = False,
         max_allele_fields: Optional[int] = None,
         raise_on_error: bool = True,
-        require_stated_species: bool = False,
+        require_explicit_species: bool = False,
     ):
         """
         Public parse entrypoint. Returns an immutable cached result object.
 
-        require_stated_species : bool
+        require_explicit_species : bool
             Only accept results whose species the input actually named. Use
             this when validating curated or free-text input, where a confident
             but inferred species is worse than no answer. See
@@ -2315,11 +2315,11 @@ class Parser:
         if result._species_source_inputs is None:
             Result._set_field(result, "_species_source_inputs", (name, default_species))
 
-        if require_stated_species and result.species_source not in (None, "stated"):
+        if require_explicit_species and result.species_source not in (None, "explicit"):
             species_source = result.species_source
             if raise_on_error:
                 raise ParseError(
-                    f"Species for '{name}' was {species_source}, not stated in the input"
+                    f"Species for '{name}' was {species_source}, not explicit in the input"
                 )
             return None
         return result

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -44,7 +44,13 @@ from .result import Result
 from .result_sorting import pick_best_result
 from .result_with_species import ResultWithSpecies
 from .serotype import Serotype
-from .species import Species, find_matching_species_objects, infer_species_from_prefix
+from .species import (
+    Species,
+    classify_species_source,
+    find_matching_species_objects,
+    infer_species_from_prefix,
+    species_named_in,
+)
 from .standard_format import parse_standard_allele_format
 from .supertype import Supertype
 from .token import Token
@@ -193,6 +199,29 @@ class Parser:
         original_prefix_length = len(original_prefix)
         remaining_string = name[original_prefix_length:]
         return species, remaining_string
+
+    @staticmethod
+    def _species_of(result):
+        """The species a result is about, whatever its type."""
+        if type(result) is Species:
+            return result
+        return getattr(result, "species", None)
+
+    def species_named_in(self, name: str):
+        """Which species, if any, the input string names outright."""
+        return species_named_in(name)
+
+    def classify_species_source(
+        self,
+        name: str,
+        result,
+        default_species: Union[Species, str, None] = DEFAULT_SPECIES_PREFIX,
+    ):
+        """
+        Returns "stated", "inferred", "default", or None -- see
+        Result.species_source.
+        """
+        return classify_species_source(name, self._species_of(result), default_species)
 
     def parse_species(self, name: str, default_species: Union[Species, str, None] = None):
         """
@@ -2251,11 +2280,18 @@ class Parser:
         only_class2: bool = False,
         max_allele_fields: Optional[int] = None,
         raise_on_error: bool = True,
+        require_stated_species: bool = False,
     ):
         """
         Public parse entrypoint. Returns an immutable cached result object.
+
+        require_stated_species : bool
+            Only accept results whose species the input actually named. Use
+            this when validating curated or free-text input, where a confident
+            but inferred species is worse than no answer. See
+            Result.species_source.
         """
-        return self._parse_cached(
+        result = self._parse_cached(
             name=name,
             infer_class2_pairing=infer_class2_pairing,
             default_species=default_species,
@@ -2266,6 +2302,27 @@ class Parser:
             max_allele_fields=max_allele_fields,
             raise_on_error=raise_on_error,
         )
+        if result is None:
+            return None
+
+        # Record what is needed to work out how the species was determined,
+        # rather than working it out now: classification re-tokenizes the
+        # string, and almost no caller asks. Result.species_source does the
+        # work on first access and memoizes it. Neither field is an __init__
+        # field, so equality and hashing are unaffected, and _parse_cached is
+        # keyed on the input string, so a given object always carries the
+        # provenance of the string it was parsed from.
+        if result._species_source_inputs is None:
+            Result._set_field(result, "_species_source_inputs", (name, default_species))
+
+        if require_stated_species and result.species_source not in (None, "stated"):
+            species_source = result.species_source
+            if raise_on_error:
+                raise ParseError(
+                    f"Species for '{name}' was {species_source}, not stated in the input"
+                )
+            return None
+        return result
 
     @cache
     def _parse_cached(

--- a/mhcgnomes/result.py
+++ b/mhcgnomes/result.py
@@ -30,6 +30,51 @@ class Result:
     def _set_field(instance, field_name, field_value):
         object.__setattr__(instance, field_name, field_value)
 
+    # Where the species on this result came from. Parser.parse records the
+    # inputs; the value is worked out on first access and memoized here.
+    # Neither is an __init__ field, so both stay out of equality, hashing,
+    # repr and to_dict() -- two alleles that differ only in how their species
+    # was determined are still the same allele.
+    _species_source = None
+    _species_source_inputs = None
+
+    @property
+    def species_source(self):
+        """
+        How this result's species was determined:
+
+            "stated"    the input named the species, e.g. "Gaga-BLB2*02"
+            "inferred"  derived from a gene or allele name, e.g. "BLB2*02"
+            "default"   fell back to default_species, e.g. "A*02:01"
+            None        no species, or this object was built directly rather
+                        than parsed
+
+        Species inference is right most of the time and load-bearing when it is
+        wrong, so a caller validating curated data can use this to reject any
+        token whose species it did not actually supply.
+        """
+        if self._species_source is not None:
+            return self._species_source
+        if self._species_source_inputs is None:
+            return None
+        # Late import: species.py imports Result, so this cannot be top-level.
+        from .species import Species, classify_species_source
+
+        name, default_species = self._species_source_inputs
+        species = self if type(self) is Species else getattr(self, "species", None)
+        value = classify_species_source(name, species, default_species)
+        Result._set_field(self, "_species_source", value)
+        return value
+
+    @property
+    def species_inferred(self):
+        """
+        True when the species was not named in the input, i.e. species_source
+        is "inferred" or "default". False when stated, and False when there is
+        no species to speak of.
+        """
+        return self.species_source in ("inferred", "default")
+
     @classmethod
     def init_field_names(cls):
         """

--- a/mhcgnomes/result.py
+++ b/mhcgnomes/result.py
@@ -67,13 +67,16 @@ class Result:
         return value
 
     @property
-    def species_inferred(self):
+    def species_from_input(self):
         """
-        True when the species was not named in the input, i.e. species_source
-        is "inferred" or "default". False when explicit, and False when there is
-        no species to speak of.
+        True when the input named the species, i.e. species_source is
+        "explicit". False when it was inferred from a gene name, taken from
+        default_species, or when there is no species to speak of.
+
+        This is the question a caller validating curated data actually asks:
+        did I supply this species, or did the parser supply it for me?
         """
-        return self.species_source in ("inferred", "default")
+        return self.species_source == "explicit"
 
     @classmethod
     def init_field_names(cls):

--- a/mhcgnomes/result.py
+++ b/mhcgnomes/result.py
@@ -43,7 +43,7 @@ class Result:
         """
         How this result's species was determined:
 
-            "stated"    the input named the species, e.g. "Gaga-BLB2*02"
+            "explicit"    the input named the species, e.g. "Gaga-BLB2*02"
             "inferred"  derived from a gene or allele name, e.g. "BLB2*02"
             "default"   fell back to default_species, e.g. "A*02:01"
             None        no species, or this object was built directly rather
@@ -70,7 +70,7 @@ class Result:
     def species_inferred(self):
         """
         True when the species was not named in the input, i.e. species_source
-        is "inferred" or "default". False when stated, and False when there is
+        is "inferred" or "default". False when explicit, and False when there is
         no species to speak of.
         """
         return self.species_source in ("inferred", "default")

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -346,6 +346,33 @@ class Species(Result):
             current = current.parent_species
         return False
 
+    def compatible_with(self, other):
+        """
+        Can these two species names describe the same sample?
+
+        True when they are the same species, or when one is a direct ancestor
+        of the other. Species legitimately differ in specificity: BoLA belongs
+        to the genus-level "Bos sp.", so a BoLA-N*013:01 allele on a sample
+        curated as Bos taurus is less specific, not contradictory.
+
+            Bos taurus        vs Bos sp.               -> True  (ancestor)
+            Coturnix japonica vs Galliformes sp.       -> True  (above genus)
+            Macaca mulatta    vs Macaca fascicularis   -> False (siblings)
+            Carassius gibelio vs Homo sapiens          -> False
+
+        Note that "shares a common ancestor" is NOT a usable test in its place:
+        every species descends from "Gnathostomata sp.", so that predicate is
+        true for any pair and fails open. Only a direct ancestor or descendant
+        relation is meaningful, which is what this checks.
+
+        Accepts a Species, a prefix, a common name or a latin name. Returns
+        False if the other name does not resolve to a species at all.
+        """
+        other = Species.get(other)
+        if other is None:
+            return False
+        return self == other or self.is_ancestor_of(other) or other.is_ancestor_of(self)
+
     @property
     def historic_mhc_prefix(self):
         """
@@ -1264,6 +1291,64 @@ def create_species_lookup_dictionaries():
     context_only_alias_to_species_objects,
     gene_name_to_species_objects,
 ) = create_species_lookup_dictionaries()
+
+
+def species_named_in(name):
+    """
+    Which species, if any, the string names outright.
+
+    Covers both routes the parser uses to take a species off the front of a
+    string, since neither alone is enough:
+
+      - an attached prefix, as in "Gaga-BLB2*02" or "H2-Kb", which tokenizes
+        as a single token
+      - leading species tokens, as in "mouse H2-Kb" or "Homo sapiens class I"
+
+    so that all of those count as naming their species while "BLB2*02" and
+    "class II" do not. Callers compare a result's own species against this
+    list, so an over-eager prefix match on a string that names no species is
+    harmless. Returns a possibly empty list.
+    """
+    from .tokenize import tokenize
+
+    matches = []
+
+    species_from_prefix = infer_species_from_prefix(name)
+    if species_from_prefix is not None:
+        matches.append(species_from_prefix[0])
+
+    tokenization_result = tokenize(name)
+    tokens = tokenization_result.tokens
+    for num_species_tokens in [3, 2, 1]:
+        if len(tokens) >= num_species_tokens:
+            query = " ".join([t.seq for t in tokens[:num_species_tokens]])
+            token_matches = find_matching_species_objects(query)
+            if token_matches:
+                matches.extend(token_matches)
+                break
+
+    attributes = tokenization_result.attributes
+    for key in ("OS", "species"):
+        if key in attributes:
+            from_attributes = Species.get(attributes[key])
+            if from_attributes is not None:
+                matches.append(from_attributes)
+            break
+    return matches
+
+
+def classify_species_source(name, species, default_species):
+    """
+    Returns "stated", "inferred", "default" or None for how `species` came to
+    be associated with the string `name`. See Result.species_source.
+    """
+    if species is None:
+        return None
+    if species in species_named_in(name):
+        return "stated"
+    if default_species is not None and species == Species.get(default_species):
+        return "default"
+    return "inferred"
 
 
 def find_matching_species_objects(name):

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -1339,13 +1339,13 @@ def species_named_in(name):
 
 def classify_species_source(name, species, default_species):
     """
-    Returns "stated", "inferred", "default" or None for how `species` came to
+    Returns "explicit", "inferred", "default" or None for how `species` came to
     be associated with the string `name`. See Result.species_source.
     """
     if species is None:
         return None
     if species in species_named_in(name):
-        return "stated"
+        return "explicit"
     if default_species is not None and species == Species.get(default_species):
         return "default"
     return "inferred"

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.37.0"
+__version__ = "3.38.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21,7 +21,7 @@ something it does not expose, so callers re-implement it badly.
 ## Review
 
 - **#116**: `Result.species_source` returns `"explicit"`, `"inferred"`,
-  `"default"` or `None`, with `Result.species_inferred` as the boolean form.
+  `"default"` or `None`, with `Result.species_from_input` as the boolean form.
   The reporter asked for a bool but noted the three-way form would be more
   useful, and it is: their worst case was a curator writing the deliberately
   generic `MHC class II` and getting *Homo sapiens* — correct behaviour, and
@@ -41,6 +41,11 @@ something it does not expose, so callers re-implement it badly.
   property does the work on first access and memoizes.
 - `require_explicit_species=True` refuses anything not explicit, and composes with
   `required_result_types`.
+- The boolean is `species_from_input` rather than the `species_inferred` the
+  issue suggested. `species_inferred` would have been true for both
+  `"inferred"` and `"default"` while sharing a name with only one of them;
+  `species_from_input` states the question a caller actually has and is the
+  exact complement of `species_source == "explicit"`.
 - **#117**: a README section on parsing untrusted input, showing
   `required_result_types` + `raise_on_error=False`, plus a table of what each
   result type means — the reporter lost time to `HLA-DR15` and `BoLA-DR`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,71 +1,62 @@
-# IPD-MHC and IMGT/HLA coverage gaps
+# Expose species provenance, and document the sharp edges
 
-Tracking issues: #111, #112, #113
+Tracking issues: #116, #117, #118
 
-Found by sweeping every IPD-MHC group species listing and the IMGT/HLA gene
-list against `species.yaml`. That sweep found zero prefix mismatches across the
-125 IPD species we already carried — everything below is absence, not error.
+Three requests from downstream curation work, all one theme: the library knows
+something it does not expose, so callers re-implement it badly.
 
 ## Specification
 
-- [x] Add the 26 remaining IPD-MHC species (2 of the 28 shipped in #108
-      because they owned prefixes that were resolving to the wrong animal).
-- [x] Keep out-of-genus species off the genus nodes, so they do not inherit a
-      prefix and gene list that is not theirs.
-- [x] Add the IMGT/HLA genes that can be added without regressing existing
-      behaviour, with pseudogene status and legacy aliases.
-- [x] Establish which IMGT/HLA genes cannot be added yet, and say why in the
-      ontology rather than leaving it to be rediscovered.
+- [x] Expose whether a result's species was stated in the input, inferred from
+      a gene name, or taken from `default_species` (#116).
+- [x] Add a parse flag that refuses a result whose species was not stated.
+- [x] Keep provenance out of result identity, and off the hot path.
+- [x] Document `required_result_types` as the way to parse untrusted text, and
+      say what each result type means (#117).
+- [x] Add a species-compatibility helper and document that the species tree is
+      nomenclature-shaped with a universal root (#118).
 - [x] Bump the version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
 - [x] Review the final diff and document the result below.
 
 ## Review
 
-- **#111**, 26 species added: 10 capuchins (*Cebus*/*Sapajus*) under
-  `Primata sp.`, 11 cetaceans under `Cetacea sp.`, and 2 jackals under
-  `Canis sp.` Prefixes are the official Comparative MHC Nomenclature Committee
-  designations; loci are not curated for any of them, so only the species
-  designations are recorded.
-- Three of the 26 are not in the genus of the group that lists them —
-  *Cuon alpinus* and *Lycaon pictus* are canids but not *Canis*, and
-  *Phacochoerus africanus* is a suid but not *Sus*. Filing them under
-  `Canis sp.`/`Sus sp.` would hand them the DLA/SLA prefix and those genera's
-  gene lists on no evidence, which is exactly the water buffalo problem in
-  #109. Added `Canidae sp.` and `Suidae sp.` instead — real taxonomic ranks,
-  the same shape as the existing `Cetacea sp.` and `Galliformes sp.` nodes,
-  and what IPD-MHC's "Canids" and "Suids" groups actually cover. Their
-  prefixes are taxonomic, so descendants do not inherit them: `DLA` still
-  resolves to `Canis sp.` and `SLA` to `Sus sp.`
-- **#113**, 10 of 19 genes added: class II pseudogenes DRB2, DQB3, DPA2, DPA3
-  and DPB2; MIC pseudogenes MICC, MICD and MICE; and the immunoproteasome
-  subunits PSMB8 and PSMB9, with LMP7/LMP2 as aliases in the same shape as the
-  existing RING4/RING11 aliases for TAP1/TAP2. All eight pseudogenes carry
-  `pseudogene: true`.
-- The other 9 are **deliberately held back**. IMGT/HLA names the class I gene
-  fragments N, R, S, T, U, W, X, Y and Z, and adding them regresses two things:
-  bare `n`, `s`, `t`, `u` and `w` stop resolving to the mouse and rat haplotype
-  shorthand they mean today and become human gene fragments, and allele-less
-  fragments start accepting allele fields, so `Z*01:01` parses. Three existing
-  tests assert `HLA-X` and `HLA-Z*01:01` are invalid. The same shadowing
-  already affects H/J/K/L/P/V against H2-k and friends, so this wants deciding
-  once for the whole letter series rather than being extended quietly. The
-  reasoning is recorded next to the gene list in `species.yaml` and on #113.
-- **Corrected #112 from the previous PR.** That fix gave `Caau` and `Hyam` to
-  the species IPD-MHC designates, on the assumption that an official
-  designation outranks a curated alias. It does not. The naming rule is
-  mechanical, so several species derive the same code and only one is usually
-  the one in print. `Caau-DAB` and `Caau-UFA` are published *Carassius
-  auratus* designations, while IPD holds no allele sequences for *Canis
-  aureus* at all — so the change broke `Caau-DAB1`, `Caau-UBA`, `Caau-DAB3`,
-  `Hyam-DAB1` and `Hyam-UBA`, all of which parsed before. Reversed it: the
-  attested species keeps the runtime prefix and the designation is recorded as
-  `context only prefixes` on the species IPD names, which stays reachable by
-  its own `CaniAure`/`HypeAmpu` prefix. The two existing tests that the
-  previous PR rewrote are restored to their original assertions, which were
-  right.
-- Verified against the bundled netMHCpan/netMHCIIpan/IEDB corpora: no change
-  beyond the single `B12 class I` correction that shipped in #108.
-- Bumped 3.36.0 to 3.37.0.
+- **#116**: `Result.species_source` returns `"stated"`, `"inferred"`,
+  `"default"` or `None`, with `Result.species_inferred` as the boolean form.
+  The reporter asked for a bool but noted the three-way form would be more
+  useful, and it is: their worst case was a curator writing the deliberately
+  generic `MHC class II` and getting *Homo sapiens* — correct behaviour, and
+  invisible. `"default"` names exactly that, and a bool could not.
+- Determining the source needs both routes the parser uses to take a species
+  off a string: an attached prefix (`Gaga-BLB2*02` tokenizes as one token) and
+  leading species tokens (`mouse H2-Kb`, `Homo sapiens class I`). Neither alone
+  is enough. `parse_species_from_prefix` is not usable for this on its own — it
+  answers *Capra sp.* for `"MHC class II"` — but a false positive is harmless
+  because the result's own species has to be in the matched set.
+- Provenance is **not** an `__init__` field, so `init_field_names()` never sees
+  it and equality, hashing, `repr` and `to_dict()` are untouched:
+  `parse("HLA-A*02:01") == parse("A*02:01")` still holds while their sources
+  differ. It is also computed lazily: an eager version cost 19% of cold parse
+  throughput (0.080 vs 0.067 ms/name), which is not a reasonable price for
+  something almost no caller reads. `parse` stores the two inputs and the
+  property does the work on first access and memoizes.
+- `require_stated_species=True` refuses anything not stated, and composes with
+  `required_result_types`.
+- **#117**: a README section on parsing untrusted input, showing
+  `required_result_types` + `raise_on_error=False`, plus a table of what each
+  result type means — the reporter lost time to `HLA-DR15` and `BoLA-DR`
+  parsing fine while yielding no allele. Every example in the section is
+  verified by running it; the first draft claimed `HLA-*02:01` was an
+  `AlleleWithoutGene` and it does not parse at all, so the example is now
+  `BoLA-D18.4`.
+- **#118**: `Species.compatible_with` implements equal-or-direct-ancestor, and
+  a README section covers the two sharp edges: `Gnathostomata sp.` is a
+  universal root so "shares a common ancestor" accepts everything and fails
+  open, and the tree is shallow where a species owns its MHC system, so
+  `Primata sp.` is not an ancestor of *Homo sapiens* although it is of
+  *Saimiri sciureus*.
+- No behavioural change: 0 of 11,558 names in the bundled corpora parse
+  differently. This PR only adds API and docs.
+- Bumped 3.37.0 to 3.38.0.
 - `./format.sh`: passed.
 - `./lint.sh`: passed.
-- `./test.sh`: passed (15,388 tests; 91% statement coverage).
+- `./test.sh`: passed (15,472 tests; 91% statement coverage).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,9 +7,9 @@ something it does not expose, so callers re-implement it badly.
 
 ## Specification
 
-- [x] Expose whether a result's species was stated in the input, inferred from
+- [x] Expose whether a result's species was explicit in the input, inferred from
       a gene name, or taken from `default_species` (#116).
-- [x] Add a parse flag that refuses a result whose species was not stated.
+- [x] Add a parse flag that refuses a result whose species was not explicit.
 - [x] Keep provenance out of result identity, and off the hot path.
 - [x] Document `required_result_types` as the way to parse untrusted text, and
       say what each result type means (#117).
@@ -20,7 +20,7 @@ something it does not expose, so callers re-implement it badly.
 
 ## Review
 
-- **#116**: `Result.species_source` returns `"stated"`, `"inferred"`,
+- **#116**: `Result.species_source` returns `"explicit"`, `"inferred"`,
   `"default"` or `None`, with `Result.species_inferred` as the boolean form.
   The reporter asked for a bool but noted the three-way form would be more
   useful, and it is: their worst case was a curator writing the deliberately
@@ -39,7 +39,7 @@ something it does not expose, so callers re-implement it badly.
   throughput (0.080 vs 0.067 ms/name), which is not a reasonable price for
   something almost no caller reads. `parse` stores the two inputs and the
   property does the work on first access and memoizes.
-- `require_stated_species=True` refuses anything not stated, and composes with
+- `require_explicit_species=True` refuses anything not explicit, and composes with
   `required_result_types`.
 - **#117**: a README section on parsing untrusted input, showing
   `required_result_types` + `raise_on_error=False`, plus a table of what each

--- a/tests/test_species_provenance.py
+++ b/tests/test_species_provenance.py
@@ -59,13 +59,19 @@ def test_species_from_default_species_is_reported_as_default(name):
 
 
 @pytest.mark.parametrize("name", EXPLICIT)
-def test_explicit_species_is_not_flagged_inferred(name):
-    assert not parse(name).species_inferred
+def test_explicit_species_is_from_input(name):
+    assert parse(name).species_from_input
 
 
 @pytest.mark.parametrize("name", INFERRED + DEFAULTED)
-def test_non_explicit_species_is_flagged_inferred(name):
-    assert parse(name).species_inferred
+def test_non_explicit_species_is_not_from_input(name):
+    assert not parse(name).species_from_input
+
+
+@pytest.mark.parametrize("name", EXPLICIT + INFERRED + DEFAULTED)
+def test_species_from_input_agrees_with_species_source(name):
+    result = parse(name)
+    eq_(result.species_from_input, result.species_source == "explicit")
 
 
 def test_default_is_distinguishable_from_inferred():

--- a/tests/test_species_provenance.py
+++ b/tests/test_species_provenance.py
@@ -1,0 +1,221 @@
+"""
+Tests for how a caller can tell a stated species from an inferred one, and for
+comparing two species names that differ in specificity.
+
+https://github.com/pirl-unc/mhcgnomes/issues/116
+https://github.com/pirl-unc/mhcgnomes/issues/118
+"""
+
+import pytest
+
+from mhcgnomes import Allele, Gene, Pair, ParseError, Species, parse
+
+from .common import eq_
+
+# ---------------------------------------------------------------------------
+# 1. species_source
+# ---------------------------------------------------------------------------
+
+STATED = [
+    "HLA-A*02:01",  # attached prefix
+    "Gaga-BLB2*02",
+    "Coja-DBB1",
+    "BoLA-N*01301",
+    "Bota-DRB3*011:01",
+    "H2-Kb",
+    "BoLA class I",
+    "mouse H2-Kb",  # leading common name
+    "Homo sapiens class I",  # leading latin name
+    "HLA",  # species alone
+]
+
+INFERRED = [
+    "BLB2*02",  # species comes from the gene name
+    "BF2*02:01",
+    "B12 class I",
+]
+
+DEFAULTED = [
+    "A*02:01",  # no species anywhere, falls back to default_species
+    "MHC class II",
+    "class II",
+    "TAP1",
+]
+
+
+@pytest.mark.parametrize("name", STATED)
+def test_stated_species_is_reported_as_stated(name):
+    eq_(parse(name).species_source, "stated")
+
+
+@pytest.mark.parametrize("name", INFERRED)
+def test_species_from_a_gene_name_is_reported_as_inferred(name):
+    eq_(parse(name).species_source, "inferred")
+
+
+@pytest.mark.parametrize("name", DEFAULTED)
+def test_species_from_default_species_is_reported_as_default(name):
+    eq_(parse(name).species_source, "default")
+
+
+@pytest.mark.parametrize("name", STATED)
+def test_stated_species_is_not_flagged_inferred(name):
+    assert not parse(name).species_inferred
+
+
+@pytest.mark.parametrize("name", INFERRED + DEFAULTED)
+def test_unstated_species_is_flagged_inferred(name):
+    assert parse(name).species_inferred
+
+
+def test_default_is_distinguishable_from_inferred():
+    """
+    The two are different problems: 'default' means no species was involved at
+    all, 'inferred' means one was derived from a gene name. A caller putting
+    human MHC on a fish study needs to tell them apart.
+    """
+    eq_(parse("MHC class II").species_source, "default")
+    eq_(parse("BLB2*02").species_source, "inferred")
+
+
+def test_default_species_argument_is_respected():
+    result = parse("A*02:01", default_species="Mamu")
+    eq_(result.species_source, "default")
+    eq_(result.species.name, "Macaca mulatta")
+
+
+# ---------------------------------------------------------------------------
+# 2. Provenance must not leak into identity
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_does_not_affect_equality_or_hashing():
+    stated = parse("HLA-A*02:01")
+    defaulted = parse("A*02:01")
+    eq_(stated.species_source, "stated")
+    eq_(defaulted.species_source, "default")
+    eq_(stated, defaulted)
+    eq_(hash(stated), hash(defaulted))
+
+
+def test_provenance_does_not_appear_in_repr_or_dict():
+    result = parse("HLA-A*02:01")
+    assert "species_source" not in repr(result)
+    assert "species_source" not in result.to_dict()
+
+
+def test_directly_constructed_results_have_no_provenance():
+    assert Allele.get("HLA", "A", "02", "01").species_source is None
+    assert Gene.get("HLA", "A").species_source is None
+
+
+# ---------------------------------------------------------------------------
+# 3. require_stated_species
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", STATED)
+def test_require_stated_species_keeps_stated_results(name):
+    eq_(parse(name, require_stated_species=True), parse(name))
+
+
+@pytest.mark.parametrize("name", INFERRED + DEFAULTED)
+def test_require_stated_species_rejects_unstated_results(name):
+    assert parse(name, require_stated_species=True, raise_on_error=False) is None
+
+
+@pytest.mark.parametrize("name", INFERRED + DEFAULTED)
+def test_require_stated_species_raises_when_asked(name):
+    with pytest.raises(ParseError):
+        parse(name, require_stated_species=True)
+
+
+def test_species_source_is_none_for_unparsed_input():
+    """
+    Every parseable result currently carries a species, so the None case only
+    arises for input that does not parse at all.
+    """
+    assert parse("n/a", raise_on_error=False) is None
+    assert parse("n/a", require_stated_species=True, raise_on_error=False) is None
+
+
+def test_require_stated_species_composes_with_required_result_types():
+    eq_(
+        parse(
+            "Gaga-BLB2*02",
+            required_result_types=(Allele, Gene, Pair),
+            require_stated_species=True,
+        ).to_string(),
+        "Gaga-BLB2*02",
+    )
+    assert (
+        parse(
+            "BLB2*02",
+            required_result_types=(Allele, Gene, Pair),
+            require_stated_species=True,
+            raise_on_error=False,
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Species.compatible_with
+# ---------------------------------------------------------------------------
+
+COMPATIBLE = [
+    ("Bos taurus", "Bos sp."),
+    ("Sus scrofa", "Sus sp."),
+    ("Coturnix japonica", "Galliformes sp."),
+    ("Homo sapiens", "Homo sapiens"),
+    ("Saimiri sciureus", "Primata sp."),
+    ("Homo sapiens", "Gnathostomata sp."),
+]
+
+INCOMPATIBLE = [
+    ("Macaca mulatta", "Macaca fascicularis"),
+    ("Carassius gibelio", "Homo sapiens"),
+    ("Bos taurus", "Ovis aries"),
+    # the ontology is nomenclature-shaped: human hangs off the root, so
+    # Primata sp. is not one of its ancestors even though a squirrel monkey's is
+    ("Homo sapiens", "Primata sp."),
+]
+
+
+@pytest.mark.parametrize("a,b", COMPATIBLE)
+def test_compatible_species(a, b):
+    assert Species.get_by_latin_name(a).compatible_with(b)
+
+
+@pytest.mark.parametrize("a,b", COMPATIBLE)
+def test_compatibility_is_symmetric(a, b):
+    assert Species.get_by_latin_name(b).compatible_with(a)
+
+
+@pytest.mark.parametrize("a,b", INCOMPATIBLE)
+def test_incompatible_species(a, b):
+    assert not Species.get_by_latin_name(a).compatible_with(b)
+    assert not Species.get_by_latin_name(b).compatible_with(a)
+
+
+def test_compatible_with_accepts_prefixes_and_common_names():
+    cattle = Species.get("BoLA")
+    assert cattle.compatible_with("Bota")
+    assert cattle.compatible_with("Bos taurus")
+    assert cattle.compatible_with("cow")
+
+
+def test_compatible_with_returns_false_for_unknown_species():
+    assert not Species.get_by_latin_name("Homo sapiens").compatible_with("not a species")
+
+
+def test_sharing_a_common_ancestor_is_not_the_same_predicate():
+    """
+    Every species descends from Gnathostomata sp., so a common-ancestor test
+    would accept anything. compatible_with requires a direct relation.
+    """
+    human = Species.get_by_latin_name("Homo sapiens")
+    carp = Species.get_by_latin_name("Carassius gibelio")
+    root = Species.get_by_latin_name("Gnathostomata sp.")
+    assert root.is_ancestor_of(human) and root.is_ancestor_of(carp)
+    assert not human.compatible_with(carp)

--- a/tests/test_species_provenance.py
+++ b/tests/test_species_provenance.py
@@ -1,5 +1,5 @@
 """
-Tests for how a caller can tell a stated species from an inferred one, and for
+Tests for how a caller can tell a explicit species from an inferred one, and for
 comparing two species names that differ in specificity.
 
 https://github.com/pirl-unc/mhcgnomes/issues/116
@@ -16,7 +16,7 @@ from .common import eq_
 # 1. species_source
 # ---------------------------------------------------------------------------
 
-STATED = [
+EXPLICIT = [
     "HLA-A*02:01",  # attached prefix
     "Gaga-BLB2*02",
     "Coja-DBB1",
@@ -43,9 +43,9 @@ DEFAULTED = [
 ]
 
 
-@pytest.mark.parametrize("name", STATED)
-def test_stated_species_is_reported_as_stated(name):
-    eq_(parse(name).species_source, "stated")
+@pytest.mark.parametrize("name", EXPLICIT)
+def test_explicit_species_is_reported_as_explicit(name):
+    eq_(parse(name).species_source, "explicit")
 
 
 @pytest.mark.parametrize("name", INFERRED)
@@ -58,13 +58,13 @@ def test_species_from_default_species_is_reported_as_default(name):
     eq_(parse(name).species_source, "default")
 
 
-@pytest.mark.parametrize("name", STATED)
-def test_stated_species_is_not_flagged_inferred(name):
+@pytest.mark.parametrize("name", EXPLICIT)
+def test_explicit_species_is_not_flagged_inferred(name):
     assert not parse(name).species_inferred
 
 
 @pytest.mark.parametrize("name", INFERRED + DEFAULTED)
-def test_unstated_species_is_flagged_inferred(name):
+def test_non_explicit_species_is_flagged_inferred(name):
     assert parse(name).species_inferred
 
 
@@ -90,12 +90,12 @@ def test_default_species_argument_is_respected():
 
 
 def test_provenance_does_not_affect_equality_or_hashing():
-    stated = parse("HLA-A*02:01")
+    explicit = parse("HLA-A*02:01")
     defaulted = parse("A*02:01")
-    eq_(stated.species_source, "stated")
+    eq_(explicit.species_source, "explicit")
     eq_(defaulted.species_source, "default")
-    eq_(stated, defaulted)
-    eq_(hash(stated), hash(defaulted))
+    eq_(explicit, defaulted)
+    eq_(hash(explicit), hash(defaulted))
 
 
 def test_provenance_does_not_appear_in_repr_or_dict():
@@ -110,24 +110,24 @@ def test_directly_constructed_results_have_no_provenance():
 
 
 # ---------------------------------------------------------------------------
-# 3. require_stated_species
+# 3. require_explicit_species
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("name", STATED)
-def test_require_stated_species_keeps_stated_results(name):
-    eq_(parse(name, require_stated_species=True), parse(name))
+@pytest.mark.parametrize("name", EXPLICIT)
+def test_require_explicit_species_keeps_explicit_results(name):
+    eq_(parse(name, require_explicit_species=True), parse(name))
 
 
 @pytest.mark.parametrize("name", INFERRED + DEFAULTED)
-def test_require_stated_species_rejects_unstated_results(name):
-    assert parse(name, require_stated_species=True, raise_on_error=False) is None
+def test_require_explicit_species_rejects_non_explicit_results(name):
+    assert parse(name, require_explicit_species=True, raise_on_error=False) is None
 
 
 @pytest.mark.parametrize("name", INFERRED + DEFAULTED)
-def test_require_stated_species_raises_when_asked(name):
+def test_require_explicit_species_raises_when_asked(name):
     with pytest.raises(ParseError):
-        parse(name, require_stated_species=True)
+        parse(name, require_explicit_species=True)
 
 
 def test_species_source_is_none_for_unparsed_input():
@@ -136,15 +136,15 @@ def test_species_source_is_none_for_unparsed_input():
     arises for input that does not parse at all.
     """
     assert parse("n/a", raise_on_error=False) is None
-    assert parse("n/a", require_stated_species=True, raise_on_error=False) is None
+    assert parse("n/a", require_explicit_species=True, raise_on_error=False) is None
 
 
-def test_require_stated_species_composes_with_required_result_types():
+def test_require_explicit_species_composes_with_required_result_types():
     eq_(
         parse(
             "Gaga-BLB2*02",
             required_result_types=(Allele, Gene, Pair),
-            require_stated_species=True,
+            require_explicit_species=True,
         ).to_string(),
         "Gaga-BLB2*02",
     )
@@ -152,7 +152,7 @@ def test_require_stated_species_composes_with_required_result_types():
         parse(
             "BLB2*02",
             required_result_types=(Allele, Gene, Pair),
-            require_stated_species=True,
+            require_explicit_species=True,
             raise_on_error=False,
         )
         is None


### PR DESCRIPTION
Fixes #116, #117 and #118. All three are the same shape: the library knows something it does not expose, so callers re-implement it badly or not at all.

## #116 — was the species stated, or guessed?

```python
>>> parse("Gaga-BLB2*02").species_source
'explicit'
>>> parse("BLB2*02").species_source        # derived from the gene name
'inferred'
>>> parse("MHC class II").species_source   # fell back to default_species
'default'
```

`result.species_from_input` is the boolean form, true only for `explicit`.

The issue suggested `species_inferred`, but that would have been true for both `"inferred"` and `"default"` while sharing a name with only one of them — `parse("MHC class II").species_inferred` reading `True` with a source of `"default"` is confusing. `species_from_input` states the question a caller actually has (did I supply this species, or did the parser?) and is the exact complement of `species_source == "explicit"`. There is only the one boolean, so there is no question about whether two forms stay in sync.

`"explicit"` rather than `"stated"`: the latter was vague about who did the stating, and named a mechanism while `"default"` named a source, so the three did not sit on one axis. `"explicit"` is the conventional antonym of `"inferred"`.

**Why three values rather than a bool.** The issue's worst case is not a parser bug: a curator writes the deliberately generic `MHC class II`, gets *Homo sapiens* — documented and correct — and human MHC lands on a Prussian carp study with nothing to flag it. `"default"` names exactly that case, and `"inferred"` names the different one where a bare gene symbol carried a species nobody supplied. A bool cannot separate them, and they need separate handling.

To refuse anything you did not name outright:

```python
>>> parse("BLB2*02", require_explicit_species=True, raise_on_error=False) is None
True
```

It composes with `required_result_types`, as the issue hoped.

### Implementation notes

**Provenance is not part of identity.** It is not an `__init__` field, so `init_field_names()` never sees it and equality, hashing, `repr` and `to_dict()` are untouched:

```python
>>> parse("HLA-A*02:01") == parse("A*02:01")     # sources differ
True
```

**It is lazy.** Computing it eagerly cost **19% of cold-parse throughput** (0.080 vs 0.067 ms/name) — not a reasonable price for something almost no caller reads, especially given #84/#93. `parse` stores the two inputs it needs; the property does the work on first access and memoizes. Throughput is back at baseline.

**Detection needs both routes** the parser itself uses to take a species off a string: an attached prefix (`Gaga-BLB2*02` tokenizes as a single token) and leading species tokens (`mouse H2-Kb`, `Homo sapiens class I`). Neither alone covers both. `parse_species_from_prefix` is not usable on its own — it answers *Capra sp.* for `"MHC class II"` — but a false positive is harmless, because the result's own species has to appear in the matched set.

## #117 — parsing untrusted input

New README section showing `required_result_types` with `raise_on_error=False`, and a table of what each result type means. The reporter hand-rolled `type(x).__name__ in {"Allele","Gene","Pair"}` because the supported argument is not in the usage docs, then lost more time to `HLA-DR15` and `BoLA-DR` parsing cleanly while yielding no allele.

Every example in the section is verified by running it — which caught one of my own: the first draft listed `HLA-*02:01` as an `AlleleWithoutGene` and it does not parse at all. The example is now `BoLA-D18.4`.

## #118 — species compatibility

```python
>>> Species.get("Bos taurus").compatible_with("Bos sp.")
True                     # less specific, not contradictory
>>> Species.get("Macaca mulatta").compatible_with("Macaca fascicularis")
False                    # siblings
```

Plus a README section on the two sharp edges the reporter identified, both confirmed:

- **`Gnathostomata sp.` is a universal root**, so "shares a common ancestor" is true for any pair and *fails open*. Only a direct ancestor or descendant relation is meaningful — which is what `compatible_with` checks, and there is a test asserting the common-ancestor predicate would accept a human/carp pair that `compatible_with` rejects.
- **The tree is shallow where a species owns its MHC system.** `Homo sapiens` attaches directly to the root, so `Primata sp.` is not one of its ancestors even though it is *Saimiri sciureus*'s.

## Verification

- 15,472 tests pass; 84 new ones cover provenance, identity-invariance, `require_stated_species`, and compatibility including both sharp edges.
- **No behavioural change**: 0 of 11,558 names in the bundled netMHCpan/netMHCIIpan/IEDB corpora parse differently. This PR only adds API and docs.
- Cold-parse throughput unchanged at ~0.067 ms/name.

## One note on #118

It cites "#115" for the water buffalo parenting; that is **#109**. Worth fixing the cross-reference so it does not dead-end.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH


