### PR TITLE
Give NHP its own node instead of a naming predicate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,11 +113,8 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
 - **Do not generalize one exception into a model.** The buffalo edge is a real
   departure from taxonomy, but reading it as proof that the whole tree is
   "prefix scope, not phylogeny" was an over-correction: exactly one parent link
-  in the ontology points at another genus's node, and `Homo sapiens` was
-  outside `Primata sp.` only because nothing expressed that `NHP` cannot name a
-  human (#122). A parent link is containment; naming scope is a separate
-  property, declared with `prefix excludes` and queried with
-  `Species.can_name`. One counterexample bounds a rule; it does not replace it.
+  in the ontology points at another genus's node. One counterexample bounds a
+  rule; it does not replace it.
 - **An invariant you assert in prose has to be tested on every path.** The
   first fix for #122 blocked `NHP` from reaching humans through prefix
   inheritance, and the PR said "`NHP-*` still cannot name it" -- but three
@@ -125,6 +122,13 @@ Do not tell the user you are "done" or that changes are "complete" until all thr
   species="Homo sapiens")` duly returned `HLA-E*01:01`. Before claiming a
   guarantee, enumerate the consumers of the thing you changed and test each
   one.
+- **Prefer fixing the structure to encoding an exception.** The next attempt at
+  #122 kept `NHP` on the primate node and added a `prefix excludes` key, a
+  `Species.can_name` predicate and a docs section to explain when to use which
+  of two near-identical predicates. Giving `NHP` its own node deleted all three
+  and made both questions plain ancestry (#126). If a fix needs a new concept
+  to describe a special case, check whether the data can be shaped so the
+  special case does not exist.
 - **An official designation is not the same as attested usage.** The naming
   rule is mechanical, so several species can derive the same code, and only
   one of them is usually the one that appears in print — the rest are

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ wherever it can be: exactly one parent link in the whole ontology points at
 another genus's node. Genes, and the rest of a species' curated data, are
 inherited along these links.
 
-Whether an ancestor's prefix may *name* a descendant is a separate question.
-An umbrella prefix normally covers everything beneath it:
+Every MHC prefix owns a node, and an umbrella prefix covers everything beneath
+its node:
 
 ```
 Bos sp. [BoLA]     ->  Bota, Boin, Bofr, Bogr, Bubu
@@ -348,30 +348,34 @@ Macaca sp. [RhLA]  ->  Mafa, Mamu, Mane, Masi, Math
 Canis sp. [DLA]    ->  Calu, Cala, Caru, Casi, Caba
 ```
 
-**`Homo sapiens` is a primate that never answers to `NHP`.** `Primata sp.` is
-the primate order and human is inside it, but the prefix it carries is
-IPD-MHC's group code for [Non-Human
-Primates](https://www.ebi.ac.uk/ipd/mhc/group/NHP/) — exclusionary by
-definition, unlike every other umbrella prefix in the file. The entry says so:
+**`NHP` is a node, not the primate order.** IPD-MHC's `NHP` group is [Non-Human
+Primates](https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it is the primate order
+*minus humans* — paraphyletic, and not a taxon. It gets its own entry, sibling
+to `Homo sapiens`:
 
-```yaml
-Primata sp.:
-  prefix: NHP
-  prefix excludes:
-    - Homo sapiens
+```
+Primata sp. [Primata]        the primate order, and the genes all primates share
+├── Homo sapiens [HLA]
+└── NHP [NHP]                the IPD-MHC group
+    └── 55 non-human primates
 ```
 
-`Species.can_name` answers the naming question and honours that declaration,
-while `is_ancestor_of` and `is_descendant_of` stay purely taxonomic:
+That keeps both questions as plain ancestry, with no second predicate:
 
 ```python
->>> Species.get("Homo sapiens").is_descendant_of("Primata sp.")
+>>> Species.get("Homo sapiens").compatible_with("Primata sp.")
 True                              # humans are primates
->>> Species.get("Primata sp.").can_name("Homo sapiens")
+>>> Species.get("Homo sapiens").compatible_with("NHP")
 False                             # NHP-* cannot denote one
 >>> parse("NHP-E*01:01", species="Homo sapiens", raise_on_error=False)
 None                              # so this is refused, not converted
 ```
+
+Because `NHP` is paraphyletic, any taxon added under `Primata sp.` has to sit
+wholly inside or wholly outside it. A `Homo sp.` node holding *H. sapiens* and
+*H. neanderthalensis* is fine as a sibling of `NHP`; a `Hominidae sp.` spanning
+humans and the great apes is not, since it would have to pull `Gorilla sp.`,
+`Pan sp.` and `Pongo sp.` out of the `NHP` umbrella.
 
 **`Bubalus bubalis` is under `Bos sp.` despite being a different genus.** This
 is the one edge that is deliberately not taxonomy. Water buffalo belongs to
@@ -404,13 +408,9 @@ mhcgnomes derives from an allele, since the two legitimately differ in
 specificity: `BoLA` belongs to the genus-level `Bos sp.`, so a `BoLA-N*013:01`
 allele on a sample curated as *Bos taurus* is compatible.
 
-**Compatibility is a question about naming, not descent.** `compatible_with`
-answers "could these two names describe the same sample?", so it follows
-`can_name` rather than ancestry. A `Bubu-*` allele is compatible with a curated
-`Bos sp.`, since `Bos sp.` denotes the BoLA group and water buffalo is in it. A
-human sample is *not* compatible with `Primata sp.`, since that name denotes
-the NHP group — even though humans are primates, which `is_descendant_of` will
-tell you.
+**Compatibility can follow an edge that exists for naming.** A `Bubu-*` allele
+is compatible with a curated `Bos sp.`, since `Bos sp.` denotes the BoLA group
+and water buffalo is in it. That is the intended answer, not a wart.
 
 An `X sp.` node is a group entry: it holds the prefix and the genes shared by
 everything beneath it. `Bos sp.` owns `BoLA` and the cattle gene list; `Bos

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -178,34 +178,46 @@ URL.
   `mhcgnomes/data/underrepresented_taxa_source_registry.yaml` until they are
   resolved.
 
-### A parent link is containment; naming scope is separate
+### A parent link is containment, and every prefix owns a node
 
 A `parent` link says "this species is inside that group". It is taxonomic
 wherever it can be -- exactly one parent link in the ontology points at another
 genus's node -- and it is what the rest of the entry is inherited along.
 
-Whether an ancestor's *prefix* may name a descendant is a different question,
-and three separate mechanisms answer it.
+An umbrella MHC prefix covers everything beneath the node that owns it. The
+loader hands a parent's prefix down to a child as its `old prefix` when the
+parent's prefix is an MHC prefix rather than its own taxon name (`BoLA`, `DLA`,
+`RhLA` are inherited; `Aves`, `Rodentia`, `Primata` are not) and the child does
+not declare an `old prefix` of its own. Note this is the *immediate* parent:
+`Macaca mulatta` inherits `RhLA` from `Macaca sp.`, not `NHP` from further up.
 
-1. **Prefix inheritance.** The loader hands a parent's prefix down to a child
-   as its `old prefix` when the parent's prefix is an MHC prefix rather than
-   its own taxon name (`BoLA`, `NHP`, `DLA` are inherited; `Aves`, `Rodentia`,
-   `Crocodylia` are not), the child does not declare an `old prefix` of its
-   own, and the parent does not exclude it. Note this is the *immediate*
-   parent: `Macaca mulatta` inherits `RhLA` from `Macaca sp.`, not `NHP`.
-2. **`prefix excludes`.** A list of species an entry's prefix must never name,
-   even though they sit beneath it. There is one, and it exists because
-   IPD-MHC's `NHP` group code means Non-Human Primates
-   (https://www.ebi.ac.uk/ipd/mhc/group/NHP/), so it cannot denote a human even
-   though humans are primates.
-3. **`Species.can_name`.** The runtime query: ancestry, minus anything an
-   ancestor excludes. `compatible_with` follows it, and so does the
-   ancestor-to-descendant conversion behind `parse(..., species=...)`, which is
-   why `parse("NHP-E*01:01", species="Homo sapiens")` is refused rather than
-   silently returned as `HLA-E*01:01`. `is_ancestor_of` and `is_descendant_of`
-   deliberately do *not* follow it: they stay purely taxonomic, so
-   `Homo sapiens` is a descendant of `Primata sp.` and always was in fact, if
-   not in this file before #122.
+Because every prefix owns a node, "is X inside taxon Y?" and "can Y's prefix
+name X?" are the same ancestry question, and one predicate answers both.
+Keeping that true is a constraint on curation: **a prefix whose group is not a
+taxon needs its own node.** `NHP` is the case that forced it. IPD-MHC's NHP
+group (https://www.ebi.ac.uk/ipd/mhc/group/NHP/) is Non-Human Primates -- the
+primate order minus humans, which is paraphyletic -- so it cannot be the
+primate node. It is a separate entry, sibling to `Homo sapiens`:
+
+```
+Primata sp. [Primata]
+|-- Homo sapiens [HLA]
+`-- NHP [NHP]
+    `-- 55 non-human primates
+```
+
+Attaching human to `Primata sp.` while leaving `NHP` on that same node (as
+3.40.0 briefly did) makes the group an ancestor of human, and then
+`parse("NHP-E*01:01", species="Homo sapiens")` converts to `HLA-E*01:01`. That
+was patched at the time with a `prefix excludes` declaration and a
+`Species.can_name` predicate; splitting the node deletes both, along with the
+question of which of two near-identical predicates a caller wants (#126).
+
+A consequence to keep in mind when adding taxa: any node under `Primata sp.`
+must sit wholly inside or wholly outside `NHP`. `Homo sp.` (humans plus other
+*Homo* species) works as a sibling of `NHP`; `Hominidae sp.` would not, because
+it would have to pull `Gorilla sp.`, `Pan sp.` and `Pongo sp.` out of the
+umbrella.
 
 The one edge that is deliberately not taxonomy is `Bubalus bubalis` under `Bos
 sp.` -- a different genus, but IPD-MHC files water buffalo in the BoLA group

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -433,12 +433,10 @@ Crocodylia sp.:
 ######################################################
 Homo sapiens:
   prefix: HLA
-  # Humans are primates -- NCBI Taxonomy places Homo sapiens (taxid 9606) in
-  # Primates (taxid 9443), https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606
-  # -- so the parent is the primate node. That node owns the prefix NHP, which
-  # can never name a human; the exclusion is declared on Primata sp. itself
-  # under "prefix excludes", because it is a property of what NHP means rather
-  # than of this entry. See #122.
+  # NCBI Taxonomy places Homo sapiens (taxid 9606) in Primates (taxid 9443),
+  # https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606 -- so the
+  # parent is the primate order. Sibling to the NHP node rather than inside it,
+  # which is what keeps NHP-* from naming a human. See #122, #126.
   parent: Primata sp.
   name: Human
   genes:
@@ -4318,16 +4316,16 @@ Tyto alba:
 #
 ################################################################################
 Primata sp.:
-  # The primate order, holding the genes every primate shares. Its prefix is
-  # the IPD-MHC group code NHP, which https://www.ebi.ac.uk/ipd/mhc/group/NHP/
-  # describes as "a specialist database for the Major Histocompatibility
-  # Complex genes of Non-Human Primates ... Apes and both Old World and New
-  # World monkeys" -- exclusionary by definition, unlike every other umbrella
-  # prefix in this file. So the node contains Homo sapiens, and the prefix is
-  # declared not to name it. See #122.
-  prefix: NHP
-  prefix excludes:
-    - Homo sapiens
+  # The primate order: every primate, humans included, holding the genes they
+  # all share. Its prefix is its own taxon name, so nothing inherits it as an
+  # MHC prefix.
+  #
+  # Its children are Homo sapiens and the NHP node below. Any taxon added here
+  # later must sit wholly inside or wholly outside NHP, because NHP is
+  # paraphyletic: "Homo sp." (humans plus other Homo species) is fine as a
+  # sibling of NHP, but a "Hominidae sp." spanning humans and the great apes
+  # would have to pull Gorilla, Pan and Pongo out of the NHP umbrella.
+  prefix: Primata
   name: Primate
   genes:
     Ib:
@@ -4352,9 +4350,22 @@ Primata sp.:
       DO:
         - DOA
         - DOB
+NHP:
+  # The IPD-MHC "NHP" group, which https://www.ebi.ac.uk/ipd/mhc/group/NHP/
+  # describes as "a specialist database for the Major Histocompatibility
+  # Complex genes of Non-Human Primates ... Apes and both Old World and New
+  # World monkeys". Not a taxon -- it is the primate order minus humans, which
+  # is paraphyletic -- so the key is the group code rather than a latin name.
+  #
+  # It exists as its own node so that "is a human a primate?" and "can NHP-*
+  # name a human?" are both answered by plain ancestry: Primata sp. is an
+  # ancestor of Homo sapiens, and this node is not. See #122, #126.
+  parent: Primata sp.
+  prefix: NHP
+  name: non-human primate
 Alouatta pigra:
   prefix: Alpi
-  parent: Primata sp.
+  parent: NHP
   name: Guatemalan black howler
   genes:
     IIa:
@@ -4363,7 +4374,7 @@ Alouatta pigra:
         - DRB
 Aotus sp.:
   prefix: OmLA
-  parent: Primata sp.
+  parent: NHP
   name:
     - Night monkey
     - Owl monkey
@@ -4408,7 +4419,7 @@ Aotus vociferans:
   name: Spix's Night Monkey
 Ateles belzebuth:
   prefix: Atbe
-  parent: Primata sp.
+  parent: NHP
   name: White-fronted Spider Monkey
   genes:
     Ia:
@@ -4419,14 +4430,14 @@ Ateles belzebuth:
         - DRB
 Ateles fusciceps:
   prefix: Atfu
-  parent: Primata sp.
+  parent: NHP
   name: Black-headed Spider Monkey
   genes:
     Ia:
       - B
 Callithrix sp.:
   prefix: MaLA
-  parent: Primata sp.
+  parent: NHP
   name: Marmoset
   # TODO:
   #   - Harmonize with this gene table
@@ -4497,7 +4508,7 @@ Callithrix jacchus:
     PS2: {pseudogene: true}
 Callicebus moloch:
   prefix: Camo
-  parent: Primata sp.
+  parent: NHP
   name: Red-bellied Titi
   genes:
     IIa:
@@ -4508,7 +4519,7 @@ Callicebus moloch:
         - DRB11
         - DRB3
 Callithrix pygmaea:
-  parent: Primata sp.
+  parent: NHP
   prefix: Capy
   old prefix: Cepy
   name: Pygmy Marmoset
@@ -4519,7 +4530,7 @@ Callithrix pygmaea:
         - DRB
         - DRB1
 Cebus apella:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceap
   name: Tufted Capuchin
   genes:
@@ -4536,47 +4547,47 @@ Cebus apella:
 #
 ############################
 Cebus albifrons:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceal
   name: White-fronted capuchin
 Cebus capucinus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceca
   name: White-faced capuchin
 Cebus imitator:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceim
   name: Panamanian white-faced capuchin
 Cebus kaapori:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceka
   name: Kaapori capuchin
 Cebus olivaceus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceol
   name: Wedge-capped capuchin
 Sapajus cay:
-  parent: Primata sp.
+  parent: NHP
   prefix: Saca
   name: Hooded capuchin
 Sapajus libidinosus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Sali
   name: Black-striped capuchin
 Sapajus apella macrocephalus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Sama
   name: Large-headed capuchin
 Sapajus nigritus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Sani
   name: Black capuchin
 Sapajus xanthosternos:
-  parent: Primata sp.
+  parent: NHP
   prefix: Saxa
   name: Golden-bellied capuchin
 Cercocebus atys:
-  parent: Primata sp.
+  parent: NHP
   prefix: Ceat
   name: Sooty Mangabey
   genes:
@@ -4588,7 +4599,7 @@ Cercocebus atys:
     I:
       - I
 Cercopithecus mitis:
-  parent: Primata sp.
+  parent: NHP
   prefix: Cemi
   name: Blue Monkey
   genes:
@@ -4599,7 +4610,7 @@ Cercopithecus mitis:
       DQ:
         - DQA1
 Cercopithecus neglectus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Cene
   name: De Brazza's monkey
   genes:
@@ -4607,7 +4618,7 @@ Cercopithecus neglectus:
       DQ:
         - DQA1
 Chlorocebus aethiops:
-  parent: Primata sp.
+  parent: NHP
   prefix: Chae
   name: Grivet
   genes:
@@ -4625,7 +4636,7 @@ Chlorocebus aethiops:
         - DRB5
         - DRB6
 Chlorocebus pygerythrus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Chpy
   name: vervet monkey
   genes:
@@ -4633,7 +4644,7 @@ Chlorocebus pygerythrus:
       - A
       - B
 Chlorocebus sabaeus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Chsa
   name: Green Monkey
   genes:
@@ -4654,7 +4665,7 @@ Chlorocebus sabaeus:
         - DRB1
         - DRB5
 Colobus guereza:
-  parent: Primata sp.
+  parent: NHP
   prefix: Cogu
   name: Mantled Guereza
   genes:
@@ -4662,7 +4673,7 @@ Colobus guereza:
       DQ:
         - DQA1
 Gorilla sp.:
-  parent: Primata sp.
+  parent: NHP
   prefix: GoLA
   name: Gorilla
   genes:
@@ -4706,7 +4717,7 @@ Gorilla gorilla:
   name:
     - Western gorilla
 Hylobates lar:
-  parent: Primata sp.
+  parent: NHP
   prefix: Hyla
   name: Lar Gibbon
   genes:
@@ -4720,7 +4731,7 @@ Hylobates lar:
         - DQB1
         - DQB2
 Hylobates moloch:
-  parent: Primata sp.
+  parent: NHP
   prefix: Hymo
   name: Silvery Javan Gibbon
   genes:
@@ -4730,11 +4741,11 @@ Hylobates moloch:
         - DRB # same as DRB1?
         - DRB1
 Leontopithecus rosalia:
-  parent: Primata sp.
+  parent: NHP
   prefix: Lero
   name: Golden Lion Tamarin
 Lophocebus aterrimus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Loat
   name: Black Crested Mangabey
   genes:
@@ -4742,7 +4753,7 @@ Lophocebus aterrimus:
       DQ:
         - DQA1
 Macaca arctoides:
-  parent: Primata sp.
+  parent: NHP
   prefix: Maar
   name: Stump-tailed Macaque
   genes:
@@ -4762,7 +4773,7 @@ Macaca arctoides:
         - DRB5
 
 Macaca assamensis:
-  parent: Primata sp.
+  parent: NHP
   prefix: Maas
   name: Assam Macaque
   genes:
@@ -4817,7 +4828,7 @@ Macaca fascicularis:
         - DRB5
         - DRB6
 Macaca fuscata:
-  parent: Primata sp.
+  parent: NHP
   prefix: Mafu
   name: Japanese Macaque
   genes:
@@ -4827,7 +4838,7 @@ Macaca fuscata:
         - DRB1
         - DRB3
 Mandrillus leucophaeus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Male
   name: Drill
   genes:
@@ -4835,7 +4846,7 @@ Mandrillus leucophaeus:
       DR:
         - DRB1
 Macaca leonina:
-  parent: Primata sp.
+  parent: NHP
   prefix: Malo
   name: Northern Pig-tailed Macaque
   genes:
@@ -4874,7 +4885,7 @@ Macaca leonina:
 # a specific A gene. This seems similar to the situation in HLA-DR but with
 # even fewer sequence differences between the gene copies.
 Macaca sp.:
-  parent: Primata sp.
+  parent: NHP
   prefix: RhLA
   name: Macaque
   genes:
@@ -4960,7 +4971,7 @@ Macaca silenus:
   prefix: Masi
   name: Lion-tailed Macaque
 Mandrillus sphinx:
-  parent: Primata sp.
+  parent: NHP
   prefix: Masp
   name: Mandrill
   genes:
@@ -4978,7 +4989,7 @@ Macaca thibetana:
   name: Milne Edward's Macaque
 
 Papio anubis:
-  parent: Primata sp.
+  parent: NHP
   prefix: Paan
   name: Olive Baboon
   genes:
@@ -5006,7 +5017,7 @@ Papio anubis:
         - DRB5
         - DRB6
 Papio cynocephalus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Pacy
   name: Yellow Baboon
   genes:
@@ -5019,7 +5030,7 @@ Papio cynocephalus:
       DQ:
         - DQA1
 Papio hamadryas:
-  parent: Primata sp.
+  parent: NHP
   prefix: Paha
   name: Hamadryas Baboon
   genes:
@@ -5040,7 +5051,7 @@ Papio hamadryas:
         - DRB1
 
 Papio papio:
-  parent: Primata sp.
+  parent: NHP
   prefix: Papp
   name: Guinea Baboon
   genes:
@@ -5048,7 +5059,7 @@ Papio papio:
       DQ:
         - DQA1
 Pan sp.:
-  parent: Primata sp.
+  parent: NHP
   prefix: ChLA
   name: Chimpanzee
   genes:
@@ -5101,7 +5112,7 @@ Pan paniscus:
     - Ppa
   name: Bonobo
 Papio ursinus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Paur
   name: Chacma Baboon
   genes:
@@ -5113,7 +5124,7 @@ Papio ursinus:
         - DRB5
         - DRB6
 Pithecia pithecia:
-  parent: Primata sp.
+  parent: NHP
   prefix: Pipi
   name: White-faced Saki
   genes:
@@ -5125,7 +5136,7 @@ Pithecia pithecia:
         - DRB
         - DRB3
 Pongo sp.:
-  parent: Primata sp.
+  parent: NHP
   prefix: OrLA
   name: Orangutan
   genes:
@@ -5166,7 +5177,7 @@ Pongo pygmaeus:
   gene properties:
     Ap: {pseudogene: true}
 Rhinopithecus roxellana:
-  parent: Primata sp.
+  parent: NHP
   prefix: Rhro
   name: Golden Snub-nosed Monkey
   genes:
@@ -5180,7 +5191,7 @@ Rhinopithecus roxellana:
         - DRB1
         - DRB2
 Saguinus fuscicollis:
-  parent: Primata sp.
+  parent: NHP
   prefix: Safu
   name: Brown-mantled Tamarin
   genes:
@@ -5190,7 +5201,7 @@ Saguinus fuscicollis:
       - PS1
       - PS2
 Saguinus geoffroyi:
-  parent: Primata sp.
+  parent: NHP
   prefix: Sage
   name: Geoffroy's Tamarin
   genes:
@@ -5198,7 +5209,7 @@ Saguinus geoffroyi:
       - PS1
       - PS2
 Saguinus labiatus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Sala
   name: White-lipped Tamarin
   genes:
@@ -5208,7 +5219,7 @@ Saguinus labiatus:
         - DRB
         - DRB1
 Saguinus mystax:
-  parent: Primata sp.
+  parent: NHP
   prefix: Samy
   name: Moustached Tamarin
   genes:
@@ -5216,7 +5227,7 @@ Saguinus mystax:
       - PS1
       - PS2
 Saguinus oedipus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Saoe
   name: Cottontop Tamarin
   genes:
@@ -5242,7 +5253,7 @@ Saguinus oedipus:
         - DRB5
 
 Saimiri sciureus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Sasc
   name: Common Squirrel Monkey
   genes:
@@ -5253,7 +5264,7 @@ Saimiri sciureus:
         - DRA
         - DRB
 Semnopithecus entellus:
-  parent: Primata sp.
+  parent: NHP
   prefix: Seen
   # Pren = Pr(esbytis) + en(tellus) under the Klein 1990 rule (PMID 2329006).
   # Presbytis entellus is the former name of this species, so it is the only
@@ -5269,7 +5280,7 @@ Semnopithecus entellus:
         - DRA
         - DRB
 Theropithecus gelada:
-  parent: Primata sp.
+  parent: NHP
   prefix: Thge
   # No 'old prefix: Pren' here, deliberately.
   #
@@ -5294,7 +5305,7 @@ Theropithecus gelada:
         - DRA
         - DRB
 Rhinopithecus strykeri:
-  parent: Primata sp.
+  parent: NHP
   prefix: RhinStry
   other prefixes:
     - Rhsi

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -750,12 +750,7 @@ def parse(
                 result_species = result.species
                 if result_species == expected:
                     matches_expected = True
-                # can_name rather than is_ancestor_of: an umbrella prefix that
-                # is exclusionary by definition must not be reinterpreted as one
-                # of the species it excludes. "NHP" names non-human primates, so
-                # parse("NHP-E*01:01", species="Homo sapiens") has to be rejected
-                # rather than converted to HLA-E*01:01. See issue #122.
-                elif result_species.can_name(expected):
+                elif result_species.is_ancestor_of(expected):
                     converted = _reparse_result_for_species(
                         parser=parser,
                         result=result,

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -148,7 +148,6 @@ class Species(Result):
     other_mhc_prefixes: Any = None
     context_only_mhc_prefixes: Any = None
     other_common_names: Any = None
-    prefix_excluded_species: Any = None
 
     def __init__(
         self,
@@ -172,7 +171,6 @@ class Species(Result):
         other_mhc_prefixes: Iterable[str] = [],
         context_only_mhc_prefixes: Iterable[str] = [],
         other_common_names: Iterable[str] = [],
-        prefix_excluded_species: Iterable[str] = [],
         raw_string: Union[str, None] = None,
         gene_name_to_properties: Union[Mapping[str, Mapping[str, Any]], None] = None,
         gene_family_name_to_gene_names: Union[Mapping[str, Iterable[str]], None] = None,
@@ -215,11 +213,6 @@ class Species(Result):
             self,
             "context_only_mhc_prefixes",
             FrozenSet(context_only_mhc_prefixes),
-        )
-        self._set_field(
-            self,
-            "prefix_excluded_species",
-            FrozenSet(prefix_excluded_species),
         )
         if old_mhc_prefix:
             normalized_old_mhc_prefix = old_mhc_prefix
@@ -353,55 +346,21 @@ class Species(Result):
             current = current.parent_species
         return False
 
-    def can_name(self, other):
-        """
-        Can a name written under this species' prefix denote `other`?
-
-        True for itself and for every descendant, except where an entry
-        declares "prefix excludes" -- an umbrella prefix that is exclusionary
-        by definition. "NHP" is IPD-MHC's group code for Non-Human Primates, so
-        Primata sp. cannot name Homo sapiens even though it is its ancestor:
-
-            Bos sp.     -> Bubalus bubalis   -> True
-            Primata sp. -> Macaca mulatta    -> True
-            Primata sp. -> Homo sapiens      -> False (prefix excludes)
-
-        This is the naming counterpart of is_ancestor_of, which stays purely
-        taxonomic. Use this one whenever the question is "may this name stand
-        for that species", such as reinterpreting a group-level allele name
-        under a specific species.
-        """
-        other = Species.get(other)
-        if other is None:
-            return False
-        if self == other:
-            return True
-        node = other
-        while node is not None and node != self:
-            if node.name in self.prefix_excluded_species:
-                return False
-            node = node.parent_species
-        return node == self
-
     def compatible_with(self, other):
         """
         Can these two species names describe the same sample?
 
-        True when they are the same species, or when one can name the other.
-        Species legitimately differ in specificity: BoLA belongs to the
+        True when they are the same species, or when one is an ancestor of the
+        other. Species legitimately differ in specificity: BoLA belongs to the
         genus-level "Bos sp.", so a BoLA-N*013:01 allele on a sample curated as
         Bos taurus is less specific, not contradictory.
 
             Bos taurus        vs Bos sp.               -> True  (ancestor)
             Coturnix japonica vs Galliformes sp.       -> True  (above genus)
+            Homo sapiens      vs Primata sp.           -> True  (humans are primates)
+            Homo sapiens      vs NHP                   -> False (a sibling group)
             Macaca mulatta    vs Macaca fascicularis   -> False (siblings)
             Carassius gibelio vs Homo sapiens          -> False
-            Homo sapiens      vs Primata sp.           -> False (prefix excludes)
-
-        The last one is the reason this is can_name rather than is_ancestor_of:
-        humans are primates, but "Primata sp." is the node that owns the NHP
-        prefix, and an NHP-* allele can never have come from a human sample.
-        For the taxonomic question, ask is_descendant_of.
 
         Note that "shares a common ancestor" is NOT a usable test in its place:
         every species descends from "Gnathostomata sp.", so that predicate is
@@ -414,7 +373,7 @@ class Species(Result):
         other = Species.get(other)
         if other is None:
             return False
-        return self == other or self.can_name(other) or other.can_name(self)
+        return self == other or self.is_ancestor_of(other) or other.is_ancestor_of(self)
 
     @property
     def historic_mhc_prefix(self):
@@ -1029,27 +988,10 @@ def create_species_for_latin_name(latin_name):
     if not prefix:
         raise ValueError(f"Missing 'prefix' for '{latin_name}' in species ontology")
 
-    # Species this entry's own prefix must never name, even though they sit
-    # beneath it in the tree. An umbrella prefix is normally handed down to
-    # every descendant, but a few of them are exclusionary by definition --
-    # IPD-MHC's "NHP" means Non-Human Primates, so it cannot name Homo sapiens
-    # even though humans are primates. See issue #122.
-    prefix_excluded_species = species_info.get("prefix excludes") or []
-    if type(prefix_excluded_species) is str:
-        prefix_excluded_species = [prefix_excluded_species]
-    for excluded_name in prefix_excluded_species:
-        if excluded_name not in raw_species_dict:
-            raise ValueError(
-                f"'prefix excludes' of '{latin_name}' names unknown species '{excluded_name}'"
-            )
-
     old_mhc_prefix = species_info.get("old prefix")
     if not old_mhc_prefix and parent_species:
         parent_prefix = parent_species.prefix
-        if (
-            not _is_taxonomic_prefix(parent_prefix, parent_species.name)
-            and latin_name not in parent_species.prefix_excluded_species
-        ):
+        if not _is_taxonomic_prefix(parent_prefix, parent_species.name):
             old_mhc_prefix = parent_prefix
 
     other_mhc_prefixes = species_info.get("other prefixes")
@@ -1277,7 +1219,6 @@ def create_species_for_latin_name(latin_name):
         other_mhc_prefixes=other_mhc_prefixes,
         context_only_mhc_prefixes=context_only_mhc_prefixes,
         other_common_names=[name for name in common_names if name != shortest_common_name],
-        prefix_excluded_species=prefix_excluded_species,
         raw_string=latin_name,
     )
 

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.40.0"
+__version__ = "3.41.0"
 
 
 def print_version():

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -23,6 +23,28 @@ actually support it. If the answer is one, write down the exception, not the
 model. Reading the code that implements the structure is part of establishing
 what the structure means.
 
+## Prefer fixing the structure to encoding an exception
+
+**What happened.** #122 said `Primata sp.` excludes `Homo sapiens` because its
+prefix is `NHP`. Two fixes were shipped before the right one. The first made
+human a child of the node and blocked prefix inheritance, which leaked (below).
+The second added a `prefix excludes` YAML key, a `prefix_excluded_species`
+field, a `Species.can_name` predicate and a docs section explaining when to
+prefer it over `compatible_with`. A downstream reader filed #126 within hours
+asking which of the two predicates answered which question.
+
+**Why it was wrong.** `NHP` is the primate order *minus humans* -- paraphyletic,
+not a taxon -- and it was sitting on the node for the primate order. One node
+was standing for two different sets. Every line of that machinery existed to
+paper over that. Giving `NHP` its own entry, sibling to `Homo sapiens`, made
+both questions plain ancestry and deleted all of it.
+
+**How to apply.** When a fix needs a new concept to describe a special case,
+check first whether the data can be shaped so the special case does not exist.
+A predicate that has to be explained in docs is a sign the structure is wrong;
+"which of these two similar methods do I want" is a question the data model
+should be answering, not the reader.
+
 ## An invariant asserted in prose has to be tested on every path
 
 **What happened.** The first fix for #122 gave `Homo sapiens` a parent of

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,82 +1,64 @@
-# Put Homo sapiens back in the primate order
+# Give NHP its own node instead of a naming predicate
 
-Tracking issue: #122
+Tracking issues: #126 (raised against 3.40.0), follow-up to #122
 
-`Primata sp.` carries the prefix `NHP`, which IPD-MHC defines as "Non-Human
-Primates". `Homo sapiens` was therefore attached straight to the root, so the
-library answered `False` to "is a human a primate?" -- a node named for a taxon
-that includes humans, scoped to a prefix that excludes them.
+3.40.0 put `Homo sapiens` under `Primata sp.` and, because that node owns the
+`NHP` prefix, had to add a `prefix excludes` declaration and a
+`Species.can_name` predicate to stop `NHP-*` naming a human. #126 pointed out
+the cost: `compatible_with` was quietly switched from ancestry to naming, so
+there was no longer a way to ask the ancestry question, and two near-identical
+predicates now had to be chosen between.
 
 ## Specification
 
-- [x] Establish from the authority what `NHP` means and whether IPD files
-      humans in that group.
-- [x] Check whether the parent link and the umbrella prefix are actually the
-      same mechanism, or two separable ones.
-- [x] Reparent `Homo sapiens` under `Primata sp.` without letting `NHP` name
-      it by any route, and cite the source next to the entry.
-- [x] Check every consumer of the parent link, not just prefix inheritance.
-- [x] Measure: A/B every name in the bundled corpora, and diff every field of
-      all 671 species objects, between `main` and the branch.
-- [x] Sweep every parent link for the same class of defect and file what turns
-      up rather than folding it in.
-- [x] Correct the README, `docs/curation.md` and `AGENTS.md`, which had
-      generalized one exception into a model.
-- [x] Pin the invariants in tests.
-- [x] Bump the version and run `./format.sh`, `./lint.sh`, and `./test.sh`.
+- [x] Check whether the two questions can be made one by shaping the data
+      instead of adding a predicate.
+- [x] Give `NHP` its own entry, sibling to `Homo sapiens` under `Primata sp.`,
+      and move the 55 non-human primates under it.
+- [x] Delete `prefix excludes`, `prefix_excluded_species` and
+      `Species.can_name`; restore `compatible_with` to plain ancestry.
+- [x] Measure against a worktree of `main`: corpus, compatibility over every
+      species pair, and every structural field.
+- [x] Record the paraphyly constraint the split imposes on future taxa.
+- [x] Update README, `docs/curation.md`, `AGENTS.md` and the tests.
+- [x] Bump the version and run `./format.sh`, `./lint.sh`, `./test.sh`.
 
 ## Review
 
-- **The fix is a parent link plus a first-class exclusion.** The issue proposed
-  either renaming the node or inserting a level above it. Neither was needed,
-  but the first attempt -- opting human out of the umbrella by spelling out
-  `old prefix: HLA` -- was not enough either. Code review found it only blocked
-  one of four consumers of the parent link:
+- **The structure answers both questions, so the predicate is unnecessary.**
+  `Primata sp.` is now the primate order with prefix `Primata`; `NHP` is a node
+  of its own holding the 55 non-human primates. `Homo sapiens` is a sibling of
+  `NHP`, not a descendant, so:
 
   ```
-  parse("NHP-E*01:01", species="Homo sapiens")  ->  HLA-E*01:01
+  compatible_with("Homo sapiens", "Primata sp.")  ->  True   (was False)
+  compatible_with("Homo sapiens", "NHP")          ->  False
+  parse("NHP-E*01:01", species="Homo sapiens")    ->  None
   ```
 
-  So the exclusion is now declared on the node that owns the prefix, and there
-  is a runtime query for it:
-
-  ```yaml
-  Primata sp.:
-    prefix: NHP
-    prefix excludes:
-      - Homo sapiens
-  ```
-
-  `Species.can_name(other)` is ancestry minus anything an ancestor excludes.
-  `compatible_with` follows it, and so does the ancestor-to-descendant
-  conversion in `function_api`. `is_ancestor_of` and `is_descendant_of` stay
-  purely taxonomic, which is what the issue was actually asking for.
-- **Authority.** https://www.ebi.ac.uk/ipd/mhc/group/NHP/ -- "a specialist
-  database for the Major Histocompatibility Complex genes of Non-Human
-  Primates ... Apes and both Old World and New World monkeys". The placement
-  itself cites NCBI Taxonomy: Homo sapiens (9606) sits in Primates (9443).
-- **Measured against a worktree of `main`, not a stash.** 0 of 11,558 corpus
-  names change; `compatible_with` is identical across all 450,241 species
-  pairs; 15 structural fields across all 671 species objects differ in exactly
-  one place, `Homo sapiens.parent`. The first round of this measurement used
-  `git stash`, which only reverts uncommitted work and so compared the branch
-  against itself -- recorded in `tasks/lessons.md`.
-- **The inertness guard now covers every inheritance channel.** Gene names were
-  only one of them: gene properties, gene families, class II locus groupings
-  and seven side tables keyed by ancestor latin name all flow down too. A
-  pseudogene flag added to `Primata sp.` reaches `HLA` and passed the original
-  name-only check; it now fails.
-- **The docs were over-corrected and are now fixed.** #120 read the water
-  buffalo edge as proof that the tree is "prefix scope, not phylogeny". Exactly
-  one parent link points at another genus's node -- the buffalo -- and `Homo
-  sapiens` was outside `Primata sp.` only because nothing expressed the NHP
-  exclusion. The buffalo exception stands; the generalization does not.
-- **Filed rather than folded: #123.** The same sweep found five primates
-  (`Macaca arctoides`, `M. assamensis`, `M. fuscata`, `M. leonina`,
-  `Callithrix pygmaea`) sitting outside their own genus node, so they inherit
-  almost no genes and `Mafu-A*01:01` does not parse while `Mamu-A*01:01` does.
-  Reparenting them is also 0/11,558, but it hands each one 49 macaque genes by
-  inheritance, which is a scientific claim that wants reading rather than
-  measuring. A test pins the list of five so it cannot grow silently.
-- Bumped 3.39.0 to 3.40.0 -- minor rather than patch, because `Species.can_name`
-  is new public API.
+  All three are plain `is_ancestor_of`. `can_name`, `prefix excludes` and the
+  docs section explaining which predicate to use are gone.
+- **The general rule this yields:** every MHC prefix owns a node, so "is X
+  inside taxon Y" and "can Y's prefix name X" are the same question. A prefix
+  whose group is not a taxon needs its own node. `NHP` is the first such case
+  because it is paraphyletic -- the primate order minus humans.
+- **Constraint recorded on the node.** Any taxon added under `Primata sp.` must
+  sit wholly inside or wholly outside `NHP`. `Homo sp.` works as a sibling;
+  `Hominidae sp.` would not, since it would have to pull `Gorilla sp.`,
+  `Pan sp.` and `Pongo sp.` out of the umbrella.
+- **Measured against a worktree of `main`** (3.40.0's `Primata sp.` placement
+  is the baseline): 0 of 11,558 corpus names change. Over the 671 species that
+  exist in both, exactly one compatibility pair changes -- `Homo sapiens` vs
+  `Primata sp.`, now True, which is what #126 asked for. One node is added.
+- **A simplification falls out.** On main `find_matching_species_objects("NHP")`
+  returned 54 objects, because 53 species carried `NHP` as an inherited
+  `old prefix` and were collapsed to the owner by the #103 tie-break. `NHP` is
+  its own taxon name now, so nothing inherits it and the lookup returns 1.
+- **Visible output change.** `NHP` and `NHP class I` resolve to the new node
+  rather than to `Primata sp.`, and `primate` now resolves to `Primata sp.`
+  with prefix `Primata`. Those two strings used to give the same answer; they
+  are different questions and now give different answers. No corpus name is
+  affected.
+- Bumped 3.40.0 to 3.41.0. `Species.can_name`, added in 3.40.0, is removed
+  again in the same day; it was public for one release and is called out in the
+  PR so anything that picked it up knows to use `compatible_with`.

--- a/tests/test_ambiguous_species_inference.py
+++ b/tests/test_ambiguous_species_inference.py
@@ -31,11 +31,10 @@ PREFIX_TO_EXPECTED_SPECIES = [
     ("CELA", "Cetacea sp."),
     ("ChLA", "Pan sp."),
     ("MusSp", "Mus sp."),
-    # NHP resolves to Primata sp., the node that owns the prefix. Homo sapiens
-    # is a child of that node but never answers to NHP: the entry declares
-    # "prefix excludes: [Homo sapiens]", since IPD-MHC's NHP group means
-    # Non-Human Primates (#122).
-    ("NHP", "Primata sp."),
+    # NHP is its own node, sibling to Homo sapiens under Primata sp., because
+    # IPD-MHC's NHP group means Non-Human Primates and so is not the primate
+    # order (#122, #126).
+    ("NHP", "NHP"),
     ("OmLA", "Aotus sp."),
     ("RT1", "Rattus sp."),
     ("RhLA", "Macaca sp."),

--- a/tests/test_species_provenance.py
+++ b/tests/test_species_provenance.py
@@ -176,20 +176,18 @@ COMPATIBLE = [
     ("Homo sapiens", "Homo sapiens"),
     ("Saimiri sciureus", "Primata sp."),
     ("Homo sapiens", "Gnathostomata sp."),
+    # Humans are primates, and Primata sp. is the primate order (#122).
+    ("Homo sapiens", "Primata sp."),
 ]
 
 INCOMPATIBLE = [
     ("Macaca mulatta", "Macaca fascicularis"),
     ("Carassius gibelio", "Homo sapiens"),
     ("Bos taurus", "Ovis aries"),
-    # Humans ARE primates and Primata sp. is an ancestor of Homo sapiens
-    # (tests/test_species_tree_shape.py pins that). But this question is about
-    # naming, not descent: Primata sp. owns the prefix NHP, which IPD-MHC
-    # defines as Non-Human Primates, so an NHP-* allele can never have come
-    # from a human sample. compatible_with follows Species.can_name, which
-    # honours the "prefix excludes" declaration; for the taxonomic question,
-    # ask is_descendant_of. See issue #122.
-    ("Homo sapiens", "Primata sp."),
+    # An NHP-* allele can never have come from a human sample. This is plain
+    # ancestry, not a special case: NHP is a sibling of Homo sapiens under
+    # Primata sp., not one of its ancestors. See issues #122 and #126.
+    ("Homo sapiens", "NHP"),
 ]
 
 

--- a/tests/test_species_tree_shape.py
+++ b/tests/test_species_tree_shape.py
@@ -3,12 +3,13 @@ Invariants about the shape of the species tree: what a parent link means, and
 where the tree deliberately departs from taxonomy.
 
 A parent link is containment, taxonomic wherever it can be, and it is what
-genes are inherited along. Whether an ancestor's prefix may *name* a descendant
-is a separate question, answered by Species.can_name and constrained by the
-"prefix excludes" declaration -- which is why Homo sapiens can be a primate
-without ever answering to NHP.
+genes are inherited along. Every MHC prefix owns a node, so "is a human a
+primate?" and "can NHP-* name a human?" are both plain ancestry questions:
+Primata sp. is the primate order and an ancestor of Homo sapiens, while NHP is
+a sibling of Homo sapiens beneath it.
 
 https://github.com/pirl-unc/mhcgnomes/issues/122
+https://github.com/pirl-unc/mhcgnomes/issues/126
 """
 
 import pytest
@@ -74,44 +75,35 @@ def test_human_does_not_inherit_the_nhp_prefix():
     ok_("NHP" not in set(human.all_identifiers))
 
 
-def test_the_primate_node_cannot_name_a_human():
+def test_nhp_is_a_sibling_of_human_not_an_ancestor():
     human = Species.get_by_latin_name("Homo sapiens")
-    primates = Species.get_by_latin_name("Primata sp.")
-    ok_(not primates.can_name(human))
-    ok_(not human.compatible_with(primates))
-    ok_(not primates.compatible_with(human))
-    ok_(not human.compatible_with("NHP"))
+    nhp = Species.get("NHP")
+    ok_(not nhp.is_ancestor_of(human))
+    ok_(not human.is_descendant_of(nhp))
+    ok_(not human.compatible_with(nhp))
+    ok_(not nhp.compatible_with(human))
+    eq_(nhp.parent.name, "Primata sp.")
 
 
-def test_the_primate_node_can_still_name_every_other_primate():
+def test_nhp_covers_every_primate_except_human():
     primates = Species.get_by_latin_name("Primata sp.")
-    unnameable = [
+    nhp = Species.get("NHP")
+    outside = sorted(
         s.name
         for s in ALL_SPECIES
-        if primates.is_ancestor_of(s) and s.name != "Homo sapiens" and not primates.can_name(s)
-    ]
-    eq_(unnameable, [], f"NHP stopped covering: {unnameable}")
+        if primates.is_ancestor_of(s) and s is not nhp and not nhp.is_ancestor_of(s)
+    )
+    eq_(outside, ["Homo sapiens"], f"outside the NHP group: {outside}")
 
 
-def test_exclusion_does_not_leak_to_nodes_above_it():
-    # Gnathostomata sp. does not exclude anything, so human stays reachable
-    # from the root even though the path passes through the excluded edge.
-    human = Species.get_by_latin_name("Homo sapiens")
-    root = Species.get_by_latin_name("Gnathostomata sp.")
-    ok_(root.can_name(human))
-    ok_(human.compatible_with(root))
-
-
-# Every gene `Primata sp.` owns, so that these exercise the conversion path
-# rather than merely failing to find a gene. `species=` on the second column is
-# the ancestor-to-descendant conversion that must be refused for NHP.
+# Every gene the primate node owns, so that these exercise the species=
+# conversion path rather than merely failing to find a gene.
 NHP_GENES = ["E", "DMB", "MICA", "CD1a"]
 
 
 @pytest.mark.parametrize("gene", NHP_GENES)
-def test_nhp_gene_names_parse_as_the_primate_node(gene):
-    result = parse(f"NHP-{gene}")
-    eq_(result.species.name, "Primata sp.")
+def test_nhp_gene_names_parse_as_the_nhp_node(gene):
+    eq_(parse(f"NHP-{gene}").species.name, "NHP")
 
 
 @pytest.mark.parametrize("gene", NHP_GENES)
@@ -125,29 +117,24 @@ def test_nhp_gene_names_are_never_converted_to_human(gene, human_name):
 
 
 def test_ancestor_to_descendant_conversion_still_works_where_it_should():
-    # The guard above must not have disabled the feature it constrains.
-    result = parse("BoLA-N*01301", species="Bos taurus")
-    eq_(result.species.name, "Bos taurus")
+    # The structure must not have disabled the feature it constrains.
+    eq_(parse("BoLA-N*01301", species="Bos taurus").species.name, "Bos taurus")
 
 
-def test_nhp_prefix_still_belongs_to_the_primate_node():
-    eq_(Species.get("NHP"), Species.get_by_latin_name("Primata sp."))
+def test_nhp_prefix_belongs_to_the_nhp_node():
+    eq_(Species.get("NHP"), Species.get_by_latin_name("NHP"))
+    eq_(Species.get("primate"), Species.get_by_latin_name("Primata sp."))
 
 
-def test_every_other_primate_still_inherits_nhp():
+def test_primata_prefix_is_its_own_taxon_name_and_is_not_inherited():
+    # "Primata" is the node's taxon name, so the loader treats it the way it
+    # treats "Aves" and "Rodentia": it is not handed down as an MHC prefix.
     primates = Species.get_by_latin_name("Primata sp.")
-    # Genus nodes inherit NHP too, despite carrying prefixes of their own:
-    # Macaca sp. is RhLA *and* old prefix NHP. The only children that do not
-    # are the two with a documented historic prefix, and human.
-    declares_own_old_prefix = {"Callithrix pygmaea", "Semnopithecus entellus", "Homo sapiens"}
-    lost = [
-        s.name
-        for s in ALL_SPECIES
-        if s.parent is primates
-        and s.name not in declares_own_old_prefix
-        and s.historic_mhc_prefix != "NHP"
+    eq_(primates.prefix, "Primata")
+    inheritors = [
+        s.name for s in ALL_SPECIES if s.historic_mhc_prefix == "Primata" and s is not primates
     ]
-    eq_(lost, [], f"children of Primata sp. that lost the NHP umbrella: {lost}")
+    eq_(inheritors, [], f"species that picked up 'Primata' as an MHC prefix: {inheritors}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #125. Closes #126.

#126 asks me to pick between two predicates. This picks neither, because the
reason there were two is a data-modelling error I introduced in 3.40.0.

## The root cause

IPD-MHC's [`NHP` group](https://www.ebi.ac.uk/ipd/mhc/group/NHP/) is the
primate order **minus humans** — paraphyletic, not a taxon. 3.40.0 left that
prefix sitting on the node for the primate order, so one node stood for two
different sets. Everything #125 and #126 report follows from that: `NHP` became
an ancestor of `Homo sapiens`, which made `parse("NHP-E*01:01",
species="Homo sapiens")` return `HLA-E*01:01`, which I patched with a
`prefix excludes` key and a `can_name` predicate, which took `compatible_with`
away from ancestry.

`NHP` gets its own node:

```
Primata sp. [Primata]        the primate order, and the genes all primates share
├── Homo sapiens [HLA]
└── NHP [NHP]                the IPD-MHC group
    └── 55 non-human primates
```

Both of #126's questions are now the same ancestry question, asked of different
nodes:

```python
>>> Species.get("Homo sapiens").compatible_with("Primata sp.")
True        # sample identity: humans are primates          (#125, #126)
>>> Species.get("Homo sapiens").compatible_with("NHP")
False       # nomenclature: NHP-* cannot write human alleles
>>> parse("NHP-E*01:01", species="Homo sapiens", raise_on_error=False)
None
```

`compatible_with` is back to the body #126 asked for, docstring and all.
`prefix excludes`, `prefix_excluded_species` and `Species.can_name` are
deleted — net **−49 lines**.

> A caller wanting nomenclature asks `can_name` directly

They ask `compatible_with(species, <the node that owns the prefix>)` instead.
That works because of the general rule this establishes: **every MHC prefix
owns a node**, so "is X inside taxon Y" and "can Y's prefix name X" are the
same question. `Bos sp.` owns `BoLA`; `NHP` owns `NHP`. The two predicates
diverged for exactly one pair precisely because one prefix had no node of its
own.

## Measurement

Against a `git worktree` of `main` (3.40.0):

| check | result |
|---|---|
| bundled netMHCpan 3.0/4.0, netMHCIIpan 3.1, IEDB corpora | **0 of 11,558** names parse differently |
| compatibility over the 671 species present in both | **1** pair changes: `Homo sapiens` ↔ `Primata sp.`, now True |
| nodes added | 1 (`NHP`) |

A simplification falls out: `find_matching_species_objects("NHP")` returned
**54** objects on main, because 53 species carried `NHP` as an inherited
`old prefix` and the #103 tie-break had to collapse them to the owner. `NHP` is
its own taxon name now, so nothing inherits it and the lookup returns **1**.

## Visible change

`NHP` and `NHP class I` resolve to the new node rather than to `Primata sp.`,
and `primate` resolves to `Primata sp.` with prefix `Primata`. Those two
strings used to give the same answer; they are different questions and now give
different answers. No corpus name is affected.

`Species.can_name` was public for one release and is removed again — call
`compatible_with` with the prefix's node.

## The constraint this imposes

`NHP` is paraphyletic, so any taxon added under `Primata sp.` must sit wholly
inside or wholly outside it. A `Homo sp.` node holding *H. sapiens* and
*H. neanderthalensis* works as a sibling of `NHP`; a `Hominidae sp.` spanning
humans and the great apes would not, since it would have to pull `Gorilla sp.`,
`Pan sp.` and `Pongo sp.` out of the umbrella. Recorded on the node itself and
in `docs/curation.md`.

## Tests

`tests/test_species_tree_shape.py` now pins the sibling relation rather than an
exclusion predicate: `NHP` is not an ancestor of human, it covers every primate
except human, `NHP-*` names are never converted to human under `species=`, the
conversion still works for `BoLA`→`Bota`, and `Primata` is never inherited as
an MHC prefix. `test_species_provenance.py` moves human/`Primata sp.` to
COMPATIBLE and adds human/`NHP` to INCOMPATIBLE.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,547 passed.
Version 3.40.0 → 3.41.0.
