### PR TITLE
Retire the 5+5 prefix tier and record where a prefix came from

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,8 +504,21 @@ Two limits are worth knowing:
 **4+4 is not collision-free.** Five forms are derivable from two entries each —
 `ChryPict` from both *Chrysemys picta* and *Chrysolophus pictus*, `LaniColl`
 from two shrikes, `LeucLeuc` from a dace and a crane. A colliding form is never
-emitted as a global alias, and where one was previously chosen as a canonical
-prefix the entry now uses its concatenated binomial instead.
+*auto-generated*, but that only suppresses the generated copy: where one side
+of a pair curates the form, it still resolves, and to that side alone —
+`ChryPict` gives the turtle, `LaniColl` gives *Lanius collurio*. Only forms
+neither side curates are unresolvable (`CaniLupu`, `BalaMusc`). Where a
+colliding form had been chosen as a canonical prefix, the entry now uses its
+concatenated binomial instead — three entries did, in 3.42.0:
+
+| species | was | now |
+|---|---|---|
+| *Chrysemys picta* | `ChryPict` | `ChrysemysPicta` |
+| *Lanius collaris* | `LaniCola` | `LaniusCollaris` |
+| *Leuciscus leuciscus* | `LeucisLeucis` | `LeuciscusLeuciscus` |
+
+Their normalized output changes accordingly, so `parse("ChryPict-UA")` now
+round-trips as `ChrysemysPicta-UA`. The old spellings stay parseable.
 
 **Subspecies mint no generated alias.** A trinomial entry such as *Canis lupus
 baileyi* deliberately does not claim `CanisLupus`, which belongs to its parent

--- a/README.md
+++ b/README.md
@@ -501,15 +501,16 @@ Homo sapiens-A*02:01 # latin name with space
 
 Two limits are worth knowing:
 
-**4+4 is not collision-free.** Five forms are derivable from two entries each —
-`ChryPict` from both *Chrysemys picta* and *Chrysolophus pictus*, `LaniColl`
-from two shrikes, `LeucLeuc` from a dace and a crane. A colliding form is never
-*auto-generated*, but that only suppresses the generated copy: where one side
-of a pair curates the form, it still resolves, and to that side alone —
-`ChryPict` gives the turtle, `LaniColl` gives *Lanius collurio*. Only forms
-neither side curates are unresolvable (`CaniLupu`, `BalaMusc`). Where a
-colliding form had been chosen as a canonical prefix, the entry now uses its
-concatenated binomial instead — three entries did, in 3.42.0:
+**4+4 is not collision-free.** Three forms are derivable from two species
+each — `ChryPict` from both *Chrysemys picta* and *Chrysolophus pictus*,
+`LaniColl` from two shrikes, `LeucLeuc` from a dace and a crane. None is ever
+*auto-generated*, but that only suppresses the generated copy: each is curated
+by one side of its pair, so it still resolves, confidently and to that side
+alone — `ChryPict` gives the turtle, `LaniColl` gives *Lanius collurio*,
+`LeucLeuc` gives the crane. Issue #134 tracks whether they should instead be
+demoted to context-only. Two of the three are still the canonical prefix of
+their owner; the entries that had a *contested* form as their canonical prefix
+now use the concatenated binomial instead — three entries did, in 3.42.0:
 
 | species | was | now |
 |---|---|---|
@@ -526,8 +527,20 @@ binomial, and no third-token variant is generated. Subspecies are reached by
 their curated prefix (`Caba`) or by latin name.
 
 A 5+5 form (`HomoSapie`) existed up to 3.41.0 as a leftover of the pre-v3.12
-scheme. It was removed in 3.42.0: no bundled corpus name, and no record in the
-sibling `mhcseqs` dataset, ever used one. See issue #128.
+scheme, and was removed in 3.42.0: no bundled corpus name, and no species token
+in the sibling `mhcseqs` dataset, ever used one. See issue #128.
+
+**This is a breaking parse change.** 596 auto-generated 5+5 aliases stop
+resolving, and so do ten that had been curated by hand as `other prefixes`
+when the scheme was introduced:
+
+```
+MonopAlbus  GaviaGange  CaimaCroco  CaimaLatir  CaretCaret
+ChrysPicta  CasuaCasua  CyaniCaeru  PhasiColch  CycluCarin
+```
+
+Anything written with a 5+5 form should move to the concatenated binomial —
+`HomoSapie-A*02:01` becomes `HomoSapiens-A*02:01`.
 
 ### Where a prefix came from
 

--- a/README.md
+++ b/README.md
@@ -480,32 +480,65 @@ does not infer TAP membership from a regex or a shared gene-name pattern.
 ### Species prefix tiers
 
 As mhcgnomes supports more species, short prefix codes increasingly collide.
-Codes like `HLA`/`SLA`/`DLA`, `OrLA`, and four-letter codes like `Calu` all
-hit collisions as coverage grows. We support multiple prefix tiers so that
-every species is always parseable:
+Codes like `HLA`/`SLA`/`DLA`, `OrLA`, and four-letter codes like `Calu` all hit
+collisions as coverage grows. Three forms are supported so that every species
+is always reachable:
 
 | Tier | Form | Example | When used |
 | --- | --- | --- | --- |
 | Established short prefix | 1–4 letters | `HLA`, `Gaga`, `Crpo` | Published in MHC literature or IPD-MHC. Preferred for display. |
-| Novel 4+4 prefix | First 4 of genus + first 4 of species | `OryzLati`, `StruCame` | Standard display prefix for species without an established literature prefix. |
-| 5+5 long prefix | First 5 of genus + first 5 of species | `HomoSapie`, `OryziLatip` | Auto-generated alias for all binomial species. Always parseable. |
-| Full latin name | Concatenated genus + species | `HomoSapiens`, `ChrysemysPicta` | Always parseable as an alternative. Guaranteed collision-free. |
+| Full latin name | Concatenated genus + species | `HomoSapiens`, `ChrysemysPicta` | The default generated form. Collision-free across every binomial in the ontology. |
+| 4+4 shorthand | First 4 of genus + first 4 of species | `TachAcul`, `AbraBram` | Compact shorthand, and the curated prefix of most species without a literature code. Emitted as an alias only where globally unique. |
 
-All tiers are parsed case-insensitively. For example, these all parse to the
-same allele:
+All are parsed case-insensitively. These all resolve to the same allele:
 
 ```
 HLA-A*02:01          # established prefix
-HomoSapi-A*02:01     # 4+4 novel prefix (auto-generated alias)
-HomoSapie-A*02:01    # 5+5 long prefix (auto-generated alias)
 HomoSapiens-A*02:01  # full latin name
+HomoSapi-A*02:01     # 4+4 shorthand (auto-generated alias)
 Homo sapiens-A*02:01 # latin name with space
 ```
 
-The 8-letter (4+4) novel prefix space greatly reduces collision probability compared to
-4-letter codes, but only the full latin name is truly guaranteed to be unique.
-Since we don't yet know what naming conventions the scientific community will
-settle on for newer taxa, we support all tiers simultaneously.
+Two limits are worth knowing:
+
+**4+4 is not collision-free.** Five forms are derivable from two entries each —
+`ChryPict` from both *Chrysemys picta* and *Chrysolophus pictus*, `LaniColl`
+from two shrikes, `LeucLeuc` from a dace and a crane. A colliding form is never
+emitted as a global alias, and where one was previously chosen as a canonical
+prefix the entry now uses its concatenated binomial instead.
+
+**Subspecies mint no generated alias.** A trinomial entry such as *Canis lupus
+baileyi* deliberately does not claim `CanisLupus`, which belongs to its parent
+binomial, and no third-token variant is generated. Subspecies are reached by
+their curated prefix (`Caba`) or by latin name.
+
+A 5+5 form (`HomoSapie`) existed up to 3.41.0 as a leftover of the pre-v3.12
+scheme. It was removed in 3.42.0: no bundled corpus name, and no record in the
+sibling `mhcseqs` dataset, ever used one. See issue #128.
+
+### Where a prefix came from
+
+`Species.prefix_provenance` says how an entry came by its prefix:
+
+| value | meaning |
+| --- | --- |
+| `"designated"` | Published nomenclature — IPD-MHC or IMGT/HLA writes alleles with it. Curated with a source in `species.yaml`; never inferred. |
+| `"generated"` | mhcgnomes derived it from the latin name. Provable by re-deriving it. |
+| `"group label"` | Names a grouping rather than a species, and is never written on an allele: `Aves`, `Galliformes`, `NHP`. |
+| `None` | Not established. |
+
+```python
+>>> Species.get("HLA").prefix_provenance
+'designated'
+>>> Species.get("TachAcul").prefix_provenance
+'generated'
+>>> Species.get("NHP").prefix_provenance
+'group label'
+```
+
+`None` is deliberately distinct from `"designated"`: a prefix mhcgnomes did not
+generate is not thereby proven to be in published use. Most short prefixes are
+still unchecked — see issue #131.
 
 **Which prefixes are established vs generated:** Comments in `species.yaml`
 document which prefixes are attested in MHC literature and which were generated

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -377,7 +377,7 @@ rationale.
 | `Orla` / `OrLA` | *Pongo sp.* (orangutan) / *Oryzias latipes* (medaka) and several killifish | Orangutan keeps `OrLA`; fish use long canonical prefixes, and `species=` can rescue source-side `Orla` strings | |
 | `Gaga` | *Gallus gallus* (chicken) / *Gavialis gangeticus* (gharial) | Chicken keeps `Gaga` ([IPD-MHC chicken](https://www.ebi.ac.uk/ipd/mhc/group/CHICKEN/)); gharial uses `GaviGang` | |
 | `Cyca` | *Cyprinus carpio* (carp) / *Cyclura carinata* (iguana) / *Cyanistes caeruleus* (blue tit) | Carp keeps `Cyca`; iguana uses `CyclCari`; blue tit uses `CyanCaer` | All three attested in literature: carp in [IPD-MHC](https://www.ebi.ac.uk/ipd/mhc/), iguana in Glaberman et al., blue tit in Westerdahl et al. |
-| `Chpi` | *Chrysolophus pictus* (golden pheasant) / *Chrysemys picta* (painted turtle) | Pheasant keeps `Chpi`; turtle uses `ChryPict` | |
+| `Chpi` | *Chrysolophus pictus* (golden pheasant) / *Chrysemys picta* (painted turtle) | Pheasant keeps `Chpi`; turtle uses `ChrysemysPicta` since 3.42.0, with `ChryPict` kept as an alias | |
 
 #### Low-risk collisions
 
@@ -402,9 +402,13 @@ in the README.
 
 The 4+4 space is not collision-free: `ChryPict` derives from both *Chrysemys
 picta* and *Chrysolophus pictus*, `LaniColl` from two shrikes, `LeucLeuc` from
-a dace and a crane. Colliding forms are never emitted as global aliases, and
-where one had been picked as a canonical prefix the entry now carries its
-concatenated binomial instead -- which also retired two tie-breaks (`LaniCola`,
+a dace and a crane. A colliding form is never *auto-generated* as an alias, but
+that only suppresses the generated copy -- where one side of a pair curates the
+form as its prefix or as an `other prefixes` entry, it still resolves globally
+and to that side alone. `ChryPict` resolves to the turtle, `LaniColl` to
+*Lanius collurio*, `LeucLeuc` to the crane. Where a colliding form had been
+picked as a canonical prefix the entry now carries its concatenated binomial
+instead -- which also retired two tie-breaks (`LaniCola`,
 `LeucisLeucis`) that belonged to no documented form. The concatenated binomial
 is the default generated alias, and is the only form with no collisions
 anywhere in the ontology.

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -185,11 +185,14 @@ wherever it can be -- exactly one parent link in the ontology points at another
 genus's node -- and it is what the rest of the entry is inherited along.
 
 An umbrella MHC prefix covers everything beneath the node that owns it. The
-loader hands a parent's prefix down to a child as its `old prefix` when the
-parent's prefix is an MHC prefix rather than its own taxon name (`BoLA`, `DLA`,
-`RhLA` are inherited; `Aves`, `Rodentia`, `Primata` are not) and the child does
-not declare an `old prefix` of its own. Note this is the *immediate* parent:
-`Macaca mulatta` inherits `RhLA` from `Macaca sp.`, not `NHP` from further up.
+loader hands a parent's prefix down to a child as its `old prefix` unless the
+parent is a group entry labelled with its own taxon name -- `Aves sp.` with
+`Aves`, `NHP` with `NHP`. Designations are inherited (`BoLA`, `DLA`, `RhLA`),
+and so are decorated group labels that are not simply the taxon (`Mus sp.` with
+`MusSp`). The child must also not declare an `old prefix` of its own. Note this
+is the *immediate* parent: `Macaca mulatta` inherits `RhLA` from `Macaca sp.`,
+not `NHP` from further up. A single species is never treated as a taxon label,
+so a subspecies parented under `Bubo bubo` inherits `BuboBubo`.
 
 Because every prefix owns a node, "is X inside taxon Y?" and "can Y's prefix
 name X?" are the same ancestry question, and one predicate answers both.
@@ -405,13 +408,16 @@ picta* and *Chrysolophus pictus*, `LaniColl` from two shrikes, `LeucLeuc` from
 a dace and a crane. A colliding form is never *auto-generated* as an alias, but
 that only suppresses the generated copy -- where one side of a pair curates the
 form as its prefix or as an `other prefixes` entry, it still resolves globally
-and to that side alone. `ChryPict` resolves to the turtle, `LaniColl` to
-*Lanius collurio*, `LeucLeuc` to the crane. Where a colliding form had been
-picked as a canonical prefix the entry now carries its concatenated binomial
-instead -- which also retired two tie-breaks (`LaniCola`,
-`LeucisLeucis`) that belonged to no documented form. The concatenated binomial
-is the default generated alias, and is the only form with no collisions
-anywhere in the ontology.
+and to that side alone -- confidently, which issue #134 tracks. `ChryPict`
+resolves to the turtle, `LaniColl` to *Lanius collurio*, `LeucLeuc` to the
+crane; two of the three are still their owner's canonical prefix.
+
+The entries that had a *contested* form as their canonical prefix now carry the
+concatenated binomial instead, which also demoted two tie-breaks belonging to
+no documented form -- `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a
+6+6). Both are kept in `other prefixes` and still resolve; only their status as
+canonical changed. The concatenated binomial is the default generated alias,
+and is the only form with no collisions anywhere in the ontology.
 
 `Species.prefix_provenance` records how an entry came by its prefix:
 `"designated"` (published nomenclature, curated with a source), `"generated"`

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -394,11 +394,28 @@ and blue tit by different research groups).
 
 The [species identity model](species-latin-name-scoping.md) now uses latin
 names as canonical identity (see `Species.latin_name`,
-`Species.get_by_latin_name()`). Every species is also parseable via its full
-concatenated latin name (e.g., `HomoSapiens-A*02:01`) and a 4+4 truncated
-form (e.g., `HomoSapi-A*02:01`). See the
+`Species.get_by_latin_name()`). Every binomial species is also parseable via
+its full concatenated latin name (e.g., `HomoSapiens-A*02:01`) and, where the
+form is globally unique, a 4+4 truncation (e.g., `HomoSapi-A*02:01`). See the
 [prefix tier documentation](https://github.com/pirl-unc/mhcgnomes/blob/main/README.md#species-prefix-tiers)
 in the README.
+
+The 4+4 space is not collision-free: `ChryPict` derives from both *Chrysemys
+picta* and *Chrysolophus pictus*, `LaniColl` from two shrikes, `LeucLeuc` from
+a dace and a crane. Colliding forms are never emitted as global aliases, and
+where one had been picked as a canonical prefix the entry now carries its
+concatenated binomial instead -- which also retired two tie-breaks (`LaniCola`,
+`LeucisLeucis`) that belonged to no documented form. The concatenated binomial
+is the default generated alias, and is the only form with no collisions
+anywhere in the ontology.
+
+`Species.prefix_provenance` records how an entry came by its prefix:
+`"designated"` (published nomenclature, curated with a source), `"generated"`
+(mhcgnomes derived it from the latin name), `"group label"` (`Aves`, `NHP` --
+names a grouping, never written on an allele), or `None` for not established.
+Only the last three are ever inferred; `"designated"` must be curated, because
+a prefix we did not generate is not thereby proven to be in use -- see the
+`Caau` case in `AGENTS.md`.
 
 ### Current special cases
 

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -432,6 +432,8 @@ Crocodylia sp.:
 # - http://www.imgt.org/IMGTrepertoireMHC/LocusGenes/nomenclatures/human/MHC/human_MHCnom.html
 ######################################################
 Homo sapiens:
+  # prefix source: designated -- IMGT/HLA names every human allele with it: https://hla.alleles.org/genes/index.html
+  prefix source: designated
   prefix: HLA
   # NCBI Taxonomy places Homo sapiens (taxid 9606) in Primates (taxid 9443),
   # https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606 -- so the
@@ -776,6 +778,8 @@ Mus saxicola:
 #
 ######################################################
 Rattus sp.:
+  # prefix source: designated -- IPD-MHC RT1 group
+  prefix source: designated
   prefix: RT1
   name: Rat
   genes:
@@ -935,6 +939,8 @@ Lycaon pictus:
   name: African wild dog
 Canis sp.:
   parent: Canidae sp.
+  # prefix source: designated -- IPD-MHC DLA group
+  prefix source: designated
   prefix: DLA
   name: Canine
   genes:
@@ -1380,8 +1386,6 @@ Monopterus albus:
   # Motacilla alba. Keep Moal as a context-only rescue alias for species=
   # and use MonoAlbu as the collision-free runtime prefix.
   prefix: MonoAlbu
-  other prefixes:
-    - MonopAlbus
   context only prefixes:
     - Moal
   name: Asian swamp eel
@@ -1774,7 +1778,13 @@ Ladigesocypris ghigii:
   name: Rhodes minnow
 Leuciscus leuciscus:
   parent: Cyprinidae sp.
-  prefix: LeucisLeucis
+  # 'LeucisLeucis' was a 6+6 tie-break against Leucogeranus leucogeranus, the
+  # Siberian crane, which derives the same 4+4 form 'LeucLeuc'. A 6+6 is not
+  # any documented prefix form, so the canonical prefix is the concatenated
+  # binomial and the old spelling stays parseable. See #128.
+  prefix: LeuciscusLeuciscus
+  other prefixes:
+    - LeucisLeucis
   name: Common dace
 Squalius cephalus:
   parent: Cyprinidae sp.
@@ -2005,8 +2015,6 @@ Gavialis gangeticus:
   parent: Crocodylia sp.
   # Natural 4-letter prefix Gaga collides with chicken (Gallus gallus).
   prefix: GaviGang
-  other prefixes:
-    - GaviaGange
   name: Gharial
 Crocodylus moreletii:
   parent: Crocodylia sp.
@@ -2047,14 +2055,10 @@ Osteolaemus tetraspis:
 Caiman crocodilus:
   parent: Crocodylia sp.
   prefix: CaimCroc
-  other prefixes:
-    - CaimaCroco
   name: Spectacled caiman
 Caiman latirostris:
   parent: Crocodylia sp.
   prefix: CaimLati
-  other prefixes:
-    - CaimaLatir
   name: Broad-snouted caiman
 Crocodylus acutus:
   parent: Crocodylia sp.
@@ -2121,8 +2125,6 @@ Testudines sp.:
 Caretta caretta:
   parent: Testudines sp.
   prefix: CareCare
-  other prefixes:
-    - CaretCaret
   name: Loggerhead sea turtle
 Chelonia mydas:
   parent: Testudines sp.
@@ -2150,10 +2152,14 @@ Chelydra serpentina:
   name: Common snapping turtle
 Chrysemys picta:
   parent: Testudines sp.
-  # Natural 4-letter prefix Chpi collides with golden pheasant.
-  prefix: ChryPict
+  # The natural 4-letter prefix Chpi belongs to the golden pheasant, and the
+  # 4+4 form ChryPict is derived by the same rule from both this species and
+  # Chrysolophus pictus, so it is not a safe canonical prefix for either. The
+  # pheasant keeps Chpi; the turtle takes the concatenated binomial, which
+  # collides with nothing. ChryPict stays parseable. See #128.
+  prefix: ChrysemysPicta
   other prefixes:
-    - ChrysPicta
+    - ChryPict
   name: Painted turtle
 Pelodiscus sinensis:
   parent: Testudines sp.
@@ -2247,8 +2253,6 @@ Casuarius casuarius:
   # Natural 4-letter prefix Caca collides with Caretta caretta and others.
   # Using long prefix as display.
   prefix: CasuCasu
-  other prefixes:
-    - CasuaCasua
   name: Southern cassowary
 Nothoprocta perdicaria:
   parent: Aves sp.
@@ -2308,6 +2312,8 @@ Chiloscyllium plagiosum:
 ##############################################
 Ovis sp.:
   name: Sheep
+  # prefix source: designated -- IPD-MHC OLA group
+  prefix source: designated
   prefix: OLA
   genes:
     Ia:
@@ -2345,6 +2351,8 @@ Ovis canadensis:
 #   https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3658703/
 ################################################################################
 Bos sp.:
+  # prefix source: designated -- IPD-MHC BoLA group; alleles are written BoLA-DRB3*011:01
+  prefix source: designated
   prefix: BoLA
   name: Cattle
   genes:
@@ -2467,6 +2475,8 @@ Bubalus bubalis:
 #
 ################################################################################
 Cetacea sp.:
+  # prefix source: designated -- IPD-MHC CeLA group
+  prefix source: designated
   prefix: CELA
   name:
     - Cetacean
@@ -2665,6 +2675,8 @@ Physeter macrocephalus:
 #
 ################################################################################
 Capra sp.:
+  # prefix source: designated -- IPD-MHC CLA group
+  prefix source: designated
   prefix: CLA
   name: Goat
   genes:
@@ -2687,6 +2699,8 @@ Capra hircus:
 # - https://www.ebi.ac.uk/ipd/mhc/group/ELA/species
 ################################################################################
 Equus sp.:
+  # prefix source: designated -- IPD-MHC ELA group
+  prefix source: designated
   prefix: ELA
   name: Equine
   genes:
@@ -2755,6 +2769,8 @@ Phacochoerus africanus:
   name: Common warthog
 Sus sp.:
   parent: Suidae sp.
+  # prefix source: designated -- IPD-MHC SLA group
+  prefix source: designated
   prefix: SLA
   name:
     - Pig
@@ -3421,8 +3437,6 @@ Cyanistes caeruleus:
   # Natural prefix Cyca collides with Cyprinus carpio (carp).
   # Cyca for blue tit attested in Westerdahl et al.; Cyca for carp in fish MHC literature.
   prefix: CyanCaer
-  other prefixes:
-    - CyaniCaeru
   name: Blue tit
 Corvus cornix:
   parent: Aves sp.
@@ -3861,7 +3875,13 @@ Haliaeetus albicilla:
   name: White-tailed eagle
 Lanius collaris:
   parent: Aves sp.
-  prefix: LaniCola
+  # 'LaniCola' was a hand-made tie-break, because this species and Lanius
+  # collurio both derive the 4+4 form 'LaniColl'. It is not any documented
+  # prefix form, so the canonical prefix is the concatenated binomial and the
+  # old spelling stays parseable. See #128.
+  prefix: LaniusCollaris
+  other prefixes:
+    - LaniCola
   name: Fiscal shrike
 Lanius senator:
   parent: Aves sp.
@@ -3913,8 +3933,6 @@ Phasianus colchicus:
   # Phco collides with Phylloscopus collybita in some datasets.
   # Using 5+5 for display prefix.
   prefix: PhasColc
-  other prefixes:
-    - PhasiColch
   name: Common pheasant
 Tympanuchus cupido:
   parent: Galliformes sp.
@@ -4955,6 +4973,8 @@ Macaca sp.:
     G: {pseudogene: true}
 Macaca mulatta:
   parent: Macaca sp.
+  # prefix source: designated -- IPD-MHC NHP nomenclature page gives Mamu as a worked example of the 2+2 rule
+  prefix source: designated
   prefix: Mamu
   name:
     - Rhesus monkey
@@ -5100,6 +5120,8 @@ Pan sp.:
         - DRB7
 Pan troglodytes:
   parent: Pan sp.
+  # prefix source: designated -- https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature: "MhcPatr defines the MHC system of the common chimpanzee"
+  prefix source: designated
   prefix: Patr
   other prefixes:
     - Ptr
@@ -5650,8 +5672,6 @@ Cyclura carinata:
   # Natural prefix Cyca collides with Cyprinus carpio (carp).
   # Attested in literature (Glaberman et al. iguana MHC studies).
   prefix: CyclCari
-  other prefixes:
-    - CycluCarin
   name: Turks and Caicos rock iguana
 Anolis carolinensis:
   parent: Reptilia sp.

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -778,7 +778,8 @@ Mus saxicola:
 #
 ######################################################
 Rattus sp.:
-  # prefix source: designated -- IPD-MHC RT1 group
+  # prefix source: designated -- listed as an IPD-MHC group, which files rat
+  # alleles under it: https://www.ebi.ac.uk/ipd/mhc/group/RT1/species
   prefix source: designated
   prefix: RT1
   name: Rat
@@ -939,7 +940,8 @@ Lycaon pictus:
   name: African wild dog
 Canis sp.:
   parent: Canidae sp.
-  # prefix source: designated -- IPD-MHC DLA group
+  # prefix source: designated -- listed as an IPD-MHC group, which files dog
+  # alleles under it: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
   prefix source: designated
   prefix: DLA
   name: Canine
@@ -1381,7 +1383,7 @@ Scophthalmus maximus:
   name: Turbot
 Monopterus albus:
   parent: Actinopterygii sp.
-  # mhcseqs report lists prefix as "Mhc" which collides; using 5+5.
+  # mhcseqs reports the prefix as "Mhc", which collides; using the 4+4 form.
   # UniProt-derived records reuse Moal-* for both Monopterus albus and
   # Motacilla alba. Keep Moal as a context-only rescue alias for species=
   # and use MonoAlbu as the collision-free runtime prefix.
@@ -2312,7 +2314,8 @@ Chiloscyllium plagiosum:
 ##############################################
 Ovis sp.:
   name: Sheep
-  # prefix source: designated -- IPD-MHC OLA group
+  # prefix source: designated -- listed as an IPD-MHC group, which files sheep
+  # alleles under it: https://www.ebi.ac.uk/ipd/mhc/group/OLA/species
   prefix source: designated
   prefix: OLA
   genes:
@@ -2351,7 +2354,9 @@ Ovis canadensis:
 #   https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3658703/
 ################################################################################
 Bos sp.:
-  # prefix source: designated -- IPD-MHC BoLA group; alleles are written BoLA-DRB3*011:01
+  # prefix source: designated -- an IPD-MHC group, and alleles are written with
+  # it (BoLA-DRB3*011:01, PMID 22383896):
+  # https://www.ebi.ac.uk/ipd/mhc/group/BoLA/species
   prefix source: designated
   prefix: BoLA
   name: Cattle
@@ -2475,7 +2480,9 @@ Bubalus bubalis:
 #
 ################################################################################
 Cetacea sp.:
-  # prefix source: designated -- IPD-MHC CeLA group
+  # prefix source: designated -- an IPD-MHC group, spelled CeLA there while the
+  # runtime prefix and published allele names use CELA:
+  # https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
   prefix source: designated
   prefix: CELA
   name:
@@ -2675,7 +2682,9 @@ Physeter macrocephalus:
 #
 ################################################################################
 Capra sp.:
-  # prefix source: designated -- IPD-MHC CLA group
+  # prefix source: designated -- listed as an IPD-MHC group, which files goat
+  # alleles under it: https://www.ebi.ac.uk/ipd/mhc/group/CLA/species
+  # (CLA is goat, not cat -- a page summary once reported otherwise, see AGENTS.md)
   prefix source: designated
   prefix: CLA
   name: Goat
@@ -2699,7 +2708,8 @@ Capra hircus:
 # - https://www.ebi.ac.uk/ipd/mhc/group/ELA/species
 ################################################################################
 Equus sp.:
-  # prefix source: designated -- IPD-MHC ELA group
+  # prefix source: designated -- listed as an IPD-MHC group, which files horse
+  # alleles under it: https://www.ebi.ac.uk/ipd/mhc/group/ELA/species
   prefix source: designated
   prefix: ELA
   name: Equine
@@ -2769,7 +2779,8 @@ Phacochoerus africanus:
   name: Common warthog
 Sus sp.:
   parent: Suidae sp.
-  # prefix source: designated -- IPD-MHC SLA group
+  # prefix source: designated -- listed as an IPD-MHC group, which files pig
+  # alleles under it: https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
   prefix source: designated
   prefix: SLA
   name:
@@ -3931,7 +3942,7 @@ Pavo cristatus:
 Phasianus colchicus:
   parent: Galliformes sp.
   # Phco collides with Phylloscopus collybita in some datasets.
-  # Using 5+5 for display prefix.
+  # Using the 4+4 form for the display prefix.
   prefix: PhasColc
   name: Common pheasant
 Tympanuchus cupido:
@@ -4973,7 +4984,9 @@ Macaca sp.:
     G: {pseudogene: true}
 Macaca mulatta:
   parent: Macaca sp.
-  # prefix source: designated -- IPD-MHC NHP nomenclature page gives Mamu as a worked example of the 2+2 rule
+  # prefix source: designated -- the IPD-MHC NHP nomenclature page uses Mamu as a
+  # worked example of the 2+2 rule and links Mamu allele listings:
+  # https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature
   prefix source: designated
   prefix: Mamu
   name:
@@ -5120,7 +5133,9 @@ Pan sp.:
         - DRB7
 Pan troglodytes:
   parent: Pan sp.
-  # prefix source: designated -- https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature: "MhcPatr defines the MHC system of the common chimpanzee"
+  # prefix source: designated -- https://www.ebi.ac.uk/ipd/mhc/group/NHP/nomenclature
+  # states verbatim: "MhcPatr defines the MHC system of the common chimpanzee
+  # (Pan troglodytes)".
   prefix source: designated
   prefix: Patr
   other prefixes:

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -148,6 +148,7 @@ class Species(Result):
     other_mhc_prefixes: Any = None
     context_only_mhc_prefixes: Any = None
     other_common_names: Any = None
+    prefix_provenance: Union[str, None] = None
 
     def __init__(
         self,
@@ -171,6 +172,7 @@ class Species(Result):
         other_mhc_prefixes: Iterable[str] = [],
         context_only_mhc_prefixes: Iterable[str] = [],
         other_common_names: Iterable[str] = [],
+        prefix_provenance: Union[str, None] = None,
         raw_string: Union[str, None] = None,
         gene_name_to_properties: Union[Mapping[str, Mapping[str, Any]], None] = None,
         gene_family_name_to_gene_names: Union[Mapping[str, Iterable[str]], None] = None,
@@ -214,6 +216,7 @@ class Species(Result):
             "context_only_mhc_prefixes",
             FrozenSet(context_only_mhc_prefixes),
         )
+        self._set_field(self, "prefix_provenance", prefix_provenance)
         if old_mhc_prefix:
             normalized_old_mhc_prefix = old_mhc_prefix
         else:
@@ -840,19 +843,6 @@ def _make_long_prefix(latin_name):
     return genus.capitalize() + species.capitalize()
 
 
-def _make_5_5_prefix(latin_name):
-    """
-    Generate a 5+5 long prefix from a latin binomial name by taking the first
-    5 characters of each word, capitalized. Kept for backward compatibility.
-    """
-    parts = _scientific_name_parts(latin_name)
-    if len(parts) < 2:
-        return None
-    genus = parts[0][:5]
-    species = parts[1][:5]
-    return genus.capitalize() + species.capitalize()
-
-
 def _make_full_scientific_prefix(latin_name):
     """
     Generate a collision-resistant scientific-name alias from the canonical
@@ -876,32 +866,37 @@ def _make_generated_alias_counts(generator):
 
 
 _GENERATED_LONG_PREFIX_COUNTS = _make_generated_alias_counts(_make_long_prefix)
-_GENERATED_5_5_PREFIX_COUNTS = _make_generated_alias_counts(_make_5_5_prefix)
 
 
 def _auto_generated_prefixes_for_latin_name(latin_name):
     """
-    Auto-generated aliases are useful compatibility shorthands, but only the
-    collision-free truncated forms should be globally parseable. The fully
-    concatenated scientific name remains the unambiguous fallback.
+    The concatenated scientific name comes first: it is the default, and the
+    only form that never collides. The 4+4 truncation follows as a shorthand,
+    and only where it is globally unique.
+
+    The 5+5 form ("HomoSapie") was removed in 3.42.0. It was a leftover of the
+    pre-v3.12 scheme that 4cd6045 replaced, its own docstring described it as
+    kept for backward compatibility, docs/curation.md never listed it, and no
+    name in the bundled corpora or in the sibling mhcseqs dataset used one.
     """
     results = []
 
-    long_prefix = _make_long_prefix(latin_name)
-    if long_prefix and _GENERATED_LONG_PREFIX_COUNTS[long_prefix] == 1:
-        results.append(long_prefix)
-
-    compat_prefix = _make_5_5_prefix(latin_name)
-    if compat_prefix and _GENERATED_5_5_PREFIX_COUNTS[compat_prefix] == 1:
-        results.append(compat_prefix)
-
-    # Concatenated scientific-name aliases are only added for modeled
-    # binomials. Trinomial/subspecies entries should collapse to the binomial
-    # runtime alias rather than minting a third-token variant.
+    # The concatenated scientific name is the default generated alias: it is
+    # the only form with no collisions anywhere in the ontology. Added only for
+    # modeled binomials -- trinomial/subspecies entries mint no generated alias
+    # and are reached by their curated prefix or latin name.
     scientific_parts = _scientific_name_parts(latin_name)
     full_prefix = _make_full_scientific_prefix(latin_name)
     if full_prefix and len(scientific_parts) == 2:
         results.append(full_prefix)
+
+    # The 4+4 truncation is kept because it is the curated prefix of 467
+    # entries, but only where it is globally unique. It is a shorthand, not the
+    # default: 4+4 collides (ChryPict is both a painted turtle and a golden
+    # pheasant) and the ties have been broken with off-book forms.
+    long_prefix = _make_long_prefix(latin_name)
+    if long_prefix and _GENERATED_LONG_PREFIX_COUNTS[long_prefix] == 1:
+        results.append(long_prefix)
 
     deduped = []
     seen = set()
@@ -948,10 +943,21 @@ def _decorated_scientific_name_candidates(name):
     return candidates
 
 
-def _is_taxonomic_prefix(prefix, latin_name):
+def _prefix_is_derived_from_name(prefix, latin_name):
     """
-    Taxonomic helper prefixes like "Galliformes" or "Crocodylia" should not
-    become inherited old MHC prefixes for child species.
+    Is this entry's prefix just a normalization of its own name?
+
+    Used to decide whether a group node hands its prefix down to descendants.
+    "Galliformes sp." carries the prefix "Galliformes" and "NHP" carries "NHP";
+    neither is a published designation, so neither becomes a child's inherited
+    old MHC prefix. "Bos sp." carries "BoLA", which is not derived from the
+    name and is a real designation, so Bos taurus inherits it.
+
+    Note what this does NOT establish. It is a string test, not a claim about
+    nomenclature: "NHP" passes it and is a paraphyletic database section rather
+    than a taxon, and a species whose curated prefix happens to equal its own
+    concatenated binomial ("Bubo bubo" -> "BuboBubo") would pass it too. That
+    second case is why group_node is required -- see the caller.
     """
     normalized_prefix = re.sub(r"[^A-Za-z0-9]+", "", prefix).lower()
     latin_parts = [part for part in latin_name.split() if part.lower() != "sp."]
@@ -960,6 +966,47 @@ def _is_taxonomic_prefix(prefix, latin_name):
     normalized_first = re.sub(r"[^A-Za-z0-9]+", "", latin_parts[0]).lower()
     normalized_concat = "".join(re.sub(r"[^A-Za-z0-9]+", "", part).lower() for part in latin_parts)
     return normalized_prefix in {normalized_first, normalized_concat}
+
+
+def _is_group_entry(latin_name):
+    """
+    Does this entry stand for a group of species rather than one species?
+
+    Group entries are written "<taxon> sp." -- plus "NHP", which is IPD-MHC's
+    section for non-human primates and is not a taxon at all (see #122). Only
+    these hand a prefix down, which is what stops a tautonym such as
+    "Bubo bubo" (prefix "BuboBubo") from being mistaken for an umbrella.
+    """
+    return latin_name.endswith(" sp.") or latin_name == "NHP"
+
+
+# How an entry came by its prefix. "designated" means it is published
+# nomenclature -- IPD-MHC or IMGT/HLA writes alleles with it. "generated" means
+# mhcgnomes derived it from the latin name. "group label" means it names a
+# grouping rather than a species and is never written on an allele. None means
+# nobody has established which, and that is deliberately distinguishable from
+# "designated": a prefix that mhcgnomes did not generate is not thereby proven
+# to be in published use. See issue #128 and the Caau case in AGENTS.md.
+PREFIX_PROVENANCE_VALUES = frozenset({"designated", "generated", "group label"})
+
+
+def _derive_prefix_provenance(prefix, latin_name):
+    """
+    What can be established about a prefix without consulting a source.
+
+    Only two answers are provable by derivation: a group entry whose prefix is
+    its own name is a label, and a prefix reproduced exactly by one of the
+    generators is one we minted. Everything else returns None so that a curator
+    has to look it up rather than inherit a guess.
+    """
+    if _is_group_entry(latin_name) and _prefix_is_derived_from_name(prefix, latin_name):
+        return "group label"
+    normalized = prefix.lower()
+    for generator in (_make_full_scientific_prefix, _make_long_prefix):
+        generated = generator(latin_name)
+        if generated and generated.lower() == normalized:
+            return "generated"
+    return None
 
 
 _EMPTY_GENE_NAMES = NormalizingSet()
@@ -988,10 +1035,22 @@ def create_species_for_latin_name(latin_name):
     if not prefix:
         raise ValueError(f"Missing 'prefix' for '{latin_name}' in species ontology")
 
+    prefix_provenance = species_info.get("prefix source")
+    if prefix_provenance is not None and prefix_provenance not in PREFIX_PROVENANCE_VALUES:
+        raise ValueError(
+            f"'prefix source' of '{latin_name}' is {prefix_provenance!r}, "
+            f"expected one of {sorted(PREFIX_PROVENANCE_VALUES)}"
+        )
+    if prefix_provenance is None:
+        prefix_provenance = _derive_prefix_provenance(prefix, latin_name)
+
     old_mhc_prefix = species_info.get("old prefix")
     if not old_mhc_prefix and parent_species:
         parent_prefix = parent_species.prefix
-        if not _is_taxonomic_prefix(parent_prefix, parent_species.name):
+        if not (
+            _is_group_entry(parent_species.name)
+            and _prefix_is_derived_from_name(parent_prefix, parent_species.name)
+        ):
             old_mhc_prefix = parent_prefix
 
     other_mhc_prefixes = species_info.get("other prefixes")
@@ -1219,6 +1278,7 @@ def create_species_for_latin_name(latin_name):
         other_mhc_prefixes=other_mhc_prefixes,
         context_only_mhc_prefixes=context_only_mhc_prefixes,
         other_common_names=[name for name in common_names if name != shortest_common_name],
+        prefix_provenance=prefix_provenance,
         raw_string=latin_name,
     )
 

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -865,7 +865,18 @@ def _make_generated_alias_counts(generator):
     return counts
 
 
-_GENERATED_LONG_PREFIX_COUNTS = _make_generated_alias_counts(_make_long_prefix)
+def _long_prefix_if_claimable(latin_name):
+    """
+    The 4+4 form only where the entry is allowed to claim it. Trinomials are
+    excluded, so a subspecies does not veto its parent binomial's shorthand by
+    deriving the same string.
+    """
+    if len(_scientific_name_parts(latin_name)) != 2:
+        return None
+    return _make_long_prefix(latin_name)
+
+
+_GENERATED_LONG_PREFIX_COUNTS = _make_generated_alias_counts(_long_prefix_if_claimable)
 
 
 def _auto_generated_prefixes_for_latin_name(latin_name):
@@ -951,6 +962,11 @@ def _decorated_scientific_name_candidates(name):
     return candidates
 
 
+def _normalize_identifier(value):
+    """Strip punctuation and case so two spellings of a prefix compare equal."""
+    return re.sub(r"[^A-Za-z0-9]+", "", value).lower()
+
+
 def _prefix_is_derived_from_name(prefix, latin_name):
     """
     Is this entry's prefix just a normalization of its own name?
@@ -967,13 +983,13 @@ def _prefix_is_derived_from_name(prefix, latin_name):
     concatenated binomial ("Bubo bubo" -> "BuboBubo") would pass it too. That
     second case is why _is_group_entry is required -- see the caller.
     """
-    normalized_prefix = re.sub(r"[^A-Za-z0-9]+", "", prefix).lower()
     latin_parts = [part for part in latin_name.split() if part.lower() != "sp."]
     if not latin_parts:
         return False
-    normalized_first = re.sub(r"[^A-Za-z0-9]+", "", latin_parts[0]).lower()
-    normalized_concat = "".join(re.sub(r"[^A-Za-z0-9]+", "", part).lower() for part in latin_parts)
-    return normalized_prefix in {normalized_first, normalized_concat}
+    return _normalize_identifier(prefix) in {
+        _normalize_identifier(latin_parts[0]),
+        "".join(_normalize_identifier(part) for part in latin_parts),
+    }
 
 
 def _is_group_entry(latin_name):
@@ -998,58 +1014,41 @@ def _is_group_entry(latin_name):
 PREFIX_PROVENANCE_VALUES = frozenset({"designated", "generated", "group label"})
 
 
-def _prefix_is_a_group_label(prefix, latin_name):
-    """
-    Is this group entry's prefix a made-up label for the group itself?
-
-    Covers the plain case, where the prefix is the taxon name ("Aves sp." with
-    "Aves"), and the decorated ones minted for group nodes: a 2+2 reading that
-    treats "sp." as the epithet ("Coregonus sp." -> "Cosp"), a genus truncation
-    ("Manacus sp." -> "Mana"), and the taxon with "Sp" appended ("Mus sp." ->
-    "MusSp"). None of these is ever written on an allele, so they are labels
-    rather than unchecked designations. Real umbrella designations are unlike
-    the name they sit on -- "Bos sp." carries "BoLA", "Felis sp." carries "FLA".
-    """
-    if not _is_group_entry(latin_name):
-        return False
-    if _prefix_is_derived_from_name(prefix, latin_name):
-        return True
-    taxon = latin_name[: -len(" sp.")] if latin_name.endswith(" sp.") else latin_name
-    taxon = re.sub(r"[^A-Za-z0-9]+", "", taxon).lower()
-    if not taxon:
-        return False
-    normalized = re.sub(r"[^A-Za-z0-9]+", "", prefix).lower()
-    return normalized in {taxon[:2] + "sp", taxon[:4], taxon + "sp"}
-
-
 def _is_inheritable_umbrella(prefix, latin_name):
     """
     Does this entry hand its prefix down to descendants as their old prefix?
 
-    True for a group entry carrying a real designation ("Bos sp." with "BoLA"),
-    false for one whose prefix is just its own name ("Aves sp." with "Aves"),
-    and false for any single species -- which is what stops a tautonym such as
-    "Bubo bubo" (prefix "BuboBubo") from acting as an umbrella.
+    True for anything carrying a prefix that is not simply its own name, which
+    covers real designations ("Bos sp." with "BoLA", "Mus sp." with "MusSp")
+    and every ordinary species. False only for a group entry labelled with its
+    own taxon: "Aves sp." with "Aves", "NHP" with "NHP".
+
+    The group-entry requirement is what fixes the tautonym case. "Bubo bubo"
+    carries "BuboBubo", which *is* derived from its name, but it is one species
+    rather than a grouping, so a subspecies parented under it should inherit
+    the prefix the way any other child does.
     """
-    return not _prefix_is_a_group_label(prefix, latin_name)
+    return not (_is_group_entry(latin_name) and _prefix_is_derived_from_name(prefix, latin_name))
 
 
 def _derive_prefix_provenance(prefix, latin_name):
     """
     What can be established about a prefix without consulting a source.
 
-    Only two answers are provable by derivation: a group entry whose prefix is
-    its own name is a label, and a prefix reproduced exactly by one of the
-    generators is one we minted. Everything else returns None so that a curator
-    has to look it up rather than inherit a guess.
+    Only two answers are provable: a group entry whose prefix is its own name is
+    a label, and a prefix this entry would actually be given by the alias
+    generator is one we minted. The second asks the emitter rather than the
+    generator functions, so a form the emitter declines -- a colliding 4+4, or
+    anything on a trinomial -- is not claimed as ours. Everything else returns
+    None so that a curator has to look it up rather than inherit a guess.
     """
-    if _prefix_is_a_group_label(prefix, latin_name):
+    if not _is_inheritable_umbrella(prefix, latin_name):
         return "group label"
     normalized = prefix.lower()
-    for generator in (_make_full_scientific_prefix, _make_long_prefix):
-        generated = generator(latin_name)
-        if generated and generated.lower() == normalized:
-            return "generated"
+    if any(
+        alias.lower() == normalized for alias in _auto_generated_prefixes_for_latin_name(latin_name)
+    ):
+        return "generated"
     return None
 
 
@@ -1066,6 +1065,9 @@ latin_name_to_own_gene_names = {}
 # silently, leaving the YAML asserting something the runtime never read.
 SPECIES_ENTRY_KEYS = frozenset(
     {
+        # "alias" and "haplotype prefix" are present in species.yaml but nothing
+        # reads them; they are listed so the file still loads, not because they
+        # do anything. See issue #136.
         "alias",
         "context only prefixes",
         "gene families",
@@ -1107,7 +1109,9 @@ def create_species_for_latin_name(latin_name):
         raise ValueError(f"Missing 'prefix' for '{latin_name}' in species ontology")
 
     prefix_provenance = species_info.get("prefix source")
-    if prefix_provenance is not None and prefix_provenance not in PREFIX_PROVENANCE_VALUES:
+    if prefix_provenance is not None and (
+        not isinstance(prefix_provenance, str) or prefix_provenance not in PREFIX_PROVENANCE_VALUES
+    ):
         raise ValueError(
             f"'prefix source' of '{latin_name}' is {prefix_provenance!r}, "
             f"expected one of {sorted(PREFIX_PROVENANCE_VALUES)}"

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -890,12 +890,20 @@ def _auto_generated_prefixes_for_latin_name(latin_name):
     if full_prefix and len(scientific_parts) == 2:
         results.append(full_prefix)
 
-    # The 4+4 truncation is kept because it is the curated prefix of 467
+    # The 4+4 truncation is kept because it is the curated prefix of 466
     # entries, but only where it is globally unique. It is a shorthand, not the
-    # default: 4+4 collides (ChryPict is both a painted turtle and a golden
-    # pheasant) and the ties have been broken with off-book forms.
+    # default: 4+4 collides (ChryPict is derivable from both a painted turtle
+    # and a golden pheasant) and the ties have been broken with off-book forms.
+    #
+    # Guarded on binomials for the same reason as the concatenated form: a
+    # trinomial's 4+4 is built from its parent's genus and species, so
+    # "Strix occidentalis caurina" would otherwise claim "StriOcci".
     long_prefix = _make_long_prefix(latin_name)
-    if long_prefix and _GENERATED_LONG_PREFIX_COUNTS[long_prefix] == 1:
+    if (
+        long_prefix
+        and len(scientific_parts) == 2
+        and _GENERATED_LONG_PREFIX_COUNTS[long_prefix] == 1
+    ):
         results.append(long_prefix)
 
     deduped = []
@@ -957,7 +965,7 @@ def _prefix_is_derived_from_name(prefix, latin_name):
     nomenclature: "NHP" passes it and is a paraphyletic database section rather
     than a taxon, and a species whose curated prefix happens to equal its own
     concatenated binomial ("Bubo bubo" -> "BuboBubo") would pass it too. That
-    second case is why group_node is required -- see the caller.
+    second case is why _is_group_entry is required -- see the caller.
     """
     normalized_prefix = re.sub(r"[^A-Za-z0-9]+", "", prefix).lower()
     latin_parts = [part for part in latin_name.split() if part.lower() != "sp."]
@@ -990,6 +998,42 @@ def _is_group_entry(latin_name):
 PREFIX_PROVENANCE_VALUES = frozenset({"designated", "generated", "group label"})
 
 
+def _prefix_is_a_group_label(prefix, latin_name):
+    """
+    Is this group entry's prefix a made-up label for the group itself?
+
+    Covers the plain case, where the prefix is the taxon name ("Aves sp." with
+    "Aves"), and the decorated ones minted for group nodes: a 2+2 reading that
+    treats "sp." as the epithet ("Coregonus sp." -> "Cosp"), a genus truncation
+    ("Manacus sp." -> "Mana"), and the taxon with "Sp" appended ("Mus sp." ->
+    "MusSp"). None of these is ever written on an allele, so they are labels
+    rather than unchecked designations. Real umbrella designations are unlike
+    the name they sit on -- "Bos sp." carries "BoLA", "Felis sp." carries "FLA".
+    """
+    if not _is_group_entry(latin_name):
+        return False
+    if _prefix_is_derived_from_name(prefix, latin_name):
+        return True
+    taxon = latin_name[: -len(" sp.")] if latin_name.endswith(" sp.") else latin_name
+    taxon = re.sub(r"[^A-Za-z0-9]+", "", taxon).lower()
+    if not taxon:
+        return False
+    normalized = re.sub(r"[^A-Za-z0-9]+", "", prefix).lower()
+    return normalized in {taxon[:2] + "sp", taxon[:4], taxon + "sp"}
+
+
+def _is_inheritable_umbrella(prefix, latin_name):
+    """
+    Does this entry hand its prefix down to descendants as their old prefix?
+
+    True for a group entry carrying a real designation ("Bos sp." with "BoLA"),
+    false for one whose prefix is just its own name ("Aves sp." with "Aves"),
+    and false for any single species -- which is what stops a tautonym such as
+    "Bubo bubo" (prefix "BuboBubo") from acting as an umbrella.
+    """
+    return not _prefix_is_a_group_label(prefix, latin_name)
+
+
 def _derive_prefix_provenance(prefix, latin_name):
     """
     What can be established about a prefix without consulting a source.
@@ -999,7 +1043,7 @@ def _derive_prefix_provenance(prefix, latin_name):
     generators is one we minted. Everything else returns None so that a curator
     has to look it up rather than inherit a guess.
     """
-    if _is_group_entry(latin_name) and _prefix_is_derived_from_name(prefix, latin_name):
+    if _prefix_is_a_group_label(prefix, latin_name):
         return "group label"
     normalized = prefix.lower()
     for generator in (_make_full_scientific_prefix, _make_long_prefix):
@@ -1017,11 +1061,38 @@ _EMPTY_GENE_NAMES = NormalizingSet()
 latin_name_to_own_gene_names = {}
 
 
+# Every key an entry in species.yaml may carry. Unknown keys are rejected
+# rather than ignored: a typo such as "prefix_source" would otherwise load
+# silently, leaving the YAML asserting something the runtime never read.
+SPECIES_ENTRY_KEYS = frozenset(
+    {
+        "alias",
+        "context only prefixes",
+        "gene families",
+        "gene properties",
+        "genes",
+        "haplotype prefix",
+        "name",
+        "old prefix",
+        "other prefixes",
+        "parent",
+        "prefix",
+        "prefix source",
+    }
+)
+
+
 @cache
 def create_species_for_latin_name(latin_name):
     if latin_name not in raw_species_dict:
         raise ValueError(f"Species not found: '{latin_name}'")
     species_info = raw_species_dict[latin_name]
+    unknown_keys = sorted(set(species_info) - SPECIES_ENTRY_KEYS)
+    if unknown_keys:
+        raise ValueError(
+            f"Unknown key(s) {unknown_keys} in the '{latin_name}' entry of the species "
+            f"ontology; expected one of {sorted(SPECIES_ENTRY_KEYS)}"
+        )
     parent_species_latin_name = species_info.get("parent")
     if not parent_species_latin_name and latin_name != "Gnathostomata sp.":
         # Default: all species descend from the jawed-vertebrate root
@@ -1047,10 +1118,7 @@ def create_species_for_latin_name(latin_name):
     old_mhc_prefix = species_info.get("old prefix")
     if not old_mhc_prefix and parent_species:
         parent_prefix = parent_species.prefix
-        if not (
-            _is_group_entry(parent_species.name)
-            and _prefix_is_derived_from_name(parent_prefix, parent_species.name)
-        ):
+        if _is_inheritable_umbrella(parent_prefix, parent_species.name):
             old_mhc_prefix = parent_prefix
 
     other_mhc_prefixes = species_info.get("other prefixes")
@@ -1065,13 +1133,14 @@ def create_species_for_latin_name(latin_name):
     elif context_only_mhc_prefixes is None:
         context_only_mhc_prefixes = []
 
-    # Auto-generate parseable aliases from the latin name:
-    # 1. A 4+4 prefix only when it is globally unique.
-    # 2. A 5+5 compatibility prefix only when it is globally unique.
-    # 3. The full concatenated scientific name (including subspecies tokens),
-    #    which is the unambiguous fallback.
+    # Auto-generate parseable aliases from the latin name, for binomials only:
+    # 1. The full concatenated scientific name, which is the default and is
+    #    collision-free across the ontology.
+    # 2. A 4+4 shorthand, only when it is globally unique.
+    # Trinomial entries mint neither, so a subspecies never claims a name
+    # derived from its parent binomial.
     for alias in _auto_generated_prefixes_for_latin_name(latin_name):
-        if alias and alias not in other_mhc_prefixes:
+        if alias and alias != prefix and alias not in other_mhc_prefixes:
             other_mhc_prefixes = [*list(other_mhc_prefixes), alias]
 
     common_name = species_info.get("name")

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.41.0"
+__version__ = "3.42.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -55,4 +55,50 @@ Four changes, in increasing order of reach.
   would rename 467 of 672 entries and change `to_string()` for each. Asked, and
   the answer was to rename only the contested prefixes for now. #129 stays open
   for the wider change; `prefix_provenance` is the field it would key off.
+
+## Review round 2 (code review found a real bug in the same PR)
+
+- **The 4+4 branch was missing the binomial guard.** The concatenated form was
+  guarded on `len(scientific_parts) == 2`, the 4+4 form was not, so
+  `Strix occidentalis caurina` claimed `StriOcci` and
+  `Sapajus apella macrocephalus` claimed `SapaApel` -- both derived from their
+  *parent* binomial -- while the safer concatenated form was withheld. The two
+  other trinomials escaped only because their 4+4 collides with the parent, so
+  the guard was accidental. This directly contradicted a README paragraph added
+  by the same commit. Fixed, and pinned by a test naming both species.
+- **Four synthetic group labels were sitting in the "not established" bucket.**
+  `MusSp`, `Cosp`, `Trsp` and `Mana` are decorations of their own taxon name,
+  not designations, but `_prefix_is_derived_from_name` only matched the plain
+  form. They now report "group label", which takes them off #131's list; the
+  eight remaining group entries there (`OmLA`, `FLA`, `GoLA`, ...) are real
+  `_LA`-style codes that genuinely need checking.
+- **Nine of the eleven "designated" claims shipped without a URL**, against an
+  explicit rule in CLAUDE.md and AGENTS.md. All eleven now cite one, and
+  `test_every_designated_prefix_cites_a_source` fails if a future one does not
+  -- verified by mutation.
+- **Two tests could not fail.** `test_prefix_provenance_values_are_valid`
+  asserted membership in a set that both producers are constrained to by
+  construction; it is replaced by `test_designated_is_never_inferred`, which
+  checks the invariant that actually matters. The `assert len(unknown) < 300`
+  canary tested the wrong direction -- it passes a bulk assignment and fires on
+  ordinary growth -- and is replaced by pinning the eight unknowns by name.
+- **Unknown keys in species.yaml are now rejected.** A `prefix_source` typo
+  used to load silently, leaving the YAML asserting a provenance the runtime
+  never read.
+- Also fixed from review: a docstring pointing at a nonexistent `group_node`, a
+  stale numbered comment describing the deleted 5+5 tier and the wrong emission
+  order, a `docs/curation.md` collision-table row still naming `ChryPict`, two
+  species.yaml comments citing "5+5" above 4+4 prefixes, generated aliases
+  duplicating the entry's own prefix, a duplicated trinomial test, a
+  single-element `for` loop, and a "467" that is 466.
+- **Not fixed, filed instead:** #134 (colliding 4+4 forms still resolve
+  confidently to one side -- `ChryPict` gives a turtle to a caller who meant a
+  pheasant; the README now says so, but whether to demote them to
+  `context only prefixes` is a behaviour decision) and #135 (`_is_group_entry`
+  hardcodes the string `"NHP"`; the fact belongs in the data).
+- **Known and accepted:** this is a breaking parse change. 596 generated 5+5
+  aliases and 10 curated ones stop resolving, and three species normalize to a
+  new prefix. #128 laid out the choice between removing in one minor bump and a
+  deprecation cycle, and the first was chosen. Recorded in the README tier
+  section rather than a changelog, since the repo has no changelog.
 - Bumped 3.41.0 to 3.42.0.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,64 +1,58 @@
-# Give NHP its own node instead of a naming predicate
+# Prefix provenance, and retiring the 5+5 tier
 
-Tracking issues: #126 (raised against 3.40.0), follow-up to #122
+Tracking issues: #128, and #129 apart from its point 3
 
-3.40.0 put `Homo sapiens` under `Primata sp.` and, because that node owns the
-`NHP` prefix, had to add a `prefix excludes` declaration and a
-`Species.can_name` predicate to stop `NHP-*` naming a human. #126 pointed out
-the cost: `compatible_with` was quietly switched from ancestry to naming, so
-there was no longer a way to ask the ancestry question, and two near-identical
-predicates now had to be chosen between.
+Four changes, in increasing order of reach.
 
 ## Specification
 
-- [x] Check whether the two questions can be made one by shaping the data
-      instead of adding a predicate.
-- [x] Give `NHP` its own entry, sibling to `Homo sapiens` under `Primata sp.`,
-      and move the 55 non-human primates under it.
-- [x] Delete `prefix excludes`, `prefix_excluded_species` and
-      `Species.can_name`; restore `compatible_with` to plain ancestry.
-- [x] Measure against a worktree of `main`: corpus, compatibility over every
-      species pair, and every structural field.
-- [x] Record the paraphyly constraint the split imposes on future taxa.
-- [x] Update README, `docs/curation.md`, `AGENTS.md` and the tests.
-- [x] Bump the version and run `./format.sh`, `./lint.sh`, `./test.sh`.
+- [x] Rename `_is_taxonomic_prefix` to `_prefix_is_derived_from_name`, which is
+      what it computes. Pure rename.
+- [x] Stop the tautonym false positive: only group entries hand a prefix down,
+      so `Bubo bubo` (prefix `BuboBubo`) is no longer treated as an umbrella.
+- [x] Remove the 5+5 tier: the generator, its collision index, and the ten
+      curated `other prefixes` entries that were 5+5 forms.
+- [x] Make the concatenated binomial the default generated alias.
+- [x] Rename only the contested 4+4 prefixes, retiring the off-book tie-breaks.
+- [x] Add `Species.prefix_provenance`, curated for "designated" and derived for
+      the rest.
+- [x] Measure against a worktree of `main`; update README and `docs/curation.md`.
 
 ## Review
 
-- **The structure answers both questions, so the predicate is unnecessary.**
-  `Primata sp.` is now the primate order with prefix `Primata`; `NHP` is a node
-  of its own holding the 55 non-human primates. `Homo sapiens` is a sibling of
-  `NHP`, not a descendant, so:
-
-  ```
-  compatible_with("Homo sapiens", "Primata sp.")  ->  True   (was False)
-  compatible_with("Homo sapiens", "NHP")          ->  False
-  parse("NHP-E*01:01", species="Homo sapiens")    ->  None
-  ```
-
-  All three are plain `is_ancestor_of`. `can_name`, `prefix excludes` and the
-  docs section explaining which predicate to use are gone.
-- **The general rule this yields:** every MHC prefix owns a node, so "is X
-  inside taxon Y" and "can Y's prefix name X" are the same question. A prefix
-  whose group is not a taxon needs its own node. `NHP` is the first such case
-  because it is paraphyletic -- the primate order minus humans.
-- **Constraint recorded on the node.** Any taxon added under `Primata sp.` must
-  sit wholly inside or wholly outside `NHP`. `Homo sp.` works as a sibling;
-  `Hominidae sp.` would not, since it would have to pull `Gorilla sp.`,
-  `Pan sp.` and `Pongo sp.` out of the umbrella.
-- **Measured against a worktree of `main`** (3.40.0's `Primata sp.` placement
-  is the baseline): 0 of 11,558 corpus names change. Over the 671 species that
-  exist in both, exactly one compatibility pair changes -- `Homo sapiens` vs
-  `Primata sp.`, now True, which is what #126 asked for. One node is added.
-- **A simplification falls out.** On main `find_matching_species_objects("NHP")`
-  returned 54 objects, because 53 species carried `NHP` as an inherited
-  `old prefix` and were collapsed to the owner by the #103 tie-break. `NHP` is
-  its own taxon name now, so nothing inherits it and the lookup returns 1.
-- **Visible output change.** `NHP` and `NHP class I` resolve to the new node
-  rather than to `Primata sp.`, and `primate` now resolves to `Primata sp.`
-  with prefix `Primata`. Those two strings used to give the same answer; they
-  are different questions and now give different answers. No corpus name is
-  affected.
-- Bumped 3.40.0 to 3.41.0. `Species.can_name`, added in 3.40.0, is removed
-  again in the same day; it was public for one release and is called out in the
-  PR so anything that picked it up knows to use `compatible_with`.
+- **`_prefix_is_derived_from_name` says what it does.** The old name claimed a
+  taxonomic judgement it never made: it is a string test, and `NHP` passes it
+  while being a paraphyletic database section. The docstring now says so.
+- **The tautonym bug was latent, and is fixed.** Six species whose curated
+  prefix equals their own concatenated binomial -- `Naja naja` -> `NajaNaja`,
+  plus `Grus grus`, `Asio otus`, `Bubo bubo`, `Tyto alba`, `Bufo bufo` -- were
+  classified as umbrella nodes. All six are leaves, so nothing inherited
+  wrongly today, but adding a subspecies to any of them would have silently
+  broken prefix inheritance. Inheritance now requires a group entry.
+- **5+5 is gone.** `_make_5_5_prefix` and `_GENERATED_5_5_PREFIX_COUNTS` are
+  deleted, along with ten curated aliases (`ChrysPicta`, `GaviaGange`, ...) all
+  added by 49e536e, the commit that introduced the scheme. Evidence it was
+  safe: its own docstring called it backward compatibility, `docs/curation.md`
+  never listed it, no name in the 11,558-name bundled corpora used one, and no
+  species token in the sibling `mhcseqs` dataset (590 distinct, 19,290 rows)
+  used one either.
+- **Three contested prefixes renamed, off-book forms retired.** `ChryPict` is
+  derivable from both a painted turtle and a golden pheasant; the pheasant
+  keeps the literature-style `Chpi` and the turtle takes `ChrysemysPicta`.
+  `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a 6+6) belonged to no
+  documented form and became `LaniusCollaris` and `LeuciscusLeuciscus`. All
+  three old spellings stay parseable as `other prefixes`.
+- **`prefix_provenance` is curated where it matters.** 469 entries derive
+  "generated", 29 derive "group label", 11 are curated "designated" with a
+  source read in this session, and 163 stay `None`. `None` is deliberately not
+  "designated": a prefix we did not generate is not proven to be in published
+  use, which is the `Caau` lesson. The remaining sweep is #131.
+- **Measured against a worktree of `main`:** 0 of 11,558 corpus names change,
+  despite three species changing their canonical prefix -- no corpus name uses
+  a generated form.
+- **Deliberately not done: #129's point 3.** That issue proposes emitting the
+  concatenated binomial for every species without an attested prefix, which
+  would rename 467 of 672 entries and change `to_string()` for each. Asked, and
+  the answer was to rename only the contested prefixes for now. #129 stays open
+  for the wider change; `prefix_provenance` is the field it would key off.
+- Bumped 3.41.0 to 3.42.0.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,7 +28,8 @@ Four changes, in increasing order of reach.
   plus `Grus grus`, `Asio otus`, `Bubo bubo`, `Tyto alba`, `Bufo bufo` -- were
   classified as umbrella nodes. All six are leaves, so nothing inherited
   wrongly today, but adding a subspecies to any of them would have silently
-  broken prefix inheritance. Inheritance now requires a group entry.
+  broken prefix inheritance. Suppressing inheritance now requires a group
+  entry, so an ordinary species hands its prefix down like any other parent.
 - **5+5 is gone.** `_make_5_5_prefix` and `_GENERATED_5_5_PREFIX_COUNTS` are
   deleted, along with ten curated aliases (`ChrysPicta`, `GaviaGange`, ...) all
   added by 49e536e, the commit that introduced the scheme. Evidence it was
@@ -42,9 +43,9 @@ Four changes, in increasing order of reach.
   `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a 6+6) belonged to no
   documented form and became `LaniusCollaris` and `LeuciscusLeuciscus`. All
   three old spellings stay parseable as `other prefixes`.
-- **`prefix_provenance` is curated where it matters.** 469 entries derive
+- **`prefix_provenance` is curated where it matters.** 467 entries derive
   "generated", 29 derive "group label", 11 are curated "designated" with a
-  source read in this session, and 163 stay `None`. `None` is deliberately not
+  source read in this session, and 165 stay `None`. `None` is deliberately not
   "designated": a prefix we did not generate is not proven to be in published
   use, which is the `Caau` lesson. The remaining sweep is #131.
 - **Measured against a worktree of `main`:** 0 of 11,558 corpus names change,
@@ -66,12 +67,23 @@ Four changes, in increasing order of reach.
   other trinomials escaped only because their 4+4 collides with the parent, so
   the guard was accidental. This directly contradicted a README paragraph added
   by the same commit. Fixed, and pinned by a test naming both species.
-- **Four synthetic group labels were sitting in the "not established" bucket.**
-  `MusSp`, `Cosp`, `Trsp` and `Mana` are decorations of their own taxon name,
-  not designations, but `_prefix_is_derived_from_name` only matched the plain
-  form. They now report "group label", which takes them off #131's list; the
-  eight remaining group entries there (`OmLA`, `FLA`, `GoLA`, ...) are real
-  `_LA`-style codes that genuinely need checking.
+- **Reverted mid-PR: classifying decorated labels as "group label".** An
+  attempt to take `MusSp`, `Cosp`, `Trsp` and `Mana` off #131's list matched
+  them with string patterns (`taxon[:2] + "sp"`, `taxon[:4]`), which is a guess
+  about nomenclature, and it was wired into prefix inheritance as well.
+  Measured against main it stripped the inherited `old prefix` from 18 species
+  -- 16 `Mus`, plus `Coregonus clupeaformis` and `Tropheus moorii` -- an
+  unmeasured behaviour change. Reverted: those four stay `None` and stay on
+  #131's list, which is the honest answer.
+- **The 4+4 collision census counted entries that cannot claim a form.** It was
+  built over every latin name including trinomials, so `Canis lupus baileyi`
+  vetoed `CaniLupu` for `Canis lupus` and `Balaenoptera musculus brevicauda`
+  vetoed `BalaMusc` -- both now resolve to their binomial. Every subspecies
+  added would otherwise have removed its parent's shorthand for free.
+- **"generated" now means the emitter would emit it**, not merely that a
+  generator function can produce the string. `LaniColl` on *Lanius collurio* is
+  a curator tie-break never auto-generated for anyone, and used to claim
+  "generated"; it reports `None`.
 - **Nine of the eleven "designated" claims shipped without a URL**, against an
   explicit rule in CLAUDE.md and AGENTS.md. All eleven now cite one, and
   `test_every_designated_prefix_cites_a_source` fails if a future one does not
@@ -101,4 +113,6 @@ Four changes, in increasing order of reach.
   new prefix. #128 laid out the choice between removing in one minor bump and a
   deprecation cycle, and the first was chosen. Recorded in the README tier
   section rather than a changelog, since the repo has no changelog.
+- **Measured after the round-3 fixes:** 3 entries change `old_mhc_prefix`
+  against main, all three the intended renames, down from 21.
 - Bumped 3.41.0 to 3.42.0.

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -266,7 +266,7 @@ def test_parse_ratite_species():
         ("Drno", "Dromaius novaehollandiae"),
         ("Apow", "Apteryx owenii"),
         ("Apma", "Apteryx mantelli"),
-        ("CasuaCasua", "Casuarius casuarius"),
+        ("CasuariusCasuarius", "Casuarius casuarius"),
         ("Nope", "Nothoprocta perdicaria"),
     ]:
         expected = Species.get(prefix)

--- a/tests/test_gene_inheritance.py
+++ b/tests/test_gene_inheritance.py
@@ -221,7 +221,7 @@ class TestCrocodyliaInheritance:
         eq_(result.species.name, "Alligator mississippiensis")
 
     def test_gharial_inherits_ua(self):
-        result = parse("GaviaGange-UA", raise_on_error=True)
+        result = parse("GavialisGangeticus-UA", raise_on_error=True)
         eq_(result.species.name, "Gavialis gangeticus")
 
     def test_crpo_has_inherited_plus_own(self):

--- a/tests/test_reptiles_amphibians.py
+++ b/tests/test_reptiles_amphibians.py
@@ -248,12 +248,12 @@ def test_parse_crpo_expanded_genes():
 
 def test_parse_turtle_species():
     for prefix, latin in [
-        ("CaretCaret", "Caretta caretta"),
+        ("CarettaCaretta", "Caretta caretta"),
         ("Chmy", "Chelonia mydas"),
         ("Deco", "Dermochelys coriacea"),
         ("Leke", "Lepidochelys kempii"),
         ("Chse", "Chelydra serpentina"),
-        ("ChrysPicta", "Chrysemys picta"),
+        ("ChrysemysPicta", "Chrysemys picta"),
         ("Pesi", "Pelodiscus sinensis"),
         ("Tetr", "Terrapene triunguis"),
         ("Gopo", "Gopherus polyphemus"),

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -10,7 +10,7 @@ import pytest
 from mhcgnomes import Allele, Gene, ParseError, Species, parse
 from mhcgnomes.common import normalize_string
 from mhcgnomes.data import species as species_data
-from mhcgnomes.species import _make_5_5_prefix, _make_long_prefix, raw_species_dict
+from mhcgnomes.species import _make_long_prefix, raw_species_dict
 
 from .common import eq_
 
@@ -161,18 +161,28 @@ def test_species_get_by_latin_name_eagle_owl():
     eq_(species.prefix, "BuboBubo")
 
 
-def test_long_prefix_always_parseable():
-    """The 5+5 long prefix should always work for parsing any species."""
-    for latin, long_prefix in [
+def test_full_scientific_prefix_always_parseable():
+    """The concatenated binomial is the default generated alias for any species."""
+    for latin, full_prefix in [
         ("Bubo bubo", "BuboBubo"),
-        ("Chrysemys picta", "ChrysPicta"),
-        ("Gavialis gangeticus", "GaviaGange"),
-        ("Casuarius casuarius", "CasuaCasua"),
-        ("Caretta caretta", "CaretCaret"),
+        ("Chrysemys picta", "ChrysemysPicta"),
+        ("Gavialis gangeticus", "GavialisGangeticus"),
+        ("Casuarius casuarius", "CasuariusCasuarius"),
+        ("Caretta caretta", "CarettaCaretta"),
     ]:
-        species = Species.get(long_prefix)
-        assert species is not None, f"Species.get({long_prefix!r}) returned None"
+        species = Species.get(full_prefix)
+        assert species is not None, f"Species.get({full_prefix!r}) returned None"
         eq_(species.name, latin)
+
+
+def test_5_5_prefixes_are_no_longer_generated():
+    """
+    The 5+5 tier was removed in 3.42.0 (see issue #128). These forms were
+    parseable up to 3.41.0 and are not any species' curated prefix, so they
+    should now resolve to nothing rather than to a species.
+    """
+    for retired in ["ChrysPicta", "GaviaGange", "CasuaCasua", "CaretCaret", "HomoSapie"]:
+        assert Species.get(retired) is None, f"{retired!r} still resolves"
 
 
 def test_generated_4_4_prefix_collisions_are_not_global_aliases():
@@ -181,7 +191,7 @@ def test_generated_4_4_prefix_collisions_are_not_global_aliases():
         assert Species.get_multiple(alias) == ()
 
 
-def test_generated_5_5_prefix_collisions_fall_back_to_full_scientific_name():
+def test_trinomials_do_not_shadow_their_parent_binomial():
     assert Species.get("CanisLupus") is not None
     eq_(Species.get("CanisLupus").name, "Canis lupus")
     assert Species.get("CanisLupusBaileyi") is None
@@ -204,7 +214,7 @@ def test_explicit_short_prefixes_beat_generated_collision_aliases():
         for alias in record.get("other prefixes", []) or []:
             explicit_owners[normalize_string(alias)].add(latin_name)
 
-    for generator in (_make_long_prefix, _make_5_5_prefix):
+    for generator in (_make_long_prefix,):
         for latin_name in raw_species_dict:
             alias = generator(latin_name)
             if not alias:
@@ -224,18 +234,18 @@ def test_trinomial_entries_do_not_get_full_concatenated_aliases():
     assert Species.get("CanisLupusBaileyi") is None
 
 
-def test_long_prefix_works_for_allele_parsing():
-    """HomoSapie-A*02:01 should parse as HLA-A*02:01."""
-    result = parse("HomoSapie-A*02:01", raise_on_error=True)
+def test_full_prefix_works_for_allele_parsing():
+    """HomoSapiens-A*02:01 should parse as HLA-A*02:01."""
+    result = parse("HomoSapiens-A*02:01", raise_on_error=True)
     assert isinstance(result, Allele)
     eq_(result.species.prefix, "HLA")
     eq_(result.gene.name, "A")
     eq_(result.allele_fields, ("02", "01"))
 
 
-def test_long_prefix_works_for_compact_allele():
-    """HomoSapie-A0201 should also parse."""
-    result = parse("HomoSapie-A0201", raise_on_error=True)
+def test_full_prefix_works_for_compact_allele():
+    """HomoSapiens-A0201 should also parse."""
+    result = parse("HomoSapiens-A0201", raise_on_error=True)
     assert isinstance(result, Allele)
     eq_(result.species.prefix, "HLA")
     eq_(result.allele_fields, ("02", "01"))
@@ -520,3 +530,66 @@ def test_no_prefix_is_claimed_by_two_species():
             claims[normalize_string(value)].add(latin_name)
     collisions = {p: sorted(v) for p, v in claims.items() if len(v) > 1}
     assert collisions == {}
+
+
+# ---------------------------------------------------------------------------
+# Prefix provenance (issue #128)
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_provenance_values_are_valid():
+    from mhcgnomes.species import PREFIX_PROVENANCE_VALUES, latin_name_to_species_object
+
+    for species in latin_name_to_species_object.values():
+        assert species.prefix_provenance is None or (
+            species.prefix_provenance in PREFIX_PROVENANCE_VALUES
+        ), f"{species.name} has provenance {species.prefix_provenance!r}"
+
+
+def test_generated_prefixes_are_reported_as_generated():
+    """A prefix mhcgnomes minted from the latin name is provable by derivation."""
+    for latin_name, prefix in [
+        ("Tachyglossus aculeatus", "TachAcul"),
+        ("Abramis brama", "AbraBram"),
+        ("Chrysemys picta", "ChrysemysPicta"),
+    ]:
+        species = Species.get_by_latin_name(latin_name)
+        eq_(species.prefix, prefix)
+        eq_(species.prefix_provenance, "generated")
+
+
+def test_group_labels_are_reported_as_group_labels():
+    """Aves, Galliformes and NHP name groupings and are never written on alleles."""
+    for latin_name in ["Aves sp.", "Galliformes sp.", "Primata sp.", "NHP"]:
+        eq_(Species.get_by_latin_name(latin_name).prefix_provenance, "group label")
+
+
+def test_published_designations_are_curated_not_inferred():
+    """
+    These are marked in species.yaml with a source, because being absent from
+    the generated forms does not prove a prefix is in published use -- the Caau
+    case. Nothing infers "designated".
+    """
+    for latin_name, prefix in [
+        ("Homo sapiens", "HLA"),
+        ("Bos sp.", "BoLA"),
+        ("Pan troglodytes", "Patr"),
+        ("Macaca mulatta", "Mamu"),
+    ]:
+        species = Species.get_by_latin_name(latin_name)
+        eq_(species.prefix, prefix)
+        eq_(species.prefix_provenance, "designated")
+
+
+def test_unestablished_provenance_stays_none():
+    """
+    Most short prefixes have not been checked against IPD/IMGT yet. They report
+    None rather than being assumed published, so the gap is visible.
+    https://github.com/pirl-unc/mhcgnomes/issues/131
+    """
+    from mhcgnomes.species import latin_name_to_species_object
+
+    unknown = [s.name for s in latin_name_to_species_object.values() if s.prefix_provenance is None]
+    assert unknown, "nothing left unestablished -- update this test if the sweep is finished"
+    # A canary: if this drops sharply, someone bulk-assigned provenance.
+    assert len(unknown) < 300, f"{len(unknown)} entries unestablished"

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -4,6 +4,7 @@ and prefixes/common names are aliases that may be ambiguous.
 """
 
 from collections import defaultdict
+from contextlib import contextmanager
 
 import pytest
 
@@ -185,10 +186,27 @@ def test_5_5_prefixes_are_no_longer_generated():
         assert Species.get(retired) is None, f"{retired!r} still resolves"
 
 
-def test_generated_4_4_prefix_collisions_are_not_global_aliases():
-    for alias in ["CaniLupu"]:
-        assert Species.get(alias) is None
-        assert Species.get_multiple(alias) == ()
+def test_colliding_4_4_forms_are_never_auto_generated():
+    """
+    Three 4+4 forms are derivable from two binomials each. None is emitted as a
+    generated alias, so the only route to one is an entry curating it, and only
+    one side of each pair does -- which is why they still resolve. See #134.
+
+    A subspecies must not veto its parent's shorthand: CaniLupu and BalaMusc
+    are derivable from a binomial and its own subspecies, and belong to the
+    binomial.
+    """
+    from mhcgnomes.species import _GENERATED_LONG_PREFIX_COUNTS, _long_prefix_if_claimable
+
+    for alias in ["ChryPict", "LaniColl", "LeucLeuc"]:
+        eq_(_GENERATED_LONG_PREFIX_COUNTS[alias], 2)
+        assert Species.get(alias) is not None, f"{alias} lost its curated owner"
+        eq_(len(Species.get_multiple(alias)), 1)
+
+    for alias, latin_name in [("CaniLupu", "Canis lupus"), ("BalaMusc", "Balaenoptera musculus")]:
+        eq_(_GENERATED_LONG_PREFIX_COUNTS[alias], 1)
+        eq_(Species.get(alias).name, latin_name)
+    assert _long_prefix_if_claimable("Canis lupus baileyi") is None
 
 
 def test_trinomials_mint_no_generated_alias_at_all():
@@ -197,11 +215,13 @@ def test_trinomials_mint_no_generated_alias_at_all():
     from the parent binomial's first two words. Before 3.42.0 the 4+4 branch
     had no arity guard, so "Strix occidentalis caurina" claimed "StriOcci".
     """
-    for subspecies, shorthand in [
-        ("Strix occidentalis caurina", "StriOcci"),
-        ("Sapajus apella macrocephalus", "SapaApel"),
+    for subspecies, shorthand, concatenated in [
+        ("Strix occidentalis caurina", "StriOcci", "StrixOccidentalis"),
+        ("Sapajus apella macrocephalus", "SapaApel", "SapajusApella"),
+        ("Canis lupus baileyi", "CanisLupusBaileyi", "CanisLupusBaileyi"),
     ]:
-        assert Species.get(shorthand) is None, f"{shorthand!r} still resolves"
+        assert Species.get(shorthand) is None, f"{shorthand!r} resolves"
+        assert Species.get(concatenated) is None, f"{concatenated!r} resolves"
         assert Species.get_by_latin_name(subspecies) is not None
 
 
@@ -574,8 +594,18 @@ def test_every_designated_prefix_cites_a_source():
     from pathlib import Path
 
     text = (Path(__file__).parent.parent / "mhcgnomes" / "data" / "species.yaml").read_text()
-    for block in re.finditer(r"(?:^  #[^\n]*\n)+^  prefix source: designated$", text, re.M):
-        comment = block.group(0)
+    declarations = re.findall(r"^  prefix source: designated$", text, re.M)
+    cited = re.findall(r"(?:^  #[^\n]*\n)+^  prefix source: designated$", text, re.M)
+    # Count first: an entry with no comment block at all matches the second
+    # pattern zero times, so iterating matches alone would skip exactly the
+    # case this test exists to catch.
+    eq_(
+        len(cited),
+        len(declarations),
+        f"{len(declarations) - len(cited)} 'prefix source: designated' declaration(s) "
+        f"with no comment above them at all",
+    )
+    for comment in cited:
         assert "http" in comment or "PMID" in comment, (
             f"'prefix source: designated' with no citation:\n{comment}"
         )
@@ -646,43 +676,65 @@ def test_unestablished_provenance_stays_none():
         )
 
 
+@contextmanager
+def temporary_species_entry(latin_name, entry):
+    """
+    Add an entry to the loaded ontology for the body of a test and take it out
+    again, so a failing assertion cannot leave a synthetic species behind for
+    the rest of the session.
+    """
+    from mhcgnomes.species import raw_species_dict
+
+    raw_species_dict[latin_name] = entry
+    try:
+        yield
+    finally:
+        del raw_species_dict[latin_name]
+
+
 def test_unknown_species_yaml_keys_are_rejected():
     """
     A misspelled key used to load silently, so species.yaml could assert
     something the runtime never read -- `prefix_source` instead of
     `prefix source` being the case that motivated this.
     """
-    from mhcgnomes.species import (
-        SPECIES_ENTRY_KEYS,
-        create_species_for_latin_name,
-        raw_species_dict,
-    )
+    from mhcgnomes.species import SPECIES_ENTRY_KEYS, create_species_for_latin_name
 
     assert "prefix source" in SPECIES_ENTRY_KEYS
     assert "prefix_source" not in SPECIES_ENTRY_KEYS
 
-    raw_species_dict["Test typo sp."] = {
-        "prefix": "TestTypo",
-        "name": "test",
-        "prefix_source": "designated",
-    }
-    try:
-        with pytest.raises(ValueError, match="Unknown key"):
-            create_species_for_latin_name("Test typo sp.")
-    finally:
-        del raw_species_dict["Test typo sp."]
+    entry = {"prefix": "TestTypo", "name": "test", "prefix_source": "designated"}
+    with (
+        temporary_species_entry("Test typo sp.", entry),
+        pytest.raises(ValueError, match="Unknown key"),
+    ):
+        create_species_for_latin_name("Test typo sp.")
 
 
 def test_invalid_prefix_source_value_is_rejected():
-    from mhcgnomes.species import create_species_for_latin_name, raw_species_dict
+    from mhcgnomes.species import create_species_for_latin_name
 
-    raw_species_dict["Test value sp."] = {
-        "prefix": "TestValue",
-        "name": "test",
-        "prefix source": "attested",
-    }
-    try:
-        with pytest.raises(ValueError, match="prefix source"):
+    # A string outside the value set, and the list form a curator would reach
+    # for when adding a second citation -- which used to raise an unhandled
+    # TypeError at import, naming no species.
+    for bad_value in ["attested", ["designated"]]:
+        entry = {"prefix": "TestValue", "name": "test", "prefix source": bad_value}
+        with (
+            temporary_species_entry("Test value sp.", entry),
+            pytest.raises(ValueError, match="prefix source"),
+        ):
             create_species_for_latin_name("Test value sp.")
-    finally:
-        del raw_species_dict["Test value sp."]
+
+
+def test_4_4_shorthand_parses_an_allele():
+    """
+    The tier README.md documents as `HomoSapi-A*02:01`. Both allele-parse tests
+    above use the concatenated form, so without this nothing covers the 4+4
+    branch and a regression in its uniqueness guard would drop the whole tier
+    silently.
+    """
+    result = parse("HomoSapi-A*02:01", raise_on_error=True)
+    assert isinstance(result, Allele)
+    eq_(result.species.prefix, "HLA")
+    eq_(result.gene.name, "A")
+    eq_(result.allele_fields, ("02", "01"))

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -191,10 +191,18 @@ def test_generated_4_4_prefix_collisions_are_not_global_aliases():
         assert Species.get_multiple(alias) == ()
 
 
-def test_trinomials_do_not_shadow_their_parent_binomial():
-    assert Species.get("CanisLupus") is not None
-    eq_(Species.get("CanisLupus").name, "Canis lupus")
-    assert Species.get("CanisLupusBaileyi") is None
+def test_trinomials_mint_no_generated_alias_at_all():
+    """
+    Neither the concatenated form nor the 4+4 shorthand, since both are built
+    from the parent binomial's first two words. Before 3.42.0 the 4+4 branch
+    had no arity guard, so "Strix occidentalis caurina" claimed "StriOcci".
+    """
+    for subspecies, shorthand in [
+        ("Strix occidentalis caurina", "StriOcci"),
+        ("Sapajus apella macrocephalus", "SapaApel"),
+    ]:
+        assert Species.get(shorthand) is None, f"{shorthand!r} still resolves"
+        assert Species.get_by_latin_name(subspecies) is not None
 
 
 def test_curated_prefix_keeps_global_owner_when_generated_alias_would_collide():
@@ -214,17 +222,16 @@ def test_explicit_short_prefixes_beat_generated_collision_aliases():
         for alias in record.get("other prefixes", []) or []:
             explicit_owners[normalize_string(alias)].add(latin_name)
 
-    for generator in (_make_long_prefix,):
-        for latin_name in raw_species_dict:
-            alias = generator(latin_name)
-            if not alias:
-                continue
-            owners = explicit_owners.get(normalize_string(alias))
-            if not owners:
-                continue
-            species = Species.get(alias)
-            assert species is not None
-            assert species.name in owners
+    for latin_name in raw_species_dict:
+        alias = _make_long_prefix(latin_name)
+        if not alias:
+            continue
+        owners = explicit_owners.get(normalize_string(alias))
+        if not owners:
+            continue
+        species = Species.get(alias)
+        assert species is not None
+        assert species.name in owners
 
 
 def test_trinomial_entries_do_not_get_full_concatenated_aliases():
@@ -537,13 +544,41 @@ def test_no_prefix_is_claimed_by_two_species():
 # ---------------------------------------------------------------------------
 
 
-def test_prefix_provenance_values_are_valid():
-    from mhcgnomes.species import PREFIX_PROVENANCE_VALUES, latin_name_to_species_object
+def test_designated_is_never_inferred():
+    """
+    "designated" has to come from a curator who read a source, so no entry
+    reporting it may be re-derivable from its latin name -- if it were, the
+    deriver would have said "generated" and the curation would be redundant or
+    wrong. Asserting membership in the value set instead would prove nothing:
+    the loader rejects anything else, and the deriver returns literals.
+    """
+    from mhcgnomes.species import _derive_prefix_provenance, latin_name_to_species_object
 
     for species in latin_name_to_species_object.values():
-        assert species.prefix_provenance is None or (
-            species.prefix_provenance in PREFIX_PROVENANCE_VALUES
-        ), f"{species.name} has provenance {species.prefix_provenance!r}"
+        if species.prefix_provenance != "designated":
+            continue
+        derived = _derive_prefix_provenance(species.prefix, species.name)
+        assert derived is None, (
+            f"{species.name} is curated 'designated' but derivation says "
+            f"{derived!r}; one of the two is wrong"
+        )
+
+
+def test_every_designated_prefix_cites_a_source():
+    """
+    CLAUDE.md: "Cite what you find in the YAML or code next to the change, with
+    a PMID or URL." This is the one provenance value that is a claim about the
+    outside world, so it is the one that must not ship uncited.
+    """
+    import re
+    from pathlib import Path
+
+    text = (Path(__file__).parent.parent / "mhcgnomes" / "data" / "species.yaml").read_text()
+    for block in re.finditer(r"(?:^  #[^\n]*\n)+^  prefix source: designated$", text, re.M):
+        comment = block.group(0)
+        assert "http" in comment or "PMID" in comment, (
+            f"'prefix source: designated' with no citation:\n{comment}"
+        )
 
 
 def test_generated_prefixes_are_reported_as_generated():
@@ -589,7 +624,65 @@ def test_unestablished_provenance_stays_none():
     """
     from mhcgnomes.species import latin_name_to_species_object
 
-    unknown = [s.name for s in latin_name_to_species_object.values() if s.prefix_provenance is None]
+    unknown = {s.name for s in latin_name_to_species_object.values() if s.prefix_provenance is None}
     assert unknown, "nothing left unestablished -- update this test if the sweep is finished"
-    # A canary: if this drops sharply, someone bulk-assigned provenance.
-    assert len(unknown) < 300, f"{len(unknown)} entries unestablished"
+    # Pinned by name rather than by count: #131 can then shrink the list one
+    # entry at a time with a citation each, while a bulk assignment that sweeps
+    # them all at once has to come here and say so. A count bound would have
+    # done neither -- it fires on ordinary growth and passes a bulk assignment.
+    for name in [
+        "Aotus sp.",
+        "Callithrix sp.",
+        "Felis sp.",
+        "Gorilla sp.",
+        "Macaca sp.",
+        "Oryctolagus sp.",
+        "Pan sp.",
+        "Pongo sp.",
+    ]:
+        assert name in unknown, (
+            f"{name} was given a provenance -- if that is a checked fact, cite "
+            f"the source in species.yaml and drop it from this list"
+        )
+
+
+def test_unknown_species_yaml_keys_are_rejected():
+    """
+    A misspelled key used to load silently, so species.yaml could assert
+    something the runtime never read -- `prefix_source` instead of
+    `prefix source` being the case that motivated this.
+    """
+    from mhcgnomes.species import (
+        SPECIES_ENTRY_KEYS,
+        create_species_for_latin_name,
+        raw_species_dict,
+    )
+
+    assert "prefix source" in SPECIES_ENTRY_KEYS
+    assert "prefix_source" not in SPECIES_ENTRY_KEYS
+
+    raw_species_dict["Test typo sp."] = {
+        "prefix": "TestTypo",
+        "name": "test",
+        "prefix_source": "designated",
+    }
+    try:
+        with pytest.raises(ValueError, match="Unknown key"):
+            create_species_for_latin_name("Test typo sp.")
+    finally:
+        del raw_species_dict["Test typo sp."]
+
+
+def test_invalid_prefix_source_value_is_rejected():
+    from mhcgnomes.species import create_species_for_latin_name, raw_species_dict
+
+    raw_species_dict["Test value sp."] = {
+        "prefix": "TestValue",
+        "name": "test",
+        "prefix source": "attested",
+    }
+    try:
+        with pytest.raises(ValueError, match="prefix source"):
+            create_species_for_latin_name("Test value sp.")
+    finally:
+        del raw_species_dict["Test value sp."]


### PR DESCRIPTION
Closes #128. Addresses #129 apart from its point 3 — see the last section.

Four changes, smallest first.

## 1. `_is_taxonomic_prefix` → `_prefix_is_derived_from_name`

The old name claimed a judgement it never made. It is a string test — "is this
prefix a normalization of the entry's own name?" — and `NHP` passes it while
being a paraphyletic database section rather than a taxon. The docstring now
says what it does not establish.

## 2. A latent tautonym bug, fixed

Six species whose curated prefix equals their own concatenated binomial were
being classified as umbrella nodes:

```
Naja naja -> NajaNaja    Grus grus -> GrusGrus    Asio otus -> AsioOtus
Bubo bubo -> BuboBubo    Tyto alba -> TytoAlba    Bufo bufo -> BufoBufo
```

All six are leaves, so nothing inherits wrongly today — but give *Naja naja* a
subspecies and it would silently not inherit `NajaNaja`. Prefix inheritance now
requires a group entry (`<taxon> sp.`, or `NHP`).

## 3. The 5+5 tier is gone

`_make_5_5_prefix`, `_GENERATED_5_5_PREFIX_COUNTS`, and ten curated
`other prefixes` entries (`ChrysPicta`, `GaviaGange`, `CaimaCroco`, …) — all
ten added by `49e536e`, the commit that introduced the scheme.

Evidence it was safe, gathered on #128:

| check | result |
|---|---|
| its own docstring | *"Kept for backward compatibility"* |
| `docs/curation.md` | never listed it — only 4+4 and the full binomial |
| 11,558 bundled corpus names | **0** use any generated form |
| sibling `mhcseqs`, 590 species tokens over 19,290 rows | **0** use a 5+5 form; where it has no literature prefix it uses the full binomial |

The concatenated binomial is now the **default** generated alias, listed first.
It is the only form with no collisions anywhere in the ontology: across all 672
entries it resolves to itself 619 times, to a *different* species 0 times, and
is absent 53 times (49 group entries, which are not binomials, and 4
subspecies, which deliberately do not claim their parent's name).

## 4. Three contested 4+4 prefixes retired

`ChryPict` is derivable by the same rule from *Chrysemys picta* and
*Chrysolophus pictus* — a painted turtle and a golden pheasant. `LaniColl` from
two shrikes, `LeucLeuc` from a dace and a Siberian crane. The tie-breaks that
had been chosen were off-book: `LaniCola` is a hand-tweaked 4+4 and
`LeucisLeucis` a 6+6, neither of which is any documented form.

| species | was | now | why |
|---|---|---|---|
| *Chrysolophus pictus* | `Chpi` | `Chpi` | literature-style code, kept |
| *Chrysemys picta* | `ChryPict` | `ChrysemysPicta` | 4+4 contested |
| *Lanius collaris* | `LaniCola` | `LaniusCollaris` | off-book tie-break |
| *Leuciscus leuciscus* | `LeucisLeucis` | `LeuciscusLeuciscus` | off-book 6+6 |

All three old spellings stay parseable as `other prefixes`.

## 5. `Species.prefix_provenance`

| value | count | how established |
|---|---|---|
| `"generated"` | 469 | provable — re-derive the 4+4 or concatenated form |
| `"group label"` | 29 | provable — a group entry whose prefix is its own name |
| `"designated"` | 11 | **curated with a source**, never inferred |
| `None` | 163 | not established |

```python
>>> Species.get("HLA").prefix_provenance
'designated'
>>> Species.get("TachAcul").prefix_provenance
'generated'
>>> Species.get("NHP").prefix_provenance
'group label'
```

`None` is deliberately distinct from `"designated"`. A prefix mhcgnomes did not
generate is not thereby proven to be in published use — that is the `Caau`
case (#112), where the official designation belongs to a species with no
deposited sequences while the prefix is in active use for a different one.
Inferring "designated" for the tail would encode that mistake 163 times. The
11 marked here cite pages read directly (IMGT/HLA, IPD-MHC group pages, the
IPD NHP nomenclature page). The remaining sweep is **#131**, with a canary test
so a bulk assignment cannot land unnoticed.

## Measurement

Against a `git worktree` of `main`: **0 of 11,558** corpus names parse
differently, despite three species changing canonical prefix — no corpus name
uses a generated form.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,553 passed. 3.41.0 → 3.42.0.

## Not done: #129 point 3

#129 proposes emitting the concatenated binomial for *every* species without an
attested prefix. That is 467 of 672 entries changing how they print — the
largest output change this library would have made. I asked, and the answer was
to rename only the contested prefixes for now, which is what this does. #129
stays open for the wider change; `prefix_provenance` is the field it would key
off, and #131 is the curation that would make it decidable.
