### PR TITLE
Curate the published water buffalo loci

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -2420,14 +2420,36 @@ Bos grunniens:
     - Domestic Yak
     - Yak
 Bubalus bubalis:
+  # Under Bos sp. because the tree is prefix scope, not phylogeny: IPD-MHC
+  # files water buffalo in the BoLA group, and its class II sequences are
+  # assigned to cattle loci by trans-species polymorphism. See the species
+  # tree section of docs/curation.md. Bubalus is a separate genus from Bos,
+  # which is why this looks wrong on first reading.
   parent: Bos sp.
   prefix: Bubu
   name: Water Buffalo
   genes:
     IIa:
+      # Loci with published water buffalo sequences. These would otherwise be
+      # inherited from Bos sp., which parses them but records no evidence that
+      # the buffalo locus itself has been characterized.
+      DR:
+        # PMID 12580780 (Immunogenetics 2003) characterized buffalo DRA and
+        # DRB, reporting eight Bubu-DRB alleles across four breeds.
+        - DRA
+        # Declared as DRB, not DRB3. PMID 22383896 states only that "the
+        # Bubu-DRB sequence showed maximum homology with the BoLA-DRB3*0101
+        # allele of cattle" -- homology, not identity -- and every paper writes
+        # the buffalo locus as Bubu-DRB. Declaring it here stops the cattle
+        # `DRB: DRB3` alias in gene_aliases.yaml from renaming it, while
+        # Bubu-DRB3 still parses by inheritance for anyone who wants it.
+        - DRB
       DQ:
         - DQA
+        # PMID 22383896 cites the isolation of cDNAs encoding buffalo DQA1 and
+        # DQA2; IPD-MHC holds 39 Bubu-DQA alleles.
         - DQA1
+        - DQA2
         - DQB
 ################################################################################
 #

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.38.0"
+__version__ = "3.39.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,67 +1,51 @@
-# Expose species provenance, and document the sharp edges
+# Curate the published water buffalo loci
 
-Tracking issues: #116, #117, #118
+Tracking issues: follow-up to #109 / #115 (both closed as not-a-bug)
 
-Three requests from downstream curation work, all one theme: the library knows
-something it does not expose, so callers re-implement it badly.
+Those two issues asked whether `Bubalus bubalis` belongs under `Bos sp.`
+It does -- the tree is prefix scope. But checking the literature to answer
+that turned up a real gap: the entry did not record the loci the buffalo
+papers actually characterize.
 
 ## Specification
 
-- [x] Expose whether a result's species was explicit in the input, inferred from
-      a gene name, or taken from `default_species` (#116).
-- [x] Add a parse flag that refuses a result whose species was not explicit.
-- [x] Keep provenance out of result identity, and off the hot path.
-- [x] Document `required_result_types` as the way to parse untrusted text, and
-      say what each result type means (#117).
-- [x] Add a species-compatibility helper and document that the species tree is
-      nomenclature-shaped with a universal root (#118).
+- [x] Declare on `Bubalus bubalis` the class II loci with published buffalo
+      sequences, with sources cited next to each.
+- [x] Stop the cattle `DRB -> DRB3` alias renaming the buffalo locus, since
+      the literature reports homology rather than identity.
+- [x] Leave inherited cattle loci reachable.
+- [x] Decide, from IPD-MHC rather than one paper, whether `BoLA-DQB3` and
+      `BoLA-DQB4` should exist.
 - [x] Bump the version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
 - [x] Review the final diff and document the result below.
 
 ## Review
 
-- **#116**: `Result.species_source` returns `"explicit"`, `"inferred"`,
-  `"default"` or `None`, with `Result.species_from_input` as the boolean form.
-  The reporter asked for a bool but noted the three-way form would be more
-  useful, and it is: their worst case was a curator writing the deliberately
-  generic `MHC class II` and getting *Homo sapiens* — correct behaviour, and
-  invisible. `"default"` names exactly that, and a bool could not.
-- Determining the source needs both routes the parser uses to take a species
-  off a string: an attached prefix (`Gaga-BLB2*02` tokenizes as one token) and
-  leading species tokens (`mouse H2-Kb`, `Homo sapiens class I`). Neither alone
-  is enough. `parse_species_from_prefix` is not usable for this on its own — it
-  answers *Capra sp.* for `"MHC class II"` — but a false positive is harmless
-  because the result's own species has to be in the matched set.
-- Provenance is **not** an `__init__` field, so `init_field_names()` never sees
-  it and equality, hashing, `repr` and `to_dict()` are untouched:
-  `parse("HLA-A*02:01") == parse("A*02:01")` still holds while their sources
-  differ. It is also computed lazily: an eager version cost 19% of cold parse
-  throughput (0.080 vs 0.067 ms/name), which is not a reasonable price for
-  something almost no caller reads. `parse` stores the two inputs and the
-  property does the work on first access and memoizes.
-- `require_explicit_species=True` refuses anything not explicit, and composes with
-  `required_result_types`.
-- The boolean is `species_from_input` rather than the `species_inferred` the
-  issue suggested. `species_inferred` would have been true for both
-  `"inferred"` and `"default"` while sharing a name with only one of them;
-  `species_from_input` states the question a caller actually has and is the
-  exact complement of `species_source == "explicit"`.
-- **#117**: a README section on parsing untrusted input, showing
-  `required_result_types` + `raise_on_error=False`, plus a table of what each
-  result type means — the reporter lost time to `HLA-DR15` and `BoLA-DR`
-  parsing fine while yielding no allele. Every example in the section is
-  verified by running it; the first draft claimed `HLA-*02:01` was an
-  `AlleleWithoutGene` and it does not parse at all, so the example is now
-  `BoLA-D18.4`.
-- **#118**: `Species.compatible_with` implements equal-or-direct-ancestor, and
-  a README section covers the two sharp edges: `Gnathostomata sp.` is a
-  universal root so "shares a common ancestor" accepts everything and fails
-  open, and the tree is shallow where a species owns its MHC system, so
-  `Primata sp.` is not an ancestor of *Homo sapiens* although it is of
-  *Saimiri sciureus*.
-- No behavioural change: 0 of 11,558 names in the bundled corpora parse
-  differently. This PR only adds API and docs.
-- Bumped 3.37.0 to 3.38.0.
+- Declared `DRA`, `DRB`, `DQA2` in addition to the existing `DQA`, `DQA1`,
+  `DQB`. All were previously inherited from `Bos sp.`, which parsed them but
+  recorded no evidence that the buffalo locus itself had been characterized.
+  Sources: PMID 12580780 (buffalo DRA and DRB, eight Bubu-DRB alleles across
+  four breeds), PMID 22383896 (cites isolation of buffalo DQA1 and DQA2
+  cDNAs), and IPD-MHC, which holds 39 Bubu-DQA alleles.
+- **`Bubu-DRB` no longer renames to `Bubu-DRB3`.** `gene_aliases.yaml` maps
+  `DRB -> DRB3` under `BoLA`, which is right for cattle, where DRB3 is the
+  expressed DRB locus, and buffalo inherited it. PMID 22383896 says only that
+  "the Bubu-DRB sequence showed maximum homology with the BoLA-DRB3*0101
+  allele of cattle" -- homology, not identity -- and every paper writes the
+  locus as Bubu-DRB. Declaring `DRB` on the species stops the rename;
+  `Bubu-DRB3` still parses by inheritance.
+- **`BoLA-DQB3` and `BoLA-DQB4` deliberately not added.** A trans-species
+  phylogeny paper assigns buffalo sequences to loci it labels `BoLA-DQB1`,
+  `BoLA-DQB3` and `BoLA-DQB4`, but IPD-MHC registers only `BoLA-DQB`. Those
+  are that analysis's locus labels rather than designations. A test pins their
+  absence so the distinction is not lost.
+- Also added the prefix-scope explanation as a comment on the entry itself,
+  since it is the specific line two people have now filed bugs against.
+- No behaviour change on real data: 0 of 11,558 names in the bundled corpora
+  parse differently. The `Bubu-DRB` rename is the only behavioural change and
+  no corpus name exercises it.
+- Bumped 3.38.0 to 3.39.0 -- minor rather than patch, because `Bubu-DRB` now
+  returns a different gene name.
 - `./format.sh`: passed.
 - `./lint.sh`: passed.
-- `./test.sh`: passed (15,472 tests; 91% statement coverage).
+- `./test.sh`: passed (15,507 tests; 91% statement coverage).

--- a/tests/test_water_buffalo.py
+++ b/tests/test_water_buffalo.py
@@ -1,0 +1,90 @@
+"""
+Water buffalo (Bubalus bubalis) MHC loci.
+
+Bubalus sits under Bos sp. because the species tree is a prefix-scope
+hierarchy: IPD-MHC files water buffalo in the BoLA group and its class II
+sequences are assigned to cattle loci by trans-species polymorphism. The
+entry declares the loci with published buffalo sequences itself, so that
+they round-trip as the literature writes them.
+
+Sources:
+  PMID 12580780  Polymorphisms in MHC-DRA and -DRB alleles of water buffalo
+  PMID 22383896  Molecular characterization of MHC-DRB cDNA in water buffalo
+  https://www.ebi.ac.uk/ipd/mhc/group/BoLA/species
+"""
+
+import pytest
+
+from mhcgnomes import Species, parse
+
+from .common import eq_
+
+# Locus names as the papers and IPD-MHC write them
+PUBLISHED_LOCI = ["DRA", "DRB", "DQA", "DQA1", "DQA2", "DQB"]
+
+
+@pytest.mark.parametrize("gene_name", PUBLISHED_LOCI)
+def test_published_buffalo_locus_round_trips(gene_name):
+    """A locus the literature names must come back with the same name."""
+    result = parse(f"Bubu-{gene_name}")
+    eq_(result.species.name, "Bubalus bubalis")
+    eq_(result.name, gene_name)
+    eq_(result.to_string(), f"Bubu-{gene_name}")
+
+
+@pytest.mark.parametrize("gene_name", PUBLISHED_LOCI)
+def test_buffalo_declares_its_published_loci(gene_name):
+    """
+    Declared rather than inherited, so the ontology records that the buffalo
+    locus itself has been characterized.
+    """
+    assert Species.get_by_latin_name("Bubalus bubalis").declares_gene(gene_name)
+
+
+def test_buffalo_DRB_is_not_renamed_to_DRB3():
+    """
+    The cattle gene alias maps DRB -> DRB3, and buffalo used to inherit it.
+    PMID 22383896 says only that "the Bubu-DRB sequence showed maximum
+    homology with the BoLA-DRB3*0101 allele of cattle" -- homology, not
+    identity -- and every paper writes the buffalo locus as Bubu-DRB.
+    """
+    eq_(parse("Bubu-DRB").name, "DRB")
+    eq_(parse("Bubu-DRB").to_string(), "Bubu-DRB")
+
+
+def test_cattle_DRB_is_still_renamed_to_DRB3():
+    """The alias is right for cattle, where DRB3 is the expressed DRB locus."""
+    eq_(parse("BoLA-DRB").name, "DRB3")
+
+
+def test_inherited_cattle_loci_still_parse_for_buffalo():
+    """
+    Buffalo remains under Bos sp., so cattle loci it does not declare are
+    still reachable. Detaching it would break these.
+    """
+    for gene_name in ["DRB3", "DQB1", "DRB1"]:
+        result = parse(f"Bubu-{gene_name}")
+        eq_(result.species.name, "Bubalus bubalis")
+        assert not result.species.declares_gene(gene_name)
+
+
+def test_buffalo_alleles_parse():
+    eq_(parse("Bubu-DQA*01:01").species.name, "Bubalus bubalis")
+    eq_(parse("Bubu-DRB*01:01").to_string(), "Bubu-DRB*01:01")
+
+
+def test_bola_still_resolves_to_cattle():
+    """The buffalo entry must not disturb the group prefix."""
+    eq_(Species.get("BoLA").name, "Bos sp.")
+    eq_(parse("BoLA class I").species.name, "Bos sp.")
+    eq_(parse("BoLA-DRB3*011:01").species.name, "Bos sp.")
+
+
+def test_no_speculative_DQB_loci():
+    """
+    A trans-species phylogeny paper labels buffalo sequences BoLA-DQB1/3/4,
+    but IPD-MHC registers only BoLA-DQB. DQB3 and DQB4 are that analysis's
+    locus labels, not designations, so they are deliberately absent.
+    """
+    assert parse("BoLA-DQB3", raise_on_error=False) is None
+    assert parse("BoLA-DQB4", raise_on_error=False) is None


### PR DESCRIPTION
Follow-up to #109 / #115, both closed as not-a-bug. Answering *whether* water buffalo belongs under `Bos sp.` turned up a real gap in the same entry: it did not record the loci the buffalo papers actually characterize.

## What the literature says, and what we did with each

| finding | what the ontology said | what it says now |
|---|---|---|
| Papers write `Bubu-DRA`, `Bubu-DRB`, `Bubu-DQA1`, `Bubu-DQA2` | all inherited from `Bos sp.`; only `DQA`, `DQA1`, `DQB` declared | `DRA`, `DRB`, `DQA2` declared with sources |
| `Bubu-DRB` is "orthologous to" / "showed maximum homology with" `BoLA-DRB3*0101` | `Bubu-DRB` **renamed** to `Bubu-DRB3` | `Bubu-DRB` stays `Bubu-DRB` |
| Buffalo sequences assigned to `BoLA-DQB1`, `BoLA-DQB3`, `BoLA-DQB4` | DQB3/DQB4 absent | **still absent, deliberately** |
| IPD-MHC files Bubu in the BoLA group | parent link, uncommented | parent link, with the reason on the line |

## The DRB rename

`gene_aliases.yaml` maps `DRB -> DRB3` under `BoLA`. That is right for **cattle**, where DRB3 is the expressed DRB locus — and buffalo inherited it, so `Bubu-DRB` came back as `Bubu-DRB3`.

The papers do not support that identity. [PMID 22383896](https://pmc.ncbi.nlm.nih.gov/articles/PMC3313522/) says only that *"the Bubu-DRB sequence showed maximum homology with the BoLA-DRB3\*0101 allele of cattle"* — homology, not identity — and [PMID 12580780](https://pubmed.ncbi.nlm.nih.gov/12580780/) is titled "…reveal **different features from cattle** DR alleles". Every paper writes the buffalo locus as `Bubu-DRB`.

Declaring `DRB` on the species stops the rename. Cattle is untouched (`BoLA-DRB` → `DRB3`), and `Bubu-DRB3` still parses by inheritance for anyone who wants it.

## Why DQB3/DQB4 are not added

The trans-species paper assigns buffalo sequences to loci it labels `BoLA-DQB1`, `BoLA-DQB3` and `BoLA-DQB4`. I checked IPD-MHC: it registers only **`BoLA-DQB`** (92 alleles). Those are one analysis's phylogenetic locus labels, not designations, so adding them would be exactly the "official designation vs one paper" mistake `AGENTS.md` now warns about. A test pins their absence so the distinction survives.

## Why declaring matters when they already parsed

All six loci parsed before, by inheritance. Declaring them:

- records that the **buffalo** locus has been characterized, not just the cattle one — `Species.declares_gene` can now tell those apart
- stops the cattle DRB alias applying to a species the papers name differently
- makes the entry state its evidence, per the sourcing rule in `AGENTS.md`

I also put the prefix-scope explanation directly on the `parent: Bos sp.` line, since that is the specific line two people have now filed bugs against.

## Verification

- 15,507 tests pass; 18 new ones cover the published loci, the DRB rename, inherited loci still resolving, and the absent DQB3/DQB4.
- **0 of 11,558** names in the bundled corpora parse differently. The `Bubu-DRB` rename is the only behavioural change and no corpus name exercises it.
- 3.39.0 rather than a patch, because `Bubu-DRB` returns a different gene name.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH
