### PR TITLE
Document that the species tree is prefix scope, not phylogeny

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,14 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
   (#109); `Caau` pointed at a goldfish rather than the golden jackal IPD
   designates (#112). Existing tests can encode the same errors — check the
   authority before assuming a failing test means your change is wrong.
+- **Do not assume our curation is wrong either.** The inverse of the rule
+  above, and just as costly. Structure that looks incorrect is often load-
+  bearing: `Bubalus bubalis` sits under `Bos sp.` despite being another genus,
+  which two readers filed as a bug, but the species tree is a prefix-scope
+  hierarchy rather than a phylogeny, and detaching it would have broken every
+  published `Bubu-*` class II parse. Before changing a structure, check what
+  depends on it -- what stops parsing, what test covers it, what the papers
+  actually write.
 - **An official designation is not the same as attested usage.** The naming
   rule is mechanical, so several species can derive the same code, and only
   one of them is usually the one that appears in print — the rest are

--- a/README.md
+++ b/README.md
@@ -333,9 +333,37 @@ in YAML data files under `mhcgnomes/data/`. The key files are:
 
 ### The species tree
 
-Species entries form a tree through their `parent` links, and it is
-**nomenclature-shaped rather than taxonomic**. Two things follow that are easy
-to get wrong:
+Species entries form a tree through their `parent` links. **It is a
+prefix-scope hierarchy, not a phylogeny.** A `parent` says "this species may be
+named under the ancestor's umbrella prefix" — nothing more. Read as taxonomy it
+looks wrong in both directions, and two independent readers have filed the same
+bug against it:
+
+```
+Bos sp. [BoLA]     ->  Bota, Boin, Bofr, Bogr, Bubu
+Macaca sp. [RhLA]  ->  Mafa, Mamu, Mane, Masi, Math
+Canis sp. [DLA]    ->  Calu, Cala, Caru, Casi, Caba
+Primata sp. [NHP]  ->  45 non-human primates
+```
+
+**`Homo sapiens` is not under `Primata sp.`.** It attaches straight to the
+root, despite humans plainly being primates — because human alleles are never
+written `NHP-*`. That is the clearest evidence of what the tree encodes.
+
+**`Bubalus bubalis` is under `Bos sp.` despite being a different genus.** Water
+buffalo belongs to *Bubalus*, a sister genus of *Bos* within Bovini, so as
+taxonomy the edge is wrong. As prefix scope it is right: IPD-MHC files water
+buffalo in the BoLA group, and the literature assigns buffalo class II
+sequences to cattle loci by trans-species polymorphism — `Bubu-DRB` is the
+orthologue of `BoLA-DRB3`. The edge is also load-bearing: the entry declares
+only `DQA`, `DQA1` and `DQB` itself, so `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2`
+and `Bubu-DQB1` all parse by inheritance, and `Bubu-DRB` normalizes to
+`Bubu-DRB3` because of it.
+
+So before "correcting" a parent link that looks taxonomically wrong, check what
+parses through it.
+
+Two further consequences are easy to get wrong:
 
 **`Gnathostomata sp.` is a universal root.** Every species descends from it, so
 "do these two share a common ancestor?" is true for any pair and useless as a
@@ -354,11 +382,11 @@ mhcgnomes derives from an allele, since the two legitimately differ in
 specificity: `BoLA` belongs to the genus-level `Bos sp.`, so a `BoLA-N*013:01`
 allele on a sample curated as *Bos taurus* is compatible.
 
-**The tree is shallow where a species owns its own MHC system.** `Homo sapiens`
-attaches directly to the root, so `Primata sp.` is *not* an ancestor of human,
-while `Saimiri sciureus` -> `Primata sp.` -> `Gnathostomata sp.` is. HLA is its
-own system rather than a generic primate one, and the tree reflects that. A
-caller reasoning purely taxonomically will guess wrong.
+**Compatibility is a claim about naming, not ancestry.** Because the tree is
+prefix scope, `compatible_with` answers "could these two names describe the
+same sample?" and not "are these related species?". A `Bubu-*` allele is
+compatible with a curated `Bos sp.`, since `Bos sp.` denotes the BoLA group and
+water buffalo is in it. That is the intended answer, not a wart.
 
 An `X sp.` node is a group entry: it holds the prefix and the genes shared by
 everything beneath it. `Bos sp.` owns `BoLA` and the cattle gene list; `Bos

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -178,6 +178,26 @@ URL.
   `mhcgnomes/data/underrepresented_taxa_source_registry.yaml` until they are
   resolved.
 
+### The tree is prefix scope, not phylogeny
+
+A `parent` link says "this species may be named under the ancestor's umbrella
+prefix". It is not a claim of descent, and reading it as one is the single most
+common misunderstanding of this file -- two independent readers have filed the
+same bug against `Bubalus bubalis` sitting under `Bos sp.`
+
+The clearest evidence is `Homo sapiens`, which attaches straight to the root
+rather than under `Primata sp.`, despite humans being primates: human alleles
+are never written `NHP-*`. `Bubalus bubalis` under `Bos sp.` is the mirror
+image -- a different genus, but IPD-MHC files water buffalo in the BoLA group
+and the literature assigns its class II sequences to cattle loci by
+trans-species polymorphism.
+
+Parent links are also load-bearing for parsing, because genes are inherited
+along them. Before changing one because it looks taxonomically wrong, check
+what stops parsing: water buffalo declares only `DQA`, `DQA1` and `DQB`, so
+detaching it would break `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2` and `Bubu-DQB1`,
+every one of which is named in the published literature.
+
 ### Inherited prefixes and inherited genes
 
 Two kinds of ambiguity are not prefix collisions between unrelated species, but

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.38.0"
+__version__ = "3.38.1"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,67 +1,44 @@
-# Expose species provenance, and document the sharp edges
+# Document that the species tree is prefix scope, not phylogeny
 
-Tracking issues: #116, #117, #118
-
-Three requests from downstream curation work, all one theme: the library knows
-something it does not expose, so callers re-implement it badly.
+Tracking issues: #109, #115 (both closed as not-a-bug)
 
 ## Specification
 
-- [x] Expose whether a result's species was explicit in the input, inferred from
-      a gene name, or taken from `default_species` (#116).
-- [x] Add a parse flag that refuses a result whose species was not explicit.
-- [x] Keep provenance out of result identity, and off the hot path.
-- [x] Document `required_result_types` as the way to parse untrusted text, and
-      say what each result type means (#117).
-- [x] Add a species-compatibility helper and document that the species tree is
-      nomenclature-shaped with a universal root (#118).
+- [x] Establish whether `Bubalus bubalis` under `Bos sp.` is wrong, from the
+      published water buffalo literature rather than from taxonomy.
+- [x] Record the answer where the misreading happens: README, curation guide,
+      and AGENTS.md.
 - [x] Bump the version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
 - [x] Review the final diff and document the result below.
 
 ## Review
 
-- **#116**: `Result.species_source` returns `"explicit"`, `"inferred"`,
-  `"default"` or `None`, with `Result.species_from_input` as the boolean form.
-  The reporter asked for a bool but noted the three-way form would be more
-  useful, and it is: their worst case was a curator writing the deliberately
-  generic `MHC class II` and getting *Homo sapiens* — correct behaviour, and
-  invisible. `"default"` names exactly that, and a bool could not.
-- Determining the source needs both routes the parser uses to take a species
-  off a string: an attached prefix (`Gaga-BLB2*02` tokenizes as one token) and
-  leading species tokens (`mouse H2-Kb`, `Homo sapiens class I`). Neither alone
-  is enough. `parse_species_from_prefix` is not usable for this on its own — it
-  answers *Capra sp.* for `"MHC class II"` — but a false positive is harmless
-  because the result's own species has to be in the matched set.
-- Provenance is **not** an `__init__` field, so `init_field_names()` never sees
-  it and equality, hashing, `repr` and `to_dict()` are untouched:
-  `parse("HLA-A*02:01") == parse("A*02:01")` still holds while their sources
-  differ. It is also computed lazily: an eager version cost 19% of cold parse
-  throughput (0.080 vs 0.067 ms/name), which is not a reasonable price for
-  something almost no caller reads. `parse` stores the two inputs and the
-  property does the work on first access and memoizes.
-- `require_explicit_species=True` refuses anything not explicit, and composes with
-  `required_result_types`.
-- The boolean is `species_from_input` rather than the `species_inferred` the
-  issue suggested. `species_inferred` would have been true for both
-  `"inferred"` and `"default"` while sharing a name with only one of them;
-  `species_from_input` states the question a caller actually has and is the
-  exact complement of `species_source == "explicit"`.
-- **#117**: a README section on parsing untrusted input, showing
-  `required_result_types` + `raise_on_error=False`, plus a table of what each
-  result type means — the reporter lost time to `HLA-DR15` and `BoLA-DR`
-  parsing fine while yielding no allele. Every example in the section is
-  verified by running it; the first draft claimed `HLA-*02:01` was an
-  `AlleleWithoutGene` and it does not parse at all, so the example is now
-  `BoLA-D18.4`.
-- **#118**: `Species.compatible_with` implements equal-or-direct-ancestor, and
-  a README section covers the two sharp edges: `Gnathostomata sp.` is a
-  universal root so "shares a common ancestor" accepts everything and fails
-  open, and the tree is shallow where a species owns its MHC system, so
-  `Primata sp.` is not an ancestor of *Homo sapiens* although it is of
-  *Saimiri sciureus*.
-- No behavioural change: 0 of 11,558 names in the bundled corpora parse
-  differently. This PR only adds API and docs.
-- Bumped 3.37.0 to 3.38.0.
+- **No data change.** The placement is correct and my own #109 proposal would
+  have broken real parses. Two of us filed the same bug independently -- #109
+  from here, #115 downstream -- so the gap was documentation, not curation.
+- The tree is a **prefix-scope hierarchy**: a `parent` says "this species may
+  be named under the ancestor's umbrella prefix". `Homo sapiens` attaching to
+  the root rather than under `Primata sp.` is the clearest evidence, since
+  human alleles are never written `NHP-*`.
+- The literature confirms it for water buffalo: `Bubu-DRB` is orthologous to
+  `BoLA-DRB3` and buffalo sequences are assigned to cattle loci by
+  trans-species polymorphism (PMC3313522; PMID 12580780). IPD-MHC files the
+  species in the BoLA group.
+- The link is load-bearing. `Bubalus bubalis` declares only `DQA`, `DQA1` and
+  `DQB`; `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2` and `Bubu-DQB1` all parse by
+  inheritance, and `Bubu-DRB` normalizes to `Bubu-DRB3` -- exactly the
+  orthology the papers describe -- only because of it. Detaching drops the
+  species from 55 visible genes to 11. I had measured that drop while
+  proposing the change and read it as an acceptable cost; it was the evidence
+  against the change.
+- Residual, not addressed: buffalo also inherits the BoLA class I loci, and
+  no water buffalo class I sequences are published. That is permissive parsing
+  of names nobody writes rather than a wrong claim, and tightening it means
+  per-locus evidence review across every group node.
+- AGENTS.md gains the inverse of the lesson added last time: do not assume our
+  curation is wrong either, and check what depends on a structure before
+  changing it.
+- Bumped 3.38.0 to 3.38.1. Docs only; no behaviour change.
 - `./format.sh`: passed.
 - `./lint.sh`: passed.
-- `./test.sh`: passed (15,472 tests; 91% statement coverage).
+- `./test.sh`: passed (15,489 tests; 91% statement coverage).


### PR DESCRIPTION
Documentation only — closes the residual from #109 and #115, both of which are closed as not-a-bug.

## What happened

Two people independently filed the same report against `Bubalus bubalis` sitting under `Bos sp.`: **#109** from here and **#115** downstream. Both read the species tree as a phylogeny. It isn't.

**A `parent` link is prefix scope, not descent.** It says "this species may be named under the ancestor's umbrella prefix", which is why the loader's `_is_taxonomic_prefix` check decides whether a prefix is inherited at all.

The clearest evidence was already in the file and I had verified it for #118 without drawing the conclusion: **`Homo sapiens` attaches straight to the root rather than under `Primata sp.`**, despite humans being primates — because human alleles are never written `NHP-*`.

## Why the buffalo edge is right

Taxonomically *Bubalus* is a sister genus of *Bos* within Bovini, so the edge looks wrong. As prefix scope it is right: IPD-MHC files water buffalo in the BoLA group, and the literature assigns buffalo class II sequences to cattle loci by trans-species polymorphism — `Bubu-DRB` is described as the orthologue of `BoLA-DRB3` ([PMC3313522](https://pmc.ncbi.nlm.nih.gov/articles/PMC3313522/), [PMID 12580780](https://pubmed.ncbi.nlm.nih.gov/12580780/)).

**It is also load-bearing.** The entry declares only `DQA`, `DQA1` and `DQB`. Everything else the papers name parses by inheritance:

```
Bubu-DRA    -> Bubu-DRA      published
Bubu-DRB    -> Bubu-DRB3     published (8 Bubu-DRB alleles)
Bubu-DRB3   -> Bubu-DRB3     published, orthologue of BoLA-DRB3
Bubu-DQA2   -> Bubu-DQA2     published
Bubu-DQB1   -> Bubu-DQB1     published
```

Detaching drops the species from 55 visible genes to 11 and breaks all five. `Bubu-DRB` normalizing to `Bubu-DRB3` is exactly the orthology the papers describe, and only works because of the inheritance.

I measured that 55 → 11 drop while proposing the re-parenting and read it as an acceptable cost. It was the evidence against the change.

## Changes

- **README** — the species-tree section now leads with prefix scope and both worked examples, and states that compatibility is a claim about naming rather than ancestry (so a `Bubu-*` allele being compatible with a curated `Bos sp.` is the intended answer, not a wart).
- **docs/curation.md** — the same warning where a curator will hit it, with the instruction to check what stops parsing before changing a parent link.
- **AGENTS.md** — the inverse of the lesson added last time: *do not assume our curation is wrong either*. Structure that looks incorrect is often load-bearing.

## Not addressed

Buffalo also inherits the BoLA class I loci — `Bubu-N`, `Bubu-1`, `Bubu-MIC1` parse — and there are no published water buffalo class I sequences; IPD holds only DQA and DQB. That is permissive parsing of names nobody writes rather than a wrong claim, and tightening it means per-locus evidence review across every group node. Noted on #109 rather than done here.

No behaviour change; 15,489 tests pass.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH
