### PR TITLE
Put Homo sapiens back in the primate order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,8 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
   parsing, what test covers it, what the papers actually write.
 - **Do not generalize one exception into a model.** The buffalo edge is a real
   departure from taxonomy, but reading it as proof that the whole tree is
-  "prefix scope, not phylogeny" was an over-correction: exactly one edge in 671
-  entries crosses a genus boundary, and `Homo sapiens` was outside `Primata
+  "prefix scope, not phylogeny" was an over-correction: exactly one parent link
+  in the ontology crosses a genus boundary, and `Homo sapiens` was outside `Primata
   sp.` only because nothing had opted it out of the `NHP` umbrella (#122). A
   parent link is containment and the umbrella prefix is a separate, opt-out-able
   property. One counterexample bounds a rule; it does not replace it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,18 +98,25 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
   the next reader cannot tell it from a checked fact.
 - **Do not assume our existing curation is right.** It is a secondary source
   and it has been wrong: Patr-AL was class Ia when the paper describing it is
-  titled "nonclassical" (#107); water buffalo is parented under `Bos sp.`
-  (#109); `Caau` pointed at a goldfish rather than the golden jackal IPD
-  designates (#112). Existing tests can encode the same errors — check the
-  authority before assuming a failing test means your change is wrong.
+  titled "nonclassical" (#107); `Pren` was claimed by two different genera
+  (#110); `Homo sapiens` hung off the root rather than under the primate node,
+  so the library denied that humans are primates (#122). Existing tests can
+  encode the same errors — check the authority before assuming a failing test
+  means your change is wrong.
 - **Do not assume our curation is wrong either.** The inverse of the rule
   above, and just as costly. Structure that looks incorrect is often load-
   bearing: `Bubalus bubalis` sits under `Bos sp.` despite being another genus,
-  which two readers filed as a bug, but the species tree is a prefix-scope
-  hierarchy rather than a phylogeny, and detaching it would have broken every
-  published `Bubu-*` class II parse. Before changing a structure, check what
-  depends on it -- what stops parsing, what test covers it, what the papers
-  actually write.
+  which two readers filed as a bug, but IPD-MHC files water buffalo in the BoLA
+  group and detaching it would have broken every published `Bubu-*` class II
+  parse. Before changing a structure, check what depends on it -- what stops
+  parsing, what test covers it, what the papers actually write.
+- **Do not generalize one exception into a model.** The buffalo edge is a real
+  departure from taxonomy, but reading it as proof that the whole tree is
+  "prefix scope, not phylogeny" was an over-correction: exactly one edge in 671
+  entries crosses a genus boundary, and `Homo sapiens` was outside `Primata
+  sp.` only because nothing had opted it out of the `NHP` umbrella (#122). A
+  parent link is containment and the umbrella prefix is a separate, opt-out-able
+  property. One counterexample bounds a rule; it does not replace it.
 - **An official designation is not the same as attested usage.** The naming
   rule is mechanical, so several species can derive the same code, and only
   one of them is usually the one that appears in print — the rest are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,10 +113,18 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
 - **Do not generalize one exception into a model.** The buffalo edge is a real
   departure from taxonomy, but reading it as proof that the whole tree is
   "prefix scope, not phylogeny" was an over-correction: exactly one parent link
-  in the ontology crosses a genus boundary, and `Homo sapiens` was outside `Primata
-  sp.` only because nothing had opted it out of the `NHP` umbrella (#122). A
-  parent link is containment and the umbrella prefix is a separate, opt-out-able
-  property. One counterexample bounds a rule; it does not replace it.
+  in the ontology points at another genus's node, and `Homo sapiens` was
+  outside `Primata sp.` only because nothing expressed that `NHP` cannot name a
+  human (#122). A parent link is containment; naming scope is a separate
+  property, declared with `prefix excludes` and queried with
+  `Species.can_name`. One counterexample bounds a rule; it does not replace it.
+- **An invariant you assert in prose has to be tested on every path.** The
+  first fix for #122 blocked `NHP` from reaching humans through prefix
+  inheritance, and the PR said "`NHP-*` still cannot name it" -- but three
+  other things read the parent link, and `parse("NHP-E*01:01",
+  species="Homo sapiens")` duly returned `HLA-E*01:01`. Before claiming a
+  guarantee, enumerate the consumers of the thing you changed and test each
+  one.
 - **An official designation is not the same as attested usage.** The naming
   rule is mechanical, so several species can derive the same code, and only
   one of them is usually the one that appears in print — the rest are

--- a/README.md
+++ b/README.md
@@ -333,32 +333,37 @@ in YAML data files under `mhcgnomes/data/`. The key files are:
 
 ### The species tree
 
-Species entries form a tree through their `parent` links. **It is a
-prefix-scope hierarchy, not a phylogeny.** A `parent` says "this species may be
-named under the ancestor's umbrella prefix" — nothing more. Read as taxonomy it
-looks wrong in both directions, and two independent readers have filed the same
-bug against it:
+Species entries form a tree through their `parent` links. A `parent` is a
+containment claim — "this species is inside that group" — and it is taxonomic
+wherever it can be: of 671 entries, exactly one edge crosses a genus boundary.
+
+The umbrella MHC prefix is a *separate* property of a node. It is handed down
+to a child only when the parent's prefix is an MHC prefix rather than a taxon
+name (`BoLA` is inherited, `Aves` is not), and only when the child does not
+declare an `old prefix` of its own:
 
 ```
 Bos sp. [BoLA]     ->  Bota, Boin, Bofr, Bogr, Bubu
 Macaca sp. [RhLA]  ->  Mafa, Mamu, Mane, Masi, Math
 Canis sp. [DLA]    ->  Calu, Cala, Caru, Casi, Caba
-Primata sp. [NHP]  ->  45 non-human primates
+Primata sp. [NHP]  ->  54 non-human primates, plus Homo sapiens
 ```
 
-**`Homo sapiens` is not under `Primata sp.`.** It attaches straight to the
-root, despite humans plainly being primates — because human alleles are never
-written `NHP-*`. That is the clearest evidence of what the tree encodes.
+**`Homo sapiens` is under `Primata sp.` and still never answers to `NHP`.**
+`NHP` is the IPD-MHC group code for [Non-Human
+Primates](https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it is exclusionary by
+definition — but it is a naming property, not a membership one. Human declares
+its own `old prefix`, which is the opt-out, so it is a primate for
+`compatible_with` and `is_descendant_of` while `NHP-*` still cannot name it.
 
-**`Bubalus bubalis` is under `Bos sp.` despite being a different genus.** Water
-buffalo belongs to *Bubalus*, a sister genus of *Bos* within Bovini, so as
-taxonomy the edge is wrong. As prefix scope it is right: IPD-MHC files water
-buffalo in the BoLA group, and the literature assigns buffalo class II
-sequences to cattle loci by trans-species polymorphism — `Bubu-DRB` is the
-orthologue of `BoLA-DRB3`. The edge is also load-bearing: the entry declares
-only `DQA`, `DQA1` and `DQB` itself, so `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2`
-and `Bubu-DQB1` all parse by inheritance, and `Bubu-DRB` normalizes to
-`Bubu-DRB3` because of it.
+**`Bubalus bubalis` is under `Bos sp.` despite being a different genus.** This
+is the one edge that is deliberately not taxonomy. Water buffalo belongs to
+*Bubalus*, a sister genus of *Bos* within Bovini, but IPD-MHC files water
+buffalo in the BoLA group and the literature assigns buffalo class II sequences
+to cattle loci by trans-species polymorphism — `Bubu-DRB` is the orthologue of
+`BoLA-DRB3`. The edge is load-bearing: the entry declares only `DQA`, `DQA1`
+and `DQB` itself, so `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2` and `Bubu-DQB1` all
+parse by inheritance, and `Bubu-DRB` normalizes to `Bubu-DRB3` because of it.
 
 So before "correcting" a parent link that looks taxonomically wrong, check what
 parses through it.
@@ -382,9 +387,9 @@ mhcgnomes derives from an allele, since the two legitimately differ in
 specificity: `BoLA` belongs to the genus-level `Bos sp.`, so a `BoLA-N*013:01`
 allele on a sample curated as *Bos taurus* is compatible.
 
-**Compatibility is a claim about naming, not ancestry.** Because the tree is
-prefix scope, `compatible_with` answers "could these two names describe the
-same sample?" and not "are these related species?". A `Bubu-*` allele is
+**Compatibility can be broader than ancestry.** `compatible_with` answers
+"could these two names describe the same sample?". Where an edge exists for
+naming rather than descent, the answer follows the edge: a `Bubu-*` allele is
 compatible with a curated `Bos sp.`, since `Bos sp.` denotes the BoLA group and
 water buffalo is in it. That is the intended answer, not a wart.
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ in YAML data files under `mhcgnomes/data/`. The key files are:
 
 Species entries form a tree through their `parent` links. A `parent` is a
 containment claim — "this species is inside that group" — and it is taxonomic
-wherever it can be: of 671 entries, exactly one edge crosses a genus boundary.
+wherever it can be: exactly one parent link in the whole ontology crosses a
+genus boundary.
 
 The umbrella MHC prefix is a *separate* property of a node. It is handed down
 to a child only when the parent's prefix is an MHC prefix rather than a taxon
@@ -346,7 +347,7 @@ declare an `old prefix` of its own:
 Bos sp. [BoLA]     ->  Bota, Boin, Bofr, Bogr, Bubu
 Macaca sp. [RhLA]  ->  Mafa, Mamu, Mane, Masi, Math
 Canis sp. [DLA]    ->  Calu, Cala, Caru, Casi, Caba
-Primata sp. [NHP]  ->  54 non-human primates, plus Homo sapiens
+Primata sp. [NHP]  ->  every non-human primate, plus Homo sapiens
 ```
 
 **`Homo sapiens` is under `Primata sp.` and still never answers to `NHP`.**

--- a/README.md
+++ b/README.md
@@ -335,27 +335,43 @@ in YAML data files under `mhcgnomes/data/`. The key files are:
 
 Species entries form a tree through their `parent` links. A `parent` is a
 containment claim — "this species is inside that group" — and it is taxonomic
-wherever it can be: exactly one parent link in the whole ontology crosses a
-genus boundary.
+wherever it can be: exactly one parent link in the whole ontology points at
+another genus's node. Genes, and the rest of a species' curated data, are
+inherited along these links.
 
-The umbrella MHC prefix is a *separate* property of a node. It is handed down
-to a child only when the parent's prefix is an MHC prefix rather than a taxon
-name (`BoLA` is inherited, `Aves` is not), and only when the child does not
-declare an `old prefix` of its own:
+Whether an ancestor's prefix may *name* a descendant is a separate question.
+An umbrella prefix normally covers everything beneath it:
 
 ```
 Bos sp. [BoLA]     ->  Bota, Boin, Bofr, Bogr, Bubu
 Macaca sp. [RhLA]  ->  Mafa, Mamu, Mane, Masi, Math
 Canis sp. [DLA]    ->  Calu, Cala, Caru, Casi, Caba
-Primata sp. [NHP]  ->  every non-human primate, plus Homo sapiens
 ```
 
-**`Homo sapiens` is under `Primata sp.` and still never answers to `NHP`.**
-`NHP` is the IPD-MHC group code for [Non-Human
-Primates](https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it is exclusionary by
-definition — but it is a naming property, not a membership one. Human declares
-its own `old prefix`, which is the opt-out, so it is a primate for
-`compatible_with` and `is_descendant_of` while `NHP-*` still cannot name it.
+**`Homo sapiens` is a primate that never answers to `NHP`.** `Primata sp.` is
+the primate order and human is inside it, but the prefix it carries is
+IPD-MHC's group code for [Non-Human
+Primates](https://www.ebi.ac.uk/ipd/mhc/group/NHP/) — exclusionary by
+definition, unlike every other umbrella prefix in the file. The entry says so:
+
+```yaml
+Primata sp.:
+  prefix: NHP
+  prefix excludes:
+    - Homo sapiens
+```
+
+`Species.can_name` answers the naming question and honours that declaration,
+while `is_ancestor_of` and `is_descendant_of` stay purely taxonomic:
+
+```python
+>>> Species.get("Homo sapiens").is_descendant_of("Primata sp.")
+True                              # humans are primates
+>>> Species.get("Primata sp.").can_name("Homo sapiens")
+False                             # NHP-* cannot denote one
+>>> parse("NHP-E*01:01", species="Homo sapiens", raise_on_error=False)
+None                              # so this is refused, not converted
+```
 
 **`Bubalus bubalis` is under `Bos sp.` despite being a different genus.** This
 is the one edge that is deliberately not taxonomy. Water buffalo belongs to
@@ -388,11 +404,13 @@ mhcgnomes derives from an allele, since the two legitimately differ in
 specificity: `BoLA` belongs to the genus-level `Bos sp.`, so a `BoLA-N*013:01`
 allele on a sample curated as *Bos taurus* is compatible.
 
-**Compatibility can be broader than ancestry.** `compatible_with` answers
-"could these two names describe the same sample?". Where an edge exists for
-naming rather than descent, the answer follows the edge: a `Bubu-*` allele is
-compatible with a curated `Bos sp.`, since `Bos sp.` denotes the BoLA group and
-water buffalo is in it. That is the intended answer, not a wart.
+**Compatibility is a question about naming, not descent.** `compatible_with`
+answers "could these two names describe the same sample?", so it follows
+`can_name` rather than ancestry. A `Bubu-*` allele is compatible with a curated
+`Bos sp.`, since `Bos sp.` denotes the BoLA group and water buffalo is in it. A
+human sample is *not* compatible with `Primata sp.`, since that name denotes
+the NHP group — even though humans are primates, which `is_descendant_of` will
+tell you.
 
 An `X sp.` node is a group entry: it holds the prefix and the genes shared by
 everything beneath it. `Bos sp.` owns `BoLA` and the cattle gene list; `Bos

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -181,8 +181,8 @@ URL.
 ### A parent link is containment; the umbrella prefix is separate
 
 A `parent` link says "this species is inside that group". It is taxonomic
-wherever it can be -- of 671 entries exactly one edge crosses a genus boundary
--- and it is what genes are inherited along.
+wherever it can be -- exactly one parent link in the whole ontology crosses a
+genus boundary -- and it is what genes are inherited along.
 
 The umbrella MHC prefix is a different mechanism layered on top. The loader
 hands a parent's prefix down to a child as its `old prefix` only when

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -178,25 +178,45 @@ URL.
   `mhcgnomes/data/underrepresented_taxa_source_registry.yaml` until they are
   resolved.
 
-### The tree is prefix scope, not phylogeny
+### A parent link is containment; the umbrella prefix is separate
 
-A `parent` link says "this species may be named under the ancestor's umbrella
-prefix". It is not a claim of descent, and reading it as one is the single most
-common misunderstanding of this file -- two independent readers have filed the
-same bug against `Bubalus bubalis` sitting under `Bos sp.`
+A `parent` link says "this species is inside that group". It is taxonomic
+wherever it can be -- of 671 entries exactly one edge crosses a genus boundary
+-- and it is what genes are inherited along.
 
-The clearest evidence is `Homo sapiens`, which attaches straight to the root
-rather than under `Primata sp.`, despite humans being primates: human alleles
-are never written `NHP-*`. `Bubalus bubalis` under `Bos sp.` is the mirror
-image -- a different genus, but IPD-MHC files water buffalo in the BoLA group
+The umbrella MHC prefix is a different mechanism layered on top. The loader
+hands a parent's prefix down to a child as its `old prefix` only when
+
+1. the parent's prefix is an MHC prefix rather than its own taxon name
+   (`BoLA`, `NHP`, `DLA` are inherited; `Aves`, `Rodentia`, `Crocodylia` are
+   not), and
+2. the child does not declare an `old prefix` of its own.
+
+Keeping the two apart is what lets `Homo sapiens` sit under `Primata sp.`
+without joining the group its prefix names. `NHP` is the IPD-MHC group code for
+Non-Human Primates (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it must never
+reach a human -- but that is a fact about naming, not about membership, and
+spelling out `old prefix: HLA` on the human entry is the opt-out. Human is a
+primate for `is_descendant_of` and `compatible_with`, and `NHP-*` still cannot
+name it. Before #122 the entry hung off the root instead, which made
+`compatible_with("Homo sapiens", "Primata sp.")` false and read as a claim that
+humans are not primates.
+
+The one edge that is deliberately not taxonomy is `Bubalus bubalis` under `Bos
+sp.` -- a different genus, but IPD-MHC files water buffalo in the BoLA group
 and the literature assigns its class II sequences to cattle loci by
-trans-species polymorphism.
+trans-species polymorphism. Two independent readers have filed that as a bug
+(#109, #115); it is not one.
 
-Parent links are also load-bearing for parsing, because genes are inherited
-along them. Before changing one because it looks taxonomically wrong, check
-what stops parsing: water buffalo declares only `DQA`, `DQA1` and `DQB`, so
+Parent links are load-bearing for parsing, because genes are inherited along
+them. Before changing one because it looks taxonomically wrong, check what
+stops parsing: water buffalo declares only `DQA`, `DQA1` and `DQB`, so
 detaching it would break `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2` and `Bubu-DQB1`,
-every one of which is named in the published literature.
+every one of which is named in the published literature. Conversely, check what
+a *new* parent would hand down: reparenting human under `Primata sp.` was safe
+precisely because human already declares all sixteen genes that node owns, so
+nothing was inherited that was not already there. `tests/test_species_tree_shape.py`
+pins both halves of this.
 
 ### Inherited prefixes and inherited genes
 

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -178,29 +178,34 @@ URL.
   `mhcgnomes/data/underrepresented_taxa_source_registry.yaml` until they are
   resolved.
 
-### A parent link is containment; the umbrella prefix is separate
+### A parent link is containment; naming scope is separate
 
 A `parent` link says "this species is inside that group". It is taxonomic
-wherever it can be -- exactly one parent link in the whole ontology crosses a
-genus boundary -- and it is what genes are inherited along.
+wherever it can be -- exactly one parent link in the ontology points at another
+genus's node -- and it is what the rest of the entry is inherited along.
 
-The umbrella MHC prefix is a different mechanism layered on top. The loader
-hands a parent's prefix down to a child as its `old prefix` only when
+Whether an ancestor's *prefix* may name a descendant is a different question,
+and three separate mechanisms answer it.
 
-1. the parent's prefix is an MHC prefix rather than its own taxon name
-   (`BoLA`, `NHP`, `DLA` are inherited; `Aves`, `Rodentia`, `Crocodylia` are
-   not), and
-2. the child does not declare an `old prefix` of its own.
-
-Keeping the two apart is what lets `Homo sapiens` sit under `Primata sp.`
-without joining the group its prefix names. `NHP` is the IPD-MHC group code for
-Non-Human Primates (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it must never
-reach a human -- but that is a fact about naming, not about membership, and
-spelling out `old prefix: HLA` on the human entry is the opt-out. Human is a
-primate for `is_descendant_of` and `compatible_with`, and `NHP-*` still cannot
-name it. Before #122 the entry hung off the root instead, which made
-`compatible_with("Homo sapiens", "Primata sp.")` false and read as a claim that
-humans are not primates.
+1. **Prefix inheritance.** The loader hands a parent's prefix down to a child
+   as its `old prefix` when the parent's prefix is an MHC prefix rather than
+   its own taxon name (`BoLA`, `NHP`, `DLA` are inherited; `Aves`, `Rodentia`,
+   `Crocodylia` are not), the child does not declare an `old prefix` of its
+   own, and the parent does not exclude it. Note this is the *immediate*
+   parent: `Macaca mulatta` inherits `RhLA` from `Macaca sp.`, not `NHP`.
+2. **`prefix excludes`.** A list of species an entry's prefix must never name,
+   even though they sit beneath it. There is one, and it exists because
+   IPD-MHC's `NHP` group code means Non-Human Primates
+   (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it cannot denote a human even
+   though humans are primates.
+3. **`Species.can_name`.** The runtime query: ancestry, minus anything an
+   ancestor excludes. `compatible_with` follows it, and so does the
+   ancestor-to-descendant conversion behind `parse(..., species=...)`, which is
+   why `parse("NHP-E*01:01", species="Homo sapiens")` is refused rather than
+   silently returned as `HLA-E*01:01`. `is_ancestor_of` and `is_descendant_of`
+   deliberately do *not* follow it: they stay purely taxonomic, so
+   `Homo sapiens` is a descendant of `Primata sp.` and always was in fact, if
+   not in this file before #122.
 
 The one edge that is deliberately not taxonomy is `Bubalus bubalis` under `Bos
 sp.` -- a different genus, but IPD-MHC files water buffalo in the BoLA group
@@ -212,11 +217,15 @@ Parent links are load-bearing for parsing, because genes are inherited along
 them. Before changing one because it looks taxonomically wrong, check what
 stops parsing: water buffalo declares only `DQA`, `DQA1` and `DQB`, so
 detaching it would break `Bubu-DRA`, `Bubu-DRB3`, `Bubu-DQA2` and `Bubu-DQB1`,
-every one of which is named in the published literature. Conversely, check what
-a *new* parent would hand down: reparenting human under `Primata sp.` was safe
-precisely because human already declares all sixteen genes that node owns, so
-nothing was inherited that was not already there. `tests/test_species_tree_shape.py`
-pins both halves of this.
+every one of which is named in the published literature.
+
+Conversely, check what a *new* parent hands down -- and note that gene names
+are only part of it. Gene properties, gene families, class II locus groupings
+and the seven side tables that merge by ancestor latin name (gene and allele
+aliases, known alleles, haplotypes, serotypes, heterodimers, supertypes) all
+inherit too, so a pseudogene flag added to `Primata sp.` would become one on
+`HLA`. `tests/test_species_tree_shape.py` checks each of those channels
+separately rather than trusting the gene list.
 
 ### Inherited prefixes and inherited genes
 

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -433,17 +433,13 @@ Crocodylia sp.:
 ######################################################
 Homo sapiens:
   prefix: HLA
+  # Humans are primates -- NCBI Taxonomy places Homo sapiens (taxid 9606) in
+  # Primates (taxid 9443), https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606
+  # -- so the parent is the primate node. That node owns the prefix NHP, which
+  # can never name a human; the exclusion is declared on Primata sp. itself
+  # under "prefix excludes", because it is a property of what NHP means rather
+  # than of this entry. See #122.
   parent: Primata sp.
-  # Humans are primates, so the parent is the primate node. The umbrella
-  # prefix of that node is NHP, which IPD-MHC defines as "Non-Human Primates"
-  # (https://www.ebi.ac.uk/ipd/mhc/group/NHP/, "a specialist database for the
-  # Major Histocompatibility Complex genes of Non-Human Primates"), and human
-  # alleles are of course never written NHP-*. Spelling out "old prefix" is
-  # what keeps HLA from inheriting NHP the way every non-human primate does:
-  # the loader only hands a parent prefix down to children that do not declare
-  # one themselves. Parent link and umbrella prefix are separate mechanisms, so
-  # humans can sit in the taxonomy without joining the naming group. See #122.
-  old prefix: HLA
   name: Human
   genes:
     Ia:
@@ -2431,13 +2427,13 @@ Bos grunniens:
     - Domestic Yak
     - Yak
 Bubalus bubalis:
-  # The one parent link in the ontology that is naming rather than taxonomy:
+  # The only parent link in the file that points at another genus's node:
   # Bubalus is a separate genus from Bos, which is why this looks wrong on
   # first reading, but IPD-MHC files water buffalo in the BoLA group and its
   # class II sequences are assigned to cattle loci by trans-species
-  # polymorphism. Every other parent link stays within its genus, so do not
-  # read this one as licence to move others around; see the species tree
-  # section of docs/curation.md.
+  # polymorphism. Naming rather than taxonomy, and the only one, so do not
+  # read it as licence to move others around; see the species tree section of
+  # docs/curation.md.
   parent: Bos sp.
   prefix: Bubu
   name: Water Buffalo
@@ -4322,13 +4318,16 @@ Tyto alba:
 #
 ################################################################################
 Primata sp.:
-  # This node is the IPD-MHC "NHP" group -- https://www.ebi.ac.uk/ipd/mhc/group/NHP/
-  # describes it as "a specialist database for the Major Histocompatibility
+  # The primate order, holding the genes every primate shares. Its prefix is
+  # the IPD-MHC group code NHP, which https://www.ebi.ac.uk/ipd/mhc/group/NHP/
+  # describes as "a specialist database for the Major Histocompatibility
   # Complex genes of Non-Human Primates ... Apes and both Old World and New
-  # World monkeys". The prefix is therefore exclusionary by definition, while
-  # the node itself is the whole primate order: Homo sapiens is a child of it
-  # and opts out of the prefix with its own "old prefix". See #122.
+  # World monkeys" -- exclusionary by definition, unlike every other umbrella
+  # prefix in this file. So the node contains Homo sapiens, and the prefix is
+  # declared not to name it. See #122.
   prefix: NHP
+  prefix excludes:
+    - Homo sapiens
   name: Primate
   genes:
     Ib:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -439,9 +439,9 @@ Homo sapiens:
   # (https://www.ebi.ac.uk/ipd/mhc/group/NHP/, "a specialist database for the
   # Major Histocompatibility Complex genes of Non-Human Primates"), and human
   # alleles are of course never written NHP-*. Spelling out "old prefix" is
-  # what keeps HLA from inheriting NHP the way the other 54 primates do: the
-  # loader only hands a parent prefix down to children that do not declare one
-  # themselves. Parent link and umbrella prefix are separate mechanisms, so
+  # what keeps HLA from inheriting NHP the way every non-human primate does:
+  # the loader only hands a parent prefix down to children that do not declare
+  # one themselves. Parent link and umbrella prefix are separate mechanisms, so
   # humans can sit in the taxonomy without joining the naming group. See #122.
   old prefix: HLA
   name: Human

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -2431,11 +2431,13 @@ Bos grunniens:
     - Domestic Yak
     - Yak
 Bubalus bubalis:
-  # Under Bos sp. because the tree is prefix scope, not phylogeny: IPD-MHC
-  # files water buffalo in the BoLA group, and its class II sequences are
-  # assigned to cattle loci by trans-species polymorphism. See the species
-  # tree section of docs/curation.md. Bubalus is a separate genus from Bos,
-  # which is why this looks wrong on first reading.
+  # The one parent link in the ontology that is naming rather than taxonomy:
+  # Bubalus is a separate genus from Bos, which is why this looks wrong on
+  # first reading, but IPD-MHC files water buffalo in the BoLA group and its
+  # class II sequences are assigned to cattle loci by trans-species
+  # polymorphism. Every other parent link stays within its genus, so do not
+  # read this one as licence to move others around; see the species tree
+  # section of docs/curation.md.
   parent: Bos sp.
   prefix: Bubu
   name: Water Buffalo

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -433,6 +433,17 @@ Crocodylia sp.:
 ######################################################
 Homo sapiens:
   prefix: HLA
+  parent: Primata sp.
+  # Humans are primates, so the parent is the primate node. The umbrella
+  # prefix of that node is NHP, which IPD-MHC defines as "Non-Human Primates"
+  # (https://www.ebi.ac.uk/ipd/mhc/group/NHP/, "a specialist database for the
+  # Major Histocompatibility Complex genes of Non-Human Primates"), and human
+  # alleles are of course never written NHP-*. Spelling out "old prefix" is
+  # what keeps HLA from inheriting NHP the way the other 54 primates do: the
+  # loader only hands a parent prefix down to children that do not declare one
+  # themselves. Parent link and umbrella prefix are separate mechanisms, so
+  # humans can sit in the taxonomy without joining the naming group. See #122.
+  old prefix: HLA
   name: Human
   genes:
     Ia:
@@ -4309,6 +4320,12 @@ Tyto alba:
 #
 ################################################################################
 Primata sp.:
+  # This node is the IPD-MHC "NHP" group -- https://www.ebi.ac.uk/ipd/mhc/group/NHP/
+  # describes it as "a specialist database for the Major Histocompatibility
+  # Complex genes of Non-Human Primates ... Apes and both Old World and New
+  # World monkeys". The prefix is therefore exclusionary by definition, while
+  # the node itself is the whole primate order: Homo sapiens is a child of it
+  # and opts out of the prefix with its own "old prefix". See #122.
   prefix: NHP
   name: Primate
   genes:

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -750,7 +750,12 @@ def parse(
                 result_species = result.species
                 if result_species == expected:
                     matches_expected = True
-                elif result_species.is_ancestor_of(expected):
+                # can_name rather than is_ancestor_of: an umbrella prefix that
+                # is exclusionary by definition must not be reinterpreted as one
+                # of the species it excludes. "NHP" names non-human primates, so
+                # parse("NHP-E*01:01", species="Homo sapiens") has to be rejected
+                # rather than converted to HLA-E*01:01. See issue #122.
+                elif result_species.can_name(expected):
                     converted = _reparse_result_for_species(
                         parser=parser,
                         result=result,

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -148,6 +148,7 @@ class Species(Result):
     other_mhc_prefixes: Any = None
     context_only_mhc_prefixes: Any = None
     other_common_names: Any = None
+    prefix_excluded_species: Any = None
 
     def __init__(
         self,
@@ -171,6 +172,7 @@ class Species(Result):
         other_mhc_prefixes: Iterable[str] = [],
         context_only_mhc_prefixes: Iterable[str] = [],
         other_common_names: Iterable[str] = [],
+        prefix_excluded_species: Iterable[str] = [],
         raw_string: Union[str, None] = None,
         gene_name_to_properties: Union[Mapping[str, Mapping[str, Any]], None] = None,
         gene_family_name_to_gene_names: Union[Mapping[str, Iterable[str]], None] = None,
@@ -213,6 +215,11 @@ class Species(Result):
             self,
             "context_only_mhc_prefixes",
             FrozenSet(context_only_mhc_prefixes),
+        )
+        self._set_field(
+            self,
+            "prefix_excluded_species",
+            FrozenSet(prefix_excluded_species),
         )
         if old_mhc_prefix:
             normalized_old_mhc_prefix = old_mhc_prefix
@@ -346,19 +353,55 @@ class Species(Result):
             current = current.parent_species
         return False
 
+    def can_name(self, other):
+        """
+        Can a name written under this species' prefix denote `other`?
+
+        True for itself and for every descendant, except where an entry
+        declares "prefix excludes" -- an umbrella prefix that is exclusionary
+        by definition. "NHP" is IPD-MHC's group code for Non-Human Primates, so
+        Primata sp. cannot name Homo sapiens even though it is its ancestor:
+
+            Bos sp.     -> Bubalus bubalis   -> True
+            Primata sp. -> Macaca mulatta    -> True
+            Primata sp. -> Homo sapiens      -> False (prefix excludes)
+
+        This is the naming counterpart of is_ancestor_of, which stays purely
+        taxonomic. Use this one whenever the question is "may this name stand
+        for that species", such as reinterpreting a group-level allele name
+        under a specific species.
+        """
+        other = Species.get(other)
+        if other is None:
+            return False
+        if self == other:
+            return True
+        node = other
+        while node is not None and node != self:
+            if node.name in self.prefix_excluded_species:
+                return False
+            node = node.parent_species
+        return node == self
+
     def compatible_with(self, other):
         """
         Can these two species names describe the same sample?
 
-        True when they are the same species, or when one is a direct ancestor
-        of the other. Species legitimately differ in specificity: BoLA belongs
-        to the genus-level "Bos sp.", so a BoLA-N*013:01 allele on a sample
-        curated as Bos taurus is less specific, not contradictory.
+        True when they are the same species, or when one can name the other.
+        Species legitimately differ in specificity: BoLA belongs to the
+        genus-level "Bos sp.", so a BoLA-N*013:01 allele on a sample curated as
+        Bos taurus is less specific, not contradictory.
 
             Bos taurus        vs Bos sp.               -> True  (ancestor)
             Coturnix japonica vs Galliformes sp.       -> True  (above genus)
             Macaca mulatta    vs Macaca fascicularis   -> False (siblings)
             Carassius gibelio vs Homo sapiens          -> False
+            Homo sapiens      vs Primata sp.           -> False (prefix excludes)
+
+        The last one is the reason this is can_name rather than is_ancestor_of:
+        humans are primates, but "Primata sp." is the node that owns the NHP
+        prefix, and an NHP-* allele can never have come from a human sample.
+        For the taxonomic question, ask is_descendant_of.
 
         Note that "shares a common ancestor" is NOT a usable test in its place:
         every species descends from "Gnathostomata sp.", so that predicate is
@@ -371,7 +414,7 @@ class Species(Result):
         other = Species.get(other)
         if other is None:
             return False
-        return self == other or self.is_ancestor_of(other) or other.is_ancestor_of(self)
+        return self == other or self.can_name(other) or other.can_name(self)
 
     @property
     def historic_mhc_prefix(self):
@@ -986,10 +1029,27 @@ def create_species_for_latin_name(latin_name):
     if not prefix:
         raise ValueError(f"Missing 'prefix' for '{latin_name}' in species ontology")
 
+    # Species this entry's own prefix must never name, even though they sit
+    # beneath it in the tree. An umbrella prefix is normally handed down to
+    # every descendant, but a few of them are exclusionary by definition --
+    # IPD-MHC's "NHP" means Non-Human Primates, so it cannot name Homo sapiens
+    # even though humans are primates. See issue #122.
+    prefix_excluded_species = species_info.get("prefix excludes") or []
+    if type(prefix_excluded_species) is str:
+        prefix_excluded_species = [prefix_excluded_species]
+    for excluded_name in prefix_excluded_species:
+        if excluded_name not in raw_species_dict:
+            raise ValueError(
+                f"'prefix excludes' of '{latin_name}' names unknown species '{excluded_name}'"
+            )
+
     old_mhc_prefix = species_info.get("old prefix")
     if not old_mhc_prefix and parent_species:
         parent_prefix = parent_species.prefix
-        if not _is_taxonomic_prefix(parent_prefix, parent_species.name):
+        if (
+            not _is_taxonomic_prefix(parent_prefix, parent_species.name)
+            and latin_name not in parent_species.prefix_excluded_species
+        ):
             old_mhc_prefix = parent_prefix
 
     other_mhc_prefixes = species_info.get("other prefixes")
@@ -1217,6 +1277,7 @@ def create_species_for_latin_name(latin_name):
         other_mhc_prefixes=other_mhc_prefixes,
         context_only_mhc_prefixes=context_only_mhc_prefixes,
         other_common_names=[name for name in common_names if name != shortest_common_name],
+        prefix_excluded_species=prefix_excluded_species,
         raw_string=latin_name,
     )
 

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.39.0"
+__version__ = "3.40.0"
 
 
 def print_version():

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -14,8 +14,7 @@ example. #122 pointed out that human's placement was not evidence for a model,
 it was a bug.
 
 **Why it was wrong.** One counterexample bounds a rule; it does not replace it.
-A sweep of all 671 entries found exactly one parent link that crosses a genus
-boundary. The tree is containment, taxonomic wherever it can be, with the
+A sweep of every parent link found exactly one that crosses a genus boundary. The tree is containment, taxonomic wherever it can be, with the
 umbrella prefix as a separate opt-out-able property -- which the loader had
 always implemented and which nobody had looked at.
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,48 @@
+# Lessons
+
+Patterns worth not repeating, written after a correction landed.
+
+## Do not generalize one exception into a model
+
+**What happened.** `Bubalus bubalis` sits under `Bos sp.` despite being another
+genus. Working out why (#109, #115) produced a correct answer -- the edge
+exists because IPD-MHC files water buffalo in the BoLA group -- and then an
+incorrect generalization: that the whole species tree is "prefix scope, not a
+phylogeny". That went into the README, `docs/curation.md` and `AGENTS.md`, with
+`Homo sapiens` sitting outside `Primata sp.` offered as the clinching second
+example. #122 pointed out that human's placement was not evidence for a model,
+it was a bug.
+
+**Why it was wrong.** One counterexample bounds a rule; it does not replace it.
+A sweep of all 671 entries found exactly one parent link that crosses a genus
+boundary. The tree is containment, taxonomic wherever it can be, with the
+umbrella prefix as a separate opt-out-able property -- which the loader had
+always implemented and which nobody had looked at.
+
+**How to apply.** Before writing a model into the docs, count how many entries
+actually support it. If the answer is one, write down the exception, not the
+model. Reading the code that implements the structure is part of establishing
+what the structure means.
+
+## Verify which copy of the package you just measured
+
+**What happened.** An A/B measurement of a data change reported "0 changes" and
+also, impossibly, no change to the field being edited. The measurement scripts
+lived in a scratchpad directory, so `sys.path[0]` was that directory and
+`import mhcgnomes` resolved to the installed copy in the shared virtualenv, not
+the working tree. Both halves of the A/B measured the released version.
+
+**Why it matters.** The failure is silent and the output looks like a clean
+result. It would have supported the wrong conclusion just as convincingly as
+the right one.
+
+**How to apply.** Any script that measures the working tree asserts it first:
+
+```python
+import mhcgnomes, os
+assert os.path.abspath(mhcgnomes.__file__).startswith(os.path.abspath(os.getcwd()))
+```
+
+More generally: when a measurement returns exactly the null result, check that
+the instrument was pointed at the thing being measured. A diff that shows no
+change to the line you just edited is an instrument fault, not a finding.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -23,6 +23,31 @@ actually support it. If the answer is one, write down the exception, not the
 model. Reading the code that implements the structure is part of establishing
 what the structure means.
 
+## An invariant asserted in prose has to be tested on every path
+
+**What happened.** The first fix for #122 gave `Homo sapiens` a parent of
+`Primata sp.` and blocked the `NHP` prefix from being inherited, then said in
+the README, in `docs/curation.md` and in the PR body that "`NHP-*` still cannot
+name it". Code review found that it could:
+
+```
+parse("NHP-E*01:01", species="Homo sapiens")  ->  HLA-E*01:01
+Species.get("Homo sapiens").compatible_with("NHP")  ->  True
+```
+
+**Why it was wrong.** Prefix inheritance is only one of four things that read a
+parent link. `is_ancestor_of`, `compatible_with` and the ancestor-to-descendant
+conversion behind `parse(..., species=...)` all saw a plain parent edge and had
+no way to know about the opt-out, because the opt-out lived in the loader. The
+measurement that "proved" the change inert -- 11,558 corpus names, every field
+of 671 species objects -- did not cover the `species=` argument at all, so a
+clean result was mistaken for a complete one.
+
+**How to apply.** Before writing a guarantee into docs, grep for every consumer
+of the thing being changed and write a test per consumer. And when a
+measurement comes back clean, ask what it does not cover: a corpus of names
+exercises one entry point, not the API surface around it.
+
 ## Verify which copy of the package you just measured
 
 **What happened.** An A/B measurement of a data change reported "0 changes" and
@@ -41,6 +66,10 @@ the right one.
 import mhcgnomes, os
 assert os.path.abspath(mhcgnomes.__file__).startswith(os.path.abspath(os.getcwd()))
 ```
+
+The same trap has a second form: `git stash` only puts back *uncommitted*
+changes, so once a branch has commits on it, stash-and-remeasure compares the
+branch against itself. Compare against a `git worktree` of `main` instead.
 
 More generally: when a measurement returns exactly the null result, check that
 the instrument was pointed at the thing being measured. A diff that shows no

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -46,7 +46,7 @@ that includes humans, scoped to a prefix that excludes them.
   `HLA` by inheritance unnoticed.
 - **The docs were over-corrected and are now fixed.** #120 read the water
   buffalo edge as proof that the tree is "prefix scope, not phylogeny". A sweep
-  of every parent link shows exactly one edge in 671 entries crosses a genus
+  of every parent link shows exactly one edge in the ontology crosses a genus
   boundary -- the buffalo -- and `Homo sapiens` was outside `Primata sp.` only
   because nothing had opted it out. The buffalo exception stands; the
   generalization does not.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,51 +1,61 @@
-# Curate the published water buffalo loci
+# Put Homo sapiens back in the primate order
 
-Tracking issues: follow-up to #109 / #115 (both closed as not-a-bug)
+Tracking issue: #122
 
-Those two issues asked whether `Bubalus bubalis` belongs under `Bos sp.`
-It does -- the tree is prefix scope. But checking the literature to answer
-that turned up a real gap: the entry did not record the loci the buffalo
-papers actually characterize.
+`Primata sp.` carries the prefix `NHP`, which IPD-MHC defines as "Non-Human
+Primates". `Homo sapiens` was therefore attached straight to the root, so the
+library answered `False` to "is a human a primate?" -- a node named for a taxon
+that includes humans, scoped to a prefix that excludes them.
 
 ## Specification
 
-- [x] Declare on `Bubalus bubalis` the class II loci with published buffalo
-      sequences, with sources cited next to each.
-- [x] Stop the cattle `DRB -> DRB3` alias renaming the buffalo locus, since
-      the literature reports homology rather than identity.
-- [x] Leave inherited cattle loci reachable.
-- [x] Decide, from IPD-MHC rather than one paper, whether `BoLA-DQB3` and
-      `BoLA-DQB4` should exist.
+- [x] Establish from the authority what `NHP` means and whether IPD files
+      humans in that group.
+- [x] Check whether the parent link and the umbrella prefix are actually the
+      same mechanism, or two separable ones.
+- [x] Reparent `Homo sapiens` under `Primata sp.` without letting it inherit
+      `NHP`, and cite the source next to the entry.
+- [x] Measure: A/B every name in the bundled corpora, and diff every field of
+      all 671 species objects, between `main` and the branch.
+- [x] Sweep every parent link for the same class of defect and file what turns
+      up rather than folding it in.
+- [x] Correct the README, `docs/curation.md` and `AGENTS.md`, which had
+      generalized one exception into a model.
+- [x] Pin the invariants in tests.
 - [x] Bump the version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
-- [x] Review the final diff and document the result below.
 
 ## Review
 
-- Declared `DRA`, `DRB`, `DQA2` in addition to the existing `DQA`, `DQA1`,
-  `DQB`. All were previously inherited from `Bos sp.`, which parsed them but
-  recorded no evidence that the buffalo locus itself had been characterized.
-  Sources: PMID 12580780 (buffalo DRA and DRB, eight Bubu-DRB alleles across
-  four breeds), PMID 22383896 (cites isolation of buffalo DQA1 and DQA2
-  cDNAs), and IPD-MHC, which holds 39 Bubu-DQA alleles.
-- **`Bubu-DRB` no longer renames to `Bubu-DRB3`.** `gene_aliases.yaml` maps
-  `DRB -> DRB3` under `BoLA`, which is right for cattle, where DRB3 is the
-  expressed DRB locus, and buffalo inherited it. PMID 22383896 says only that
-  "the Bubu-DRB sequence showed maximum homology with the BoLA-DRB3*0101
-  allele of cattle" -- homology, not identity -- and every paper writes the
-  locus as Bubu-DRB. Declaring `DRB` on the species stops the rename;
-  `Bubu-DRB3` still parses by inheritance.
-- **`BoLA-DQB3` and `BoLA-DQB4` deliberately not added.** A trans-species
-  phylogeny paper assigns buffalo sequences to loci it labels `BoLA-DQB1`,
-  `BoLA-DQB3` and `BoLA-DQB4`, but IPD-MHC registers only `BoLA-DQB`. Those
-  are that analysis's locus labels rather than designations. A test pins their
-  absence so the distinction is not lost.
-- Also added the prefix-scope explanation as a comment on the entry itself,
-  since it is the specific line two people have now filed bugs against.
-- No behaviour change on real data: 0 of 11,558 names in the bundled corpora
-  parse differently. The `Bubu-DRB` rename is the only behavioural change and
-  no corpus name exercises it.
-- Bumped 3.38.0 to 3.39.0 -- minor rather than patch, because `Bubu-DRB` now
-  returns a different gene name.
-- `./format.sh`: passed.
-- `./lint.sh`: passed.
-- `./test.sh`: passed (15,507 tests; 91% statement coverage).
+- **The fix is one parent link and one `old prefix`.** The issue proposed
+  either renaming the node or inserting an extra level above it. Neither was
+  needed: `create_species_for_latin_name` already hands a parent's prefix down
+  only when the child does not declare an `old prefix` of its own, so spelling
+  out `old prefix: HLA` opts human out of the `NHP` umbrella while leaving it
+  in the taxon. The parent link and the umbrella prefix were never the same
+  mechanism.
+- **Authority.** https://www.ebi.ac.uk/ipd/mhc/group/NHP/ -- "a specialist
+  database for the Major Histocompatibility Complex genes of Non-Human
+  Primates ... Apes and both Old World and New World monkeys". The prefix is
+  exclusionary by definition, which is why the opt-out has to be explicit and
+  is now tested.
+- **Measured inert.** 0 of 11,558 corpus names change. Diffing 15 structural
+  fields across all 671 species objects between `main` and the branch shows
+  exactly one difference: `Homo sapiens.parent`. Human's gene count is
+  unchanged at 56 because it already declares all sixteen genes `Primata sp.`
+  owns -- a test now pins that, so a future primate-wide gene cannot land in
+  `HLA` by inheritance unnoticed.
+- **The docs were over-corrected and are now fixed.** #120 read the water
+  buffalo edge as proof that the tree is "prefix scope, not phylogeny". A sweep
+  of every parent link shows exactly one edge in 671 entries crosses a genus
+  boundary -- the buffalo -- and `Homo sapiens` was outside `Primata sp.` only
+  because nothing had opted it out. The buffalo exception stands; the
+  generalization does not.
+- **Filed rather than folded: #123.** The same sweep found five primates
+  (`Macaca arctoides`, `M. assamensis`, `M. fuscata`, `M. leonina`,
+  `Callithrix pygmaea`) sitting outside their own genus node, so they inherit
+  almost no genes and `Mafu-A*01:01` does not parse while `Mamu-A*01:01` does.
+  Reparenting them is also 0/11,558, but it hands each one 49 macaque genes by
+  inheritance, which is a scientific claim that wants reading rather than
+  measuring. A test pins the list of five so it cannot grow silently.
+- Bumped 3.39.0 to 3.40.0 -- minor rather than patch, because
+  `compatible_with` now answers `True` for human against `Primata sp.`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,8 +13,9 @@ that includes humans, scoped to a prefix that excludes them.
       humans in that group.
 - [x] Check whether the parent link and the umbrella prefix are actually the
       same mechanism, or two separable ones.
-- [x] Reparent `Homo sapiens` under `Primata sp.` without letting it inherit
-      `NHP`, and cite the source next to the entry.
+- [x] Reparent `Homo sapiens` under `Primata sp.` without letting `NHP` name
+      it by any route, and cite the source next to the entry.
+- [x] Check every consumer of the parent link, not just prefix inheritance.
 - [x] Measure: A/B every name in the bundled corpora, and diff every field of
       all 671 species objects, between `main` and the branch.
 - [x] Sweep every parent link for the same class of defect and file what turns
@@ -26,30 +27,50 @@ that includes humans, scoped to a prefix that excludes them.
 
 ## Review
 
-- **The fix is one parent link and one `old prefix`.** The issue proposed
-  either renaming the node or inserting an extra level above it. Neither was
-  needed: `create_species_for_latin_name` already hands a parent's prefix down
-  only when the child does not declare an `old prefix` of its own, so spelling
-  out `old prefix: HLA` opts human out of the `NHP` umbrella while leaving it
-  in the taxon. The parent link and the umbrella prefix were never the same
-  mechanism.
+- **The fix is a parent link plus a first-class exclusion.** The issue proposed
+  either renaming the node or inserting a level above it. Neither was needed,
+  but the first attempt -- opting human out of the umbrella by spelling out
+  `old prefix: HLA` -- was not enough either. Code review found it only blocked
+  one of four consumers of the parent link:
+
+  ```
+  parse("NHP-E*01:01", species="Homo sapiens")  ->  HLA-E*01:01
+  ```
+
+  So the exclusion is now declared on the node that owns the prefix, and there
+  is a runtime query for it:
+
+  ```yaml
+  Primata sp.:
+    prefix: NHP
+    prefix excludes:
+      - Homo sapiens
+  ```
+
+  `Species.can_name(other)` is ancestry minus anything an ancestor excludes.
+  `compatible_with` follows it, and so does the ancestor-to-descendant
+  conversion in `function_api`. `is_ancestor_of` and `is_descendant_of` stay
+  purely taxonomic, which is what the issue was actually asking for.
 - **Authority.** https://www.ebi.ac.uk/ipd/mhc/group/NHP/ -- "a specialist
   database for the Major Histocompatibility Complex genes of Non-Human
-  Primates ... Apes and both Old World and New World monkeys". The prefix is
-  exclusionary by definition, which is why the opt-out has to be explicit and
-  is now tested.
-- **Measured inert.** 0 of 11,558 corpus names change. Diffing 15 structural
-  fields across all 671 species objects between `main` and the branch shows
-  exactly one difference: `Homo sapiens.parent`. Human's gene count is
-  unchanged at 56 because it already declares all sixteen genes `Primata sp.`
-  owns -- a test now pins that, so a future primate-wide gene cannot land in
-  `HLA` by inheritance unnoticed.
+  Primates ... Apes and both Old World and New World monkeys". The placement
+  itself cites NCBI Taxonomy: Homo sapiens (9606) sits in Primates (9443).
+- **Measured against a worktree of `main`, not a stash.** 0 of 11,558 corpus
+  names change; `compatible_with` is identical across all 450,241 species
+  pairs; 15 structural fields across all 671 species objects differ in exactly
+  one place, `Homo sapiens.parent`. The first round of this measurement used
+  `git stash`, which only reverts uncommitted work and so compared the branch
+  against itself -- recorded in `tasks/lessons.md`.
+- **The inertness guard now covers every inheritance channel.** Gene names were
+  only one of them: gene properties, gene families, class II locus groupings
+  and seven side tables keyed by ancestor latin name all flow down too. A
+  pseudogene flag added to `Primata sp.` reaches `HLA` and passed the original
+  name-only check; it now fails.
 - **The docs were over-corrected and are now fixed.** #120 read the water
-  buffalo edge as proof that the tree is "prefix scope, not phylogeny". A sweep
-  of every parent link shows exactly one edge in the ontology crosses a genus
-  boundary -- the buffalo -- and `Homo sapiens` was outside `Primata sp.` only
-  because nothing had opted it out. The buffalo exception stands; the
-  generalization does not.
+  buffalo edge as proof that the tree is "prefix scope, not phylogeny". Exactly
+  one parent link points at another genus's node -- the buffalo -- and `Homo
+  sapiens` was outside `Primata sp.` only because nothing expressed the NHP
+  exclusion. The buffalo exception stands; the generalization does not.
 - **Filed rather than folded: #123.** The same sweep found five primates
   (`Macaca arctoides`, `M. assamensis`, `M. fuscata`, `M. leonina`,
   `Callithrix pygmaea`) sitting outside their own genus node, so they inherit
@@ -57,5 +78,5 @@ that includes humans, scoped to a prefix that excludes them.
   Reparenting them is also 0/11,558, but it hands each one 49 macaque genes by
   inheritance, which is a scientific claim that wants reading rather than
   measuring. A test pins the list of five so it cannot grow silently.
-- Bumped 3.39.0 to 3.40.0 -- minor rather than patch, because
-  `compatible_with` now answers `True` for human against `Primata sp.`
+- Bumped 3.39.0 to 3.40.0 -- minor rather than patch, because `Species.can_name`
+  is new public API.

--- a/tests/test_ambiguous_species_inference.py
+++ b/tests/test_ambiguous_species_inference.py
@@ -32,8 +32,9 @@ PREFIX_TO_EXPECTED_SPECIES = [
     ("ChLA", "Pan sp."),
     ("MusSp", "Mus sp."),
     # NHP resolves to Primata sp., the node that owns the prefix. Homo sapiens
-    # is a child of that node but does not answer to NHP, because it declares
-    # its own "old prefix" and so never inherits the umbrella one (#122).
+    # is a child of that node but never answers to NHP: the entry declares
+    # "prefix excludes: [Homo sapiens]", since IPD-MHC's NHP group means
+    # Non-Human Primates (#122).
     ("NHP", "Primata sp."),
     ("OmLA", "Aotus sp."),
     ("RT1", "Rattus sp."),

--- a/tests/test_ambiguous_species_inference.py
+++ b/tests/test_ambiguous_species_inference.py
@@ -31,10 +31,9 @@ PREFIX_TO_EXPECTED_SPECIES = [
     ("CELA", "Cetacea sp."),
     ("ChLA", "Pan sp."),
     ("MusSp", "Mus sp."),
-    # NHP resolves to Primata sp. because that is what the ontology maps the
-    # prefix to. Worth noting that "NHP" means *non-human* primate while
-    # Primata sp. is an ancestor of Homo sapiens; that mismatch predates this
-    # change and is a curation question, not a parsing one.
+    # NHP resolves to Primata sp., the node that owns the prefix. Homo sapiens
+    # is a child of that node but does not answer to NHP, because it declares
+    # its own "old prefix" and so never inherits the umbrella one (#122).
     ("NHP", "Primata sp."),
     ("OmLA", "Aotus sp."),
     ("RT1", "Rattus sp."),

--- a/tests/test_species_provenance.py
+++ b/tests/test_species_provenance.py
@@ -176,15 +176,16 @@ COMPATIBLE = [
     ("Homo sapiens", "Homo sapiens"),
     ("Saimiri sciureus", "Primata sp."),
     ("Homo sapiens", "Gnathostomata sp."),
+    # Humans are primates. The NHP prefix on Primata sp. excludes them from the
+    # naming group, not from the taxon -- the parent link and the umbrella
+    # prefix are separate mechanisms. See issue #122.
+    ("Homo sapiens", "Primata sp."),
 ]
 
 INCOMPATIBLE = [
     ("Macaca mulatta", "Macaca fascicularis"),
     ("Carassius gibelio", "Homo sapiens"),
     ("Bos taurus", "Ovis aries"),
-    # the ontology is nomenclature-shaped: human hangs off the root, so
-    # Primata sp. is not one of its ancestors even though a squirrel monkey's is
-    ("Homo sapiens", "Primata sp."),
 ]
 
 

--- a/tests/test_species_provenance.py
+++ b/tests/test_species_provenance.py
@@ -176,16 +176,20 @@ COMPATIBLE = [
     ("Homo sapiens", "Homo sapiens"),
     ("Saimiri sciureus", "Primata sp."),
     ("Homo sapiens", "Gnathostomata sp."),
-    # Humans are primates. The NHP prefix on Primata sp. excludes them from the
-    # naming group, not from the taxon -- the parent link and the umbrella
-    # prefix are separate mechanisms. See issue #122.
-    ("Homo sapiens", "Primata sp."),
 ]
 
 INCOMPATIBLE = [
     ("Macaca mulatta", "Macaca fascicularis"),
     ("Carassius gibelio", "Homo sapiens"),
     ("Bos taurus", "Ovis aries"),
+    # Humans ARE primates and Primata sp. is an ancestor of Homo sapiens
+    # (tests/test_species_tree_shape.py pins that). But this question is about
+    # naming, not descent: Primata sp. owns the prefix NHP, which IPD-MHC
+    # defines as Non-Human Primates, so an NHP-* allele can never have come
+    # from a human sample. compatible_with follows Species.can_name, which
+    # honours the "prefix excludes" declaration; for the taxonomic question,
+    # ask is_descendant_of. See issue #122.
+    ("Homo sapiens", "Primata sp."),
 ]
 
 

--- a/tests/test_species_tree_shape.py
+++ b/tests/test_species_tree_shape.py
@@ -54,16 +54,26 @@ def test_human_does_not_inherit_the_nhp_prefix():
     ok_("NHP" not in set(human.all_identifiers))
 
 
-@pytest.mark.parametrize(
-    "name", ["NHP", "NHP class I", "NHP class II", "NHP-A*01:01", "NHP-DRB1*03:01"]
-)
-def test_nhp_strings_never_resolve_to_human(name):
+# What each NHP string resolves to today. None means "does not parse"; the point
+# of listing the resolutions rather than only asserting "not human" is that a
+# string which silently stopped parsing would otherwise pass this test.
+NHP_STRINGS = [
+    ("NHP", "Primata sp."),
+    ("NHP class I", "Primata sp."),
+    ("NHP class II", "Primata sp."),
+    ("NHP-A*01:01", None),
+    ("NHP-DRB1*03:01", None),
+]
+
+
+@pytest.mark.parametrize("name,expected", NHP_STRINGS)
+def test_nhp_strings_never_resolve_to_human(name, expected):
     result = parse(name, raise_on_error=False)
-    if result is None:
+    if expected is None:
+        eq_(result, None, f"'{name}' now parses as {result}")
         return
-    species = getattr(result, "species", None)
-    if species is None:
-        return
+    species = result if isinstance(result, Species) else result.species
+    eq_(species.name, expected)
     ok_(
         not species.is_human,
         f"'{name}' resolved to {species.name} through the non-human-primate prefix",

--- a/tests/test_species_tree_shape.py
+++ b/tests/test_species_tree_shape.py
@@ -1,0 +1,162 @@
+"""
+Invariants about the shape of the species tree: what a parent link means, and
+where the tree deliberately departs from taxonomy.
+
+A parent link is containment, and it is taxonomic wherever it can be. The
+umbrella MHC prefix is a *separate*, opt-out-able property of a node, which is
+why Homo sapiens can be a primate without answering to NHP.
+
+https://github.com/pirl-unc/mhcgnomes/issues/122
+"""
+
+import pytest
+
+from mhcgnomes import Species, parse
+from mhcgnomes.species import latin_name_to_species_object
+
+from .common import eq_, ok_
+
+ALL_SPECIES = sorted(latin_name_to_species_object.values(), key=lambda s: s.name)
+
+GENUS_NODES = {s.name[: -len(" sp.")]: s for s in ALL_SPECIES if s.name.endswith(" sp.")}
+
+
+# ---------------------------------------------------------------------------
+# 1. Homo sapiens is a primate
+# ---------------------------------------------------------------------------
+
+
+def test_human_is_a_descendant_of_the_primate_node():
+    human = Species.get_by_latin_name("Homo sapiens")
+    primates = Species.get_by_latin_name("Primata sp.")
+    ok_(human.is_descendant_of(primates))
+    ok_(primates.is_ancestor_of(human))
+    ok_(human.compatible_with(primates))
+    ok_(primates.compatible_with(human))
+
+
+def test_human_still_descends_from_the_root():
+    human = Species.get_by_latin_name("Homo sapiens")
+    ok_(human.is_descendant_of(Species.get_by_latin_name("Gnathostomata sp.")))
+
+
+# ---------------------------------------------------------------------------
+# 2. ...but is not in the NHP naming group
+# ---------------------------------------------------------------------------
+# "NHP" is the IPD-MHC group code for Non-Human Primates
+# (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it must never reach a human.
+
+
+def test_human_does_not_inherit_the_nhp_prefix():
+    human = Species.get_by_latin_name("Homo sapiens")
+    eq_(human.historic_mhc_prefix, "HLA")
+    ok_("NHP" not in human.all_mhc_prefixes)
+    ok_("NHP" not in set(human.all_identifiers))
+
+
+@pytest.mark.parametrize(
+    "name", ["NHP", "NHP class I", "NHP class II", "NHP-A*01:01", "NHP-DRB1*03:01"]
+)
+def test_nhp_strings_never_resolve_to_human(name):
+    result = parse(name, raise_on_error=False)
+    if result is None:
+        return
+    species = getattr(result, "species", None)
+    if species is None:
+        return
+    ok_(
+        not species.is_human,
+        f"'{name}' resolved to {species.name} through the non-human-primate prefix",
+    )
+
+
+def test_nhp_prefix_still_belongs_to_the_primate_node():
+    eq_(Species.get("NHP"), Species.get_by_latin_name("Primata sp."))
+
+
+def test_every_other_primate_still_inherits_nhp():
+    primates = Species.get_by_latin_name("Primata sp.")
+    # Children with an umbrella prefix of their own (a genus node, or a
+    # documented historic prefix) legitimately do not inherit NHP.
+    declares_own_old_prefix = {"Callithrix pygmaea", "Semnopithecus entellus", "Homo sapiens"}
+    inherited = [
+        s.name
+        for s in ALL_SPECIES
+        if s.parent is primates
+        and s.name not in declares_own_old_prefix
+        and s.historic_mhc_prefix != "NHP"
+    ]
+    eq_(inherited, [], f"children of Primata sp. that lost the NHP umbrella: {inherited}")
+
+
+# ---------------------------------------------------------------------------
+# 3. Reparenting must stay inert for gene inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_human_declares_every_gene_it_inherits_from_the_primate_node():
+    """
+    Homo sapiens gains nothing by being parented under Primata sp.: it already
+    declares all sixteen genes that node owns. If a primate-wide gene is ever
+    added that humans do not declare, this fails and the addition has to be
+    thought about rather than silently landing in HLA.
+    """
+    human = Species.get_by_latin_name("Homo sapiens")
+    primates = Species.get_by_latin_name("Primata sp.")
+    own = {g.upper() for g in human.own_gene_names}
+    missing = sorted(g for g in primates.own_gene_names if g.upper() not in own)
+    eq_(missing, [], f"HLA would inherit these from Primata sp. without declaring them: {missing}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Where the tree departs from taxonomy
+# ---------------------------------------------------------------------------
+
+# The one parent link in the ontology that crosses a genus boundary. Water
+# buffalo is Bubalus, not Bos, but IPD-MHC files it in the BoLA group and the
+# literature assigns its class II sequences to cattle loci by trans-species
+# polymorphism, so the edge is what makes Bubu-DRA and Bubu-DRB3 parse (#115).
+GENUS_CROSSING_EDGES = {("Bubalus bubalis", "Bos sp.")}
+
+
+def test_only_documented_edges_cross_a_genus_boundary():
+    crossing = set()
+    for species in ALL_SPECIES:
+        parent = species.parent
+        if parent is None or not parent.name.endswith(" sp."):
+            continue
+        genus = parent.name[: -len(" sp.")]
+        if " " in genus or not genus[0].isupper():
+            continue
+        # Only genus-level nodes constrain their children's genus; ranks above
+        # genus (Aves sp., Primata sp.) legitimately hold many genera.
+        if genus not in {s.name.split()[0] for s in ALL_SPECIES if not s.name.endswith(" sp.")}:
+            continue
+        if not species.name.startswith(genus + " "):
+            crossing.add((species.name, parent.name))
+    eq_(sorted(crossing), sorted(GENUS_CROSSING_EDGES))
+
+
+# Species that sit at the primate node even though their own genus has a node.
+# These are curation gaps rather than decisions: reparenting them would hand
+# them the genus gene list, which needs its own check against the literature.
+# https://github.com/pirl-unc/mhcgnomes/issues/123
+UNPLACED_WITHIN_GENUS = {
+    "Callithrix pygmaea",
+    "Macaca arctoides",
+    "Macaca assamensis",
+    "Macaca fuscata",
+    "Macaca leonina",
+}
+
+
+def test_species_sit_under_their_genus_node_when_one_exists():
+    unplaced = set()
+    for species in ALL_SPECIES:
+        if species.name.endswith(" sp."):
+            continue
+        node = GENUS_NODES.get(species.name.split()[0])
+        if node is None or node.is_ancestor_of(species):
+            continue
+        unplaced.add(species.name)
+    eq_(sorted(unplaced), sorted(UNPLACED_WITHIN_GENUS))

--- a/tests/test_species_tree_shape.py
+++ b/tests/test_species_tree_shape.py
@@ -2,9 +2,11 @@
 Invariants about the shape of the species tree: what a parent link means, and
 where the tree deliberately departs from taxonomy.
 
-A parent link is containment, and it is taxonomic wherever it can be. The
-umbrella MHC prefix is a *separate*, opt-out-able property of a node, which is
-why Homo sapiens can be a primate without answering to NHP.
+A parent link is containment, taxonomic wherever it can be, and it is what
+genes are inherited along. Whether an ancestor's prefix may *name* a descendant
+is a separate question, answered by Species.can_name and constrained by the
+"prefix excludes" declaration -- which is why Homo sapiens can be a primate
+without ever answering to NHP.
 
 https://github.com/pirl-unc/mhcgnomes/issues/122
 """
@@ -12,13 +14,31 @@ https://github.com/pirl-unc/mhcgnomes/issues/122
 import pytest
 
 from mhcgnomes import Species, parse
-from mhcgnomes.species import latin_name_to_species_object
+from mhcgnomes.species import (
+    latin_name_to_species_object,
+    raw_allele_aliases_dict,
+    raw_gene_aliases_dict,
+    raw_haplotypes_dict,
+    raw_heterodimers_dict,
+    raw_known_alleles_dict,
+    raw_serotypes_dict,
+    raw_species_dict,
+    raw_supertypes_dict,
+)
 
 from .common import eq_, ok_
 
 ALL_SPECIES = sorted(latin_name_to_species_object.values(), key=lambda s: s.name)
 
-GENUS_NODES = {s.name[: -len(" sp.")]: s for s in ALL_SPECIES if s.name.endswith(" sp.")}
+# Nodes standing for a group rather than one species, indexed by the taxon they
+# are named for: {"Bos": Species("Bos sp."), "Aves": Species("Aves sp."), ...}
+GROUP_NODES = {s.name[: -len(" sp.")]: s for s in ALL_SPECIES if s.name.endswith(" sp.")}
+
+# The genera that actually appear in a binomial, so that "Bos sp." is
+# recognised as a genus node while "Aves sp." and "Primata sp." are not.
+BINOMIAL_GENERA = {s.name.split()[0] for s in ALL_SPECIES if not s.name.endswith(" sp.")}
+
+GENUS_NODES = {genus: node for genus, node in GROUP_NODES.items() if genus in BINOMIAL_GENERA}
 
 
 # ---------------------------------------------------------------------------
@@ -31,8 +51,6 @@ def test_human_is_a_descendant_of_the_primate_node():
     primates = Species.get_by_latin_name("Primata sp.")
     ok_(human.is_descendant_of(primates))
     ok_(primates.is_ancestor_of(human))
-    ok_(human.compatible_with(primates))
-    ok_(primates.compatible_with(human))
 
 
 def test_human_still_descends_from_the_root():
@@ -44,7 +62,9 @@ def test_human_still_descends_from_the_root():
 # 2. ...but is not in the NHP naming group
 # ---------------------------------------------------------------------------
 # "NHP" is the IPD-MHC group code for Non-Human Primates
-# (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it must never reach a human.
+# (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it must never reach a human by
+# any route: not as an inherited prefix, not through compatible_with, and not
+# through the ancestor-to-descendant conversion that species= performs.
 
 
 def test_human_does_not_inherit_the_nhp_prefix():
@@ -54,30 +74,60 @@ def test_human_does_not_inherit_the_nhp_prefix():
     ok_("NHP" not in set(human.all_identifiers))
 
 
-# What each NHP string resolves to today. None means "does not parse"; the point
-# of listing the resolutions rather than only asserting "not human" is that a
-# string which silently stopped parsing would otherwise pass this test.
-NHP_STRINGS = [
-    ("NHP", "Primata sp."),
-    ("NHP class I", "Primata sp."),
-    ("NHP class II", "Primata sp."),
-    ("NHP-A*01:01", None),
-    ("NHP-DRB1*03:01", None),
-]
+def test_the_primate_node_cannot_name_a_human():
+    human = Species.get_by_latin_name("Homo sapiens")
+    primates = Species.get_by_latin_name("Primata sp.")
+    ok_(not primates.can_name(human))
+    ok_(not human.compatible_with(primates))
+    ok_(not primates.compatible_with(human))
+    ok_(not human.compatible_with("NHP"))
 
 
-@pytest.mark.parametrize("name,expected", NHP_STRINGS)
-def test_nhp_strings_never_resolve_to_human(name, expected):
-    result = parse(name, raise_on_error=False)
-    if expected is None:
-        eq_(result, None, f"'{name}' now parses as {result}")
-        return
-    species = result if isinstance(result, Species) else result.species
-    eq_(species.name, expected)
-    ok_(
-        not species.is_human,
-        f"'{name}' resolved to {species.name} through the non-human-primate prefix",
+def test_the_primate_node_can_still_name_every_other_primate():
+    primates = Species.get_by_latin_name("Primata sp.")
+    unnameable = [
+        s.name
+        for s in ALL_SPECIES
+        if primates.is_ancestor_of(s) and s.name != "Homo sapiens" and not primates.can_name(s)
+    ]
+    eq_(unnameable, [], f"NHP stopped covering: {unnameable}")
+
+
+def test_exclusion_does_not_leak_to_nodes_above_it():
+    # Gnathostomata sp. does not exclude anything, so human stays reachable
+    # from the root even though the path passes through the excluded edge.
+    human = Species.get_by_latin_name("Homo sapiens")
+    root = Species.get_by_latin_name("Gnathostomata sp.")
+    ok_(root.can_name(human))
+    ok_(human.compatible_with(root))
+
+
+# Every gene `Primata sp.` owns, so that these exercise the conversion path
+# rather than merely failing to find a gene. `species=` on the second column is
+# the ancestor-to-descendant conversion that must be refused for NHP.
+NHP_GENES = ["E", "DMB", "MICA", "CD1a"]
+
+
+@pytest.mark.parametrize("gene", NHP_GENES)
+def test_nhp_gene_names_parse_as_the_primate_node(gene):
+    result = parse(f"NHP-{gene}")
+    eq_(result.species.name, "Primata sp.")
+
+
+@pytest.mark.parametrize("gene", NHP_GENES)
+@pytest.mark.parametrize("human_name", ["Homo sapiens", "HLA", "human"])
+def test_nhp_gene_names_are_never_converted_to_human(gene, human_name):
+    eq_(
+        parse(f"NHP-{gene}", species=human_name, raise_on_error=False),
+        None,
+        f"'NHP-{gene}' was relabelled as {human_name}",
     )
+
+
+def test_ancestor_to_descendant_conversion_still_works_where_it_should():
+    # The guard above must not have disabled the feature it constrains.
+    result = parse("BoLA-N*01301", species="Bos taurus")
+    eq_(result.species.name, "Bos taurus")
 
 
 def test_nhp_prefix_still_belongs_to_the_primate_node():
@@ -86,70 +136,104 @@ def test_nhp_prefix_still_belongs_to_the_primate_node():
 
 def test_every_other_primate_still_inherits_nhp():
     primates = Species.get_by_latin_name("Primata sp.")
-    # Children with an umbrella prefix of their own (a genus node, or a
-    # documented historic prefix) legitimately do not inherit NHP.
+    # Genus nodes inherit NHP too, despite carrying prefixes of their own:
+    # Macaca sp. is RhLA *and* old prefix NHP. The only children that do not
+    # are the two with a documented historic prefix, and human.
     declares_own_old_prefix = {"Callithrix pygmaea", "Semnopithecus entellus", "Homo sapiens"}
-    inherited = [
+    lost = [
         s.name
         for s in ALL_SPECIES
         if s.parent is primates
         and s.name not in declares_own_old_prefix
         and s.historic_mhc_prefix != "NHP"
     ]
-    eq_(inherited, [], f"children of Primata sp. that lost the NHP umbrella: {inherited}")
+    eq_(lost, [], f"children of Primata sp. that lost the NHP umbrella: {lost}")
 
 
 # ---------------------------------------------------------------------------
-# 3. Reparenting must stay inert for gene inheritance
+# 3. Reparenting must stay inert
 # ---------------------------------------------------------------------------
+# Gene *names* are only one of the things inherited along a parent link. Gene
+# properties, gene families, class II locus groupings and seven side tables
+# keyed by ancestor latin name all flow down too, so checking names alone would
+# let a pseudogene flag on Primata sp. silently become one on HLA.
+
+SIDE_TABLES = {
+    "gene_aliases.yaml": raw_gene_aliases_dict,
+    "allele_aliases.yaml": raw_allele_aliases_dict,
+    "known_alleles.yaml": raw_known_alleles_dict,
+    "haplotypes.yaml": raw_haplotypes_dict,
+    "serotypes.yaml": raw_serotypes_dict,
+    "heterodimers.yaml": raw_heterodimers_dict,
+    "supertypes.yaml": raw_supertypes_dict,
+}
 
 
-def test_human_declares_every_gene_it_inherits_from_the_primate_node():
-    """
-    Homo sapiens gains nothing by being parented under Primata sp.: it already
-    declares all sixteen genes that node owns. If a primate-wide gene is ever
-    added that humans do not declare, this fails and the addition has to be
-    thought about rather than silently landing in HLA.
-    """
-    human = Species.get_by_latin_name("Homo sapiens")
-    primates = Species.get_by_latin_name("Primata sp.")
-    own = {g.upper() for g in human.own_gene_names}
-    missing = sorted(g for g in primates.own_gene_names if g.upper() not in own)
-    eq_(missing, [], f"HLA would inherit these from Primata sp. without declaring them: {missing}")
+def _declared_gene_names(entry):
+    names = set()
+    for members in entry.get("genes", {}).values():
+        groups = members.values() if isinstance(members, dict) else [members]
+        for group in groups:
+            names.update(str(gene).upper() for gene in group)
+    return names
+
+
+def test_the_primate_node_declares_no_gene_hla_does_not():
+    primates = raw_species_dict["Primata sp."]
+    human = raw_species_dict["Homo sapiens"]
+    missing = sorted(_declared_gene_names(primates) - _declared_gene_names(human))
+    eq_(missing, [], f"HLA would inherit these genes without declaring them: {missing}")
+
+
+@pytest.mark.parametrize("key", ["gene properties", "gene families"])
+def test_the_primate_node_declares_no_metadata_hla_does_not(key):
+    primates = raw_species_dict["Primata sp."].get(key) or {}
+    human = {
+        str(k).upper(): v for k, v in (raw_species_dict["Homo sapiens"].get(key) or {}).items()
+    }
+    mismatched = sorted(k for k, v in primates.items() if human.get(str(k).upper()) != v)
+    eq_(mismatched, [], f"HLA would inherit '{key}' for {mismatched} without declaring it")
+
+
+@pytest.mark.parametrize("filename,table", sorted(SIDE_TABLES.items()))
+def test_the_primate_node_has_no_side_table_entries(filename, table):
+    # These merge into every descendant by ancestor latin name, so a Primata
+    # sp. entry lands in HLA wholesale. Adding one may well be right -- but it
+    # has to be checked against IMGT/HLA for humans too, not just for monkeys.
+    ok_(
+        "Primata sp." not in table,
+        f"{filename} now has a 'Primata sp.' entry, which HLA inherits; "
+        f"confirm it is correct for humans before allowlisting it here",
+    )
 
 
 # ---------------------------------------------------------------------------
 # 4. Where the tree departs from taxonomy
 # ---------------------------------------------------------------------------
 
-# The one parent link in the ontology that crosses a genus boundary. Water
-# buffalo is Bubalus, not Bos, but IPD-MHC files it in the BoLA group and the
-# literature assigns its class II sequences to cattle loci by trans-species
+# The one parent link in the ontology that points at another genus's node.
+# Water buffalo is Bubalus, not Bos, but IPD-MHC files it in the BoLA group and
+# the literature assigns its class II sequences to cattle loci by trans-species
 # polymorphism, so the edge is what makes Bubu-DRA and Bubu-DRB3 parse (#115).
 GENUS_CROSSING_EDGES = {("Bubalus bubalis", "Bos sp.")}
 
 
-def test_only_documented_edges_cross_a_genus_boundary():
-    crossing = set()
-    for species in ALL_SPECIES:
-        parent = species.parent
-        if parent is None or not parent.name.endswith(" sp."):
-            continue
-        genus = parent.name[: -len(" sp.")]
-        if " " in genus or not genus[0].isupper():
-            continue
-        # Only genus-level nodes constrain their children's genus; ranks above
-        # genus (Aves sp., Primata sp.) legitimately hold many genera.
-        if genus not in {s.name.split()[0] for s in ALL_SPECIES if not s.name.endswith(" sp.")}:
-            continue
-        if not species.name.startswith(genus + " "):
-            crossing.add((species.name, parent.name))
+def test_only_documented_edges_point_at_another_genus_node():
+    # Ranks above genus (Aves sp., Primata sp.) legitimately hold many genera
+    # and are not considered here; only nodes named for an actual genus are.
+    crossing = {
+        (species.name, species.parent.name)
+        for species in ALL_SPECIES
+        if species.parent is not None
+        and species.parent is GENUS_NODES.get(species.parent.name[: -len(" sp.")])
+        and not species.name.startswith(species.parent.name[: -len(" sp.")] + " ")
+    }
     eq_(sorted(crossing), sorted(GENUS_CROSSING_EDGES))
 
 
-# Species that sit at the primate node even though their own genus has a node.
-# These are curation gaps rather than decisions: reparenting them would hand
-# them the genus gene list, which needs its own check against the literature.
+# Species that sit at a higher node even though their own genus has one. These
+# are curation gaps rather than decisions: reparenting them would hand them the
+# genus gene list, which needs its own check against the literature.
 # https://github.com/pirl-unc/mhcgnomes/issues/123
 UNPLACED_WITHIN_GENUS = {
     "Callithrix pygmaea",
@@ -161,12 +245,11 @@ UNPLACED_WITHIN_GENUS = {
 
 
 def test_species_sit_under_their_genus_node_when_one_exists():
-    unplaced = set()
-    for species in ALL_SPECIES:
-        if species.name.endswith(" sp."):
-            continue
-        node = GENUS_NODES.get(species.name.split()[0])
-        if node is None or node.is_ancestor_of(species):
-            continue
-        unplaced.add(species.name)
+    unplaced = {
+        species.name
+        for species in ALL_SPECIES
+        if not species.name.endswith(" sp.")
+        and species.name.split()[0] in GENUS_NODES
+        and not GENUS_NODES[species.name.split()[0]].is_ancestor_of(species)
+    }
     eq_(sorted(unplaced), sorted(UNPLACED_WITHIN_GENUS))

--- a/tests/test_water_buffalo.py
+++ b/tests/test_water_buffalo.py
@@ -1,11 +1,12 @@
 """
 Water buffalo (Bubalus bubalis) MHC loci.
 
-Bubalus sits under Bos sp. because the species tree is a prefix-scope
-hierarchy: IPD-MHC files water buffalo in the BoLA group and its class II
-sequences are assigned to cattle loci by trans-species polymorphism. The
-entry declares the loci with published buffalo sequences itself, so that
-they round-trip as the literature writes them.
+Bubalus sits under Bos sp. even though Bubalus is a separate genus: it is
+the one parent link in the ontology that follows naming rather than
+taxonomy, because IPD-MHC files water buffalo in the BoLA group and its
+class II sequences are assigned to cattle loci by trans-species
+polymorphism. The entry declares the loci with published buffalo sequences
+itself, so that they round-trip as the literature writes them.
 
 Sources:
   PMID 12580780  Polymorphisms in MHC-DRA and -DRB alleles of water buffalo

--- a/tests/test_water_buffalo.py
+++ b/tests/test_water_buffalo.py
@@ -2,11 +2,12 @@
 Water buffalo (Bubalus bubalis) MHC loci.
 
 Bubalus sits under Bos sp. even though Bubalus is a separate genus: it is
-the one parent link in the ontology that follows naming rather than
-taxonomy, because IPD-MHC files water buffalo in the BoLA group and its
-class II sequences are assigned to cattle loci by trans-species
-polymorphism. The entry declares the loci with published buffalo sequences
-itself, so that they round-trip as the literature writes them.
+the only parent link in the ontology that points at another genus's node,
+following naming rather than taxonomy. IPD-MHC files water buffalo in the
+BoLA group and its class II sequences are assigned to cattle loci by
+trans-species polymorphism. The entry declares the loci with published
+buffalo sequences itself, so that they round-trip as the literature writes
+them.
 
 Sources:
   PMID 12580780  Polymorphisms in MHC-DRA and -DRB alleles of water buffalo


### PR DESCRIPTION
Closes #122.

## The finding

`Primata sp.` carries the prefix `NHP`. IPD-MHC's group page is unambiguous
about what that means — [https://www.ebi.ac.uk/ipd/mhc/group/NHP/](https://www.ebi.ac.uk/ipd/mhc/group/NHP/):
"a specialist database for the Major Histocompatibility Complex genes of
**Non-Human Primates** ... Apes and both Old World and New World monkeys". So
`Homo sapiens` was attached straight to the root, and the library answered
`False` to "is a human a primate?".

## The fix

Human is now a child of `Primata sp.`, and the exclusion is declared on the
node that owns the prefix, where it is a property of what `NHP` means rather
than of the human entry:

```yaml
Primata sp.:
  prefix: NHP
  prefix excludes:
    - Homo sapiens
```

`Species.can_name(other)` is the new naming query — ancestry, minus anything an
ancestor excludes. `compatible_with` follows it, and so does the
ancestor-to-descendant conversion behind `parse(..., species=...)`.
`is_ancestor_of` and `is_descendant_of` stay purely taxonomic, which is what
the issue was asking for:

```python
>>> Species.get("Homo sapiens").is_descendant_of("Primata sp.")
True                              # humans are primates
>>> Species.get("Primata sp.").can_name("Homo sapiens")
False                             # NHP-* cannot denote one
>>> parse("NHP-E*01:01", species="Homo sapiens", raise_on_error=False)
None                              # refused, not converted
```

Neither structural change the issue proposed was needed. The node is still both
the primate order and the NHP group, but the place where those two readings
disagree is now declared in the data and enforced at every call site, so
splitting it would change public output (`Species.get("NHP")`, and what
`NHP class I` prints) without buying more correctness.

### What the first attempt got wrong

The first version of this PR opted human out by spelling `old prefix: HLA` on
the human entry. `/code-review` caught that this only blocks *prefix
inheritance* — three other things read a parent link — and that the PR's own
claim was therefore false:

```
parse("NHP-E*01:01", species="Homo sapiens")        ->  HLA-E*01:01   (None on main)
Species.get("Homo sapiens").compatible_with("NHP")  ->  True          (False on main)
```

24 strings flipped from rejected to accepted that way: every gene `Primata sp.`
owns, under `species=` of "Homo sapiens", "HLA" and "human". That is fixed
above, and `tasks/lessons.md` records the pattern — an invariant asserted in
prose has to be tested on every path that could violate it.

## Measurement

Against a `git worktree` of `main` (the first round used `git stash`, which
only reverts uncommitted work and so compared the branch against itself):

| check | result |
|---|---|
| bundled netMHCpan 3.0/4.0, netMHCIIpan 3.1, IEDB corpora | **0 of 11,558** names parse differently |
| `compatible_with` over every species pair | **0 of 450,241** differ |
| 15 structural fields × all 671 species objects | **1** difference: `Homo sapiens.parent` |

## Inertness is now checked on every inheritance channel

Gene names were only one of them. Gene properties, gene families, class II
locus groupings and seven side tables keyed by ancestor latin name all flow
down a parent link too — review demonstrated that adding
`gene properties: {MICB: {pseudogene: true}}` to `Primata sp.` makes `HLA-MICB`
a pseudogene with every test still passing. Each channel now has its own guard,
and that mutation fails.

## The docs were over-corrected, and are fixed here

#120 read the water buffalo edge as proof that the species tree is "prefix
scope, not a phylogeny", and offered human's placement as the clinching second
example. Sweeping every parent link shows that was too strong: **exactly one
edge points at another genus's node** — `Bubalus bubalis` under `Bos sp.` — and
human was outside `Primata sp.` only because nothing expressed the NHP
exclusion. #109/#115 stay not-a-bug.

Also corrected, from review: `NHP` is inherited from the *immediate* parent
only, so `Macaca mulatta` gets `RhLA` and not `NHP`; genus nodes under
`Primata sp.` do inherit `NHP` despite carrying prefixes of their own; and
"every other parent link stays within its genus" was simply false.

## Filed rather than folded in: #123

Five primates sit outside their own genus node — `Macaca arctoides`,
`M. assamensis`, `M. fuscata`, `M. leonina`, `Callithrix pygmaea` — so they
inherit almost no genes:

```
Mafu-A*01:01   ->  None
Mamu-A*01:01   ->  Allele(Macaca mulatta A*01:01)
```

Reparenting them is also 0/11,558, but it hands each one the 49-gene macaque
list by inheritance, which is a scientific claim to be read rather than
measured. A test pins the list of five so it cannot grow silently.

## Tests

New `tests/test_species_tree_shape.py` (37 tests): human is a primate; `NHP`
cannot reach a human by prefix, by `compatible_with`, or by `species=`
conversion; the conversion still works where it should; every other primate is
still covered by `NHP`; the exclusion does not leak to nodes above it; each
inheritance channel is inert; and two curation sweeps over the whole ontology.
`test_species_provenance.py` keeps human/`Primata sp.` incompatible, now with
the reason recorded and the taxonomic question pointed at `is_descendant_of`.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,544 passed.
Version 3.39.0 → 3.40.0 (minor: `Species.can_name` is new public API).
