### PR TITLE
A contested prefix names nobody, and group-ness lives in the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,25 +501,35 @@ Homo sapiens-A*02:01 # latin name with space
 
 Two limits are worth knowing:
 
-**4+4 is not collision-free.** Three forms are derivable from two species
-each — `ChryPict` from both *Chrysemys picta* and *Chrysolophus pictus*,
-`LaniColl` from two shrikes, `LeucLeuc` from a dace and a crane. None is ever
-*auto-generated*, but that only suppresses the generated copy: each is curated
-by one side of its pair, so it still resolves, confidently and to that side
-alone — `ChryPict` gives the turtle, `LaniColl` gives *Lanius collurio*,
-`LeucLeuc` gives the crane. Issue #134 tracks whether they should instead be
-demoted to context-only. Two of the three are still the canonical prefix of
-their owner; the entries that had a *contested* form as their canonical prefix
-now use the concatenated binomial instead — three entries did, in 3.42.0:
+**4+4 is not collision-free, and a contested form names nobody.** Three forms
+are derivable from two species each — `ChryPict` from both *Chrysemys picta*
+and *Chrysolophus pictus*, `LaniColl` from two shrikes, `LeucLeuc` from a dace
+and a crane. Since 3.43.0 none of them resolves on its own:
 
-| species | was | now |
-|---|---|---|
-| *Chrysemys picta* | `ChryPict` | `ChrysemysPicta` |
-| *Lanius collaris* | `LaniCola` | `LaniusCollaris` |
-| *Leuciscus leuciscus* | `LeucisLeucis` | `LeuciscusLeuciscus` |
+```python
+>>> parse("ChryPict-B", raise_on_error=False)
+None                       # was a painted turtle, even if you meant the pheasant
+>>> parse("ChryPict-B", species="Chrysolophus pictus").species.name
+'Chrysolophus pictus'      # explicit species still resolves it
+```
 
-Their normalized output changes accordingly, so `parse("ChryPict-UA")` now
-round-trips as `ChrysemysPicta-UA`. The old spellings stay parseable.
+Both claimants list the form under `context only prefixes`, so it resolves
+only when the caller has already said which species they mean. The species that
+had held a contested form as their canonical prefix use their concatenated
+binomial instead — three entries did, in 3.42.0:
+
+| species | was | now | old spelling |
+|---|---|---|---|
+| *Chrysemys picta* | `ChryPict` | `ChrysemysPicta` | context only |
+| *Chrysolophus pictus* | `Chpi` | `Chpi` | — |
+| *Lanius collurio* | `LaniColl` | `LaniusCollurio` | context only |
+| *Lanius collaris* | `LaniCola` | `LaniusCollaris` | alias |
+| *Leucogeranus leucogeranus* | `LeucLeuc` | `LeucogeranusLeucogeranus` | context only |
+| *Leuciscus leuciscus* | `LeucisLeucis` | `LeuciscusLeuciscus` | alias |
+
+Normalized output changes accordingly. The uncontested old spellings
+(`LaniCola`, `LeucisLeucis`) stay parseable as plain aliases; the contested
+ones (`ChryPict`, `LaniColl`, `LeucLeuc`) need an explicit `species=`.
 
 **Subspecies mint no generated alias.** A trinomial entry such as *Canis lupus
 baileyi* deliberately does not claim `CanisLupus`, which belongs to its parent

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -187,7 +187,10 @@ genus's node -- and it is what the rest of the entry is inherited along.
 An umbrella MHC prefix covers everything beneath the node that owns it. The
 loader hands a parent's prefix down to a child as its `old prefix` unless the
 parent is a group entry labelled with its own taxon name -- `Aves sp.` with
-`Aves`, `NHP` with `NHP`. Designations are inherited (`BoLA`, `DLA`, `RhLA`),
+`Aves`, `NHP` with `NHP`. Most group entries announce themselves by ending in
+`sp.`; `NHP` cannot, since it is not a taxon, so it carries `group: true`
+instead -- and so should any future database section that is not a clade,
+rather than being named in the loader (#135). Designations are inherited (`BoLA`, `DLA`, `RhLA`),
 and so are decorated group labels that are not simply the taxon (`Mus sp.` with
 `MusSp`). The child must also not declare an `old prefix` of its own. Note this
 is the *immediate* parent: `Macaca mulatta` inherits `RhLA` from `Macaca sp.`,
@@ -408,15 +411,17 @@ picta* and *Chrysolophus pictus*, `LaniColl` from two shrikes, `LeucLeuc` from
 a dace and a crane. A colliding form is never *auto-generated* as an alias, but
 that only suppresses the generated copy -- where one side of a pair curates the
 form as its prefix or as an `other prefixes` entry, it still resolves globally
-and to that side alone -- confidently, which issue #134 tracks. `ChryPict`
-resolves to the turtle, `LaniColl` to *Lanius collurio*, `LeucLeuc` to the
-crane; two of the three are still their owner's canonical prefix.
+and to that side alone -- confidently, which was the bug in #134. Since 3.43.0
+none of the three resolves on its own: both claimants list the form under
+`context only prefixes`, so `ChryPict-B` fails and
+`parse("ChryPict-B", species="Chrysolophus pictus")` works.
 
-The entries that had a *contested* form as their canonical prefix now carry the
-concatenated binomial instead, which also demoted two tie-breaks belonging to
-no documented form -- `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a
-6+6). Both are kept in `other prefixes` and still resolve; only their status as
-canonical changed. The concatenated binomial is the default generated alias,
+**The rule this sets: a prefix two entries can derive is curated by neither as
+a plain alias.** Put it under `context only prefixes` on both, and give each
+species its concatenated binomial as the canonical prefix. Six entries follow
+it today. It also demoted two tie-breaks belonging to no documented form --
+`LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a 6+6) -- though those are
+uncontested, so they stay plain `other prefixes` aliases and still resolve. The concatenated binomial is the default generated alias,
 and is the only form with no collisions anywhere in the ontology.
 
 `Species.prefix_provenance` records how an entry came by its prefix:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -1787,6 +1787,12 @@ Leuciscus leuciscus:
   prefix: LeuciscusLeuciscus
   other prefixes:
     - LeucisLeucis
+  # LeucLeuc is derived by the 4+4 rule from this species and from
+  # Leucogeranus leucogeranus (Siberian crane), so it can name neither on its own. Context only:
+  # it resolves under an explicit species=, and a bare LeucLeuc-* fails
+  # loudly rather than picking a side. See #134.
+  context only prefixes:
+    - LeucLeuc
   name: Common dace
 Squalius cephalus:
   parent: Cyprinidae sp.
@@ -2158,9 +2164,13 @@ Chrysemys picta:
   # 4+4 form ChryPict is derived by the same rule from both this species and
   # Chrysolophus pictus, so it is not a safe canonical prefix for either. The
   # pheasant keeps Chpi; the turtle takes the concatenated binomial, which
-  # collides with nothing. ChryPict stays parseable. See #128.
+  # collides with nothing. See #128.
   prefix: ChrysemysPicta
-  other prefixes:
+  # ChryPict is derived by the 4+4 rule from this species and from
+  # Chrysolophus pictus (golden pheasant), so it can name neither on its own. Context only:
+  # it resolves under an explicit species=, and a bare ChryPict-* fails
+  # loudly rather than picking a side. See #134.
+  context only prefixes:
     - ChryPict
   name: Painted turtle
 Pelodiscus sinensis:
@@ -3430,7 +3440,15 @@ Grus nigricollis:
   name: Black-necked crane
 Leucogeranus leucogeranus:
   parent: Gruiformes sp.
-  prefix: LeucLeuc
+  # LeucLeuc was the canonical prefix here, but Leuciscus leuciscus derives the
+  # same 4+4 form, so it named this species only by curation order. See #134.
+  prefix: LeucogeranusLeucogeranus
+  # LeucLeuc is derived by the 4+4 rule from this species and from
+  # Leuciscus leuciscus (common dace), so it can name neither on its own. Context only:
+  # it resolves under an explicit species=, and a bare LeucLeuc-* fails
+  # loudly rather than picking a side. See #134.
+  context only prefixes:
+    - LeucLeuc
   name: Siberian crane
 ################################################################################
 #
@@ -3512,9 +3530,17 @@ Motacilla alba:
         - DAB4
 Lanius collurio:
   parent: Aves sp.
-  prefix: LaniColl
+  # LaniColl was the canonical prefix here, but Lanius collaris derives the
+  # same 4+4 form, so it named this species only by curation order. See #134.
+  prefix: LaniusCollurio
   other prefixes:
     - Laco
+  # LaniColl is derived by the 4+4 rule from this species and from
+  # Lanius collaris (fiscal shrike), so it can name neither on its own. Context only:
+  # it resolves under an explicit species=, and a bare LaniColl-* fails
+  # loudly rather than picking a side. See #134.
+  context only prefixes:
+    - LaniColl
   name: Red-backed shrike
 Emberiza citrinella:
   parent: Aves sp.
@@ -3893,6 +3919,12 @@ Lanius collaris:
   prefix: LaniusCollaris
   other prefixes:
     - LaniCola
+  # LaniColl is derived by the 4+4 rule from this species and from
+  # Lanius collurio (red-backed shrike), so it can name neither on its own. Context only:
+  # it resolves under an explicit species=, and a bare LaniColl-* fails
+  # loudly rather than picking a side. See #134.
+  context only prefixes:
+    - LaniColl
   name: Fiscal shrike
 Lanius senator:
   parent: Aves sp.
@@ -4015,6 +4047,12 @@ Gallus gallus:
 Chrysolophus pictus:
   parent: Galliformes sp.
   prefix: Chpi
+  # ChryPict is derived by the 4+4 rule from this species and from
+  # Chrysemys picta (painted turtle), so it can name neither on its own. Context only:
+  # it resolves under an explicit species=, and a bare ChryPict-* fails
+  # loudly rather than picking a side. See #134.
+  context only prefixes:
+    - ChryPict
   name: Golden pheasant
   genes:
     Ia:
@@ -4390,6 +4428,9 @@ NHP:
   # name a human?" are both answered by plain ancestry: Primata sp. is an
   # ancestor of Homo sapiens, and this node is not. See #122, #126.
   parent: Primata sp.
+  # Not written "<taxon> sp." because it is not a taxon, so group-ness is
+  # declared rather than inferred from the key. See #122, #135.
+  group: true
   prefix: NHP
   name: non-human primate
 Alouatta pigra:

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -996,12 +996,19 @@ def _is_group_entry(latin_name):
     """
     Does this entry stand for a group of species rather than one species?
 
-    Group entries are written "<taxon> sp." -- plus "NHP", which is IPD-MHC's
-    section for non-human primates and is not a taxon at all (see #122). Only
-    these hand a prefix down, which is what stops a tautonym such as
-    "Bubo bubo" (prefix "BuboBubo") from being mistaken for an umbrella.
+    Most group entries announce themselves by being written "<taxon> sp.". One
+    cannot: "NHP" is IPD-MHC's section for non-human primates and is not a
+    taxon at all (#122), so it declares "group: true" instead. Any future
+    database section that is not a clade does the same, rather than being
+    hardcoded here (#135).
+
+    Group-ness decides two things: whether a prefix that is merely the entry's
+    own name is suppressed rather than inherited, and whether provenance
+    reports "group label".
     """
-    return latin_name.endswith(" sp.") or latin_name == "NHP"
+    if raw_species_dict.get(latin_name, {}).get("group"):
+        return True
+    return latin_name.endswith(" sp.")
 
 
 # How an entry came by its prefix. "designated" means it is published
@@ -1069,6 +1076,7 @@ SPECIES_ENTRY_KEYS = frozenset(
         # reads them; they are listed so the file still loads, not because they
         # do anything. See issue #136.
         "alias",
+        "group",
         "context only prefixes",
         "gene families",
         "gene properties",

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -1074,7 +1074,7 @@ SPECIES_ENTRY_KEYS = frozenset(
     {
         # "alias" and "haplotype prefix" are present in species.yaml but nothing
         # reads them; they are listed so the file still loads, not because they
-        # do anything. See issue #136.
+        # do anything, and "alias" holds a transposed MhcPatr. See issue #139.
         "alias",
         "group",
         "context only prefixes",

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.42.0"
+__version__ = "3.43.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,118 +1,49 @@
-# Prefix provenance, and retiring the 5+5 tier
+# A contested prefix names nobody, and group-ness lives in the data
 
-Tracking issues: #128, and #129 apart from its point 3
-
-Four changes, in increasing order of reach.
+Tracking issues: #134, #135
 
 ## Specification
 
-- [x] Rename `_is_taxonomic_prefix` to `_prefix_is_derived_from_name`, which is
-      what it computes. Pure rename.
-- [x] Stop the tautonym false positive: only group entries hand a prefix down,
-      so `Bubo bubo` (prefix `BuboBubo`) is no longer treated as an umbrella.
-- [x] Remove the 5+5 tier: the generator, its collision index, and the ten
-      curated `other prefixes` entries that were 5+5 forms.
-- [x] Make the concatenated binomial the default generated alias.
-- [x] Rename only the contested 4+4 prefixes, retiring the off-book tie-breaks.
-- [x] Add `Species.prefix_provenance`, curated for "designated" and derived for
-      the rest.
+- [x] #135: replace the hardcoded `latin_name == "NHP"` in `_is_group_entry`
+      with a `group: true` key, keeping the `" sp."` suffix as the shorthand.
+- [x] #134: stop a 4+4 form derivable from two species resolving confidently to
+      whichever of them curated it.
+- [x] Give the two species that still held a contested form as their canonical
+      prefix their concatenated binomial instead.
 - [x] Measure against a worktree of `main`; update README and `docs/curation.md`.
 
 ## Review
 
-- **`_prefix_is_derived_from_name` says what it does.** The old name claimed a
-  taxonomic judgement it never made: it is a string test, and `NHP` passes it
-  while being a paraphyletic database section. The docstring now says so.
-- **The tautonym bug was latent, and is fixed.** Six species whose curated
-  prefix equals their own concatenated binomial -- `Naja naja` -> `NajaNaja`,
-  plus `Grus grus`, `Asio otus`, `Bubo bubo`, `Tyto alba`, `Bufo bufo` -- were
-  classified as umbrella nodes. All six are leaves, so nothing inherited
-  wrongly today, but adding a subspecies to any of them would have silently
-  broken prefix inheritance. Suppressing inheritance now requires a group
-  entry, so an ordinary species hands its prefix down like any other parent.
-- **5+5 is gone.** `_make_5_5_prefix` and `_GENERATED_5_5_PREFIX_COUNTS` are
-  deleted, along with ten curated aliases (`ChrysPicta`, `GaviaGange`, ...) all
-  added by 49e536e, the commit that introduced the scheme. Evidence it was
-  safe: its own docstring called it backward compatibility, `docs/curation.md`
-  never listed it, no name in the 11,558-name bundled corpora used one, and no
-  species token in the sibling `mhcseqs` dataset (590 distinct, 19,290 rows)
-  used one either.
-- **Three contested prefixes renamed, off-book forms retired.** `ChryPict` is
-  derivable from both a painted turtle and a golden pheasant; the pheasant
-  keeps the literature-style `Chpi` and the turtle takes `ChrysemysPicta`.
-  `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a 6+6) belonged to no
-  documented form and became `LaniusCollaris` and `LeuciscusLeuciscus`. All
-  three old spellings stay parseable as `other prefixes`.
-- **`prefix_provenance` is curated where it matters.** 467 entries derive
-  "generated", 29 derive "group label", 11 are curated "designated" with a
-  source read in this session, and 165 stay `None`. `None` is deliberately not
-  "designated": a prefix we did not generate is not proven to be in published
-  use, which is the `Caau` lesson. The remaining sweep is #131.
-- **Measured against a worktree of `main`:** 0 of 11,558 corpus names change,
-  despite three species changing their canonical prefix -- no corpus name uses
-  a generated form.
-- **Deliberately not done: #129's point 3.** That issue proposes emitting the
-  concatenated binomial for every species without an attested prefix, which
-  would rename 467 of 672 entries and change `to_string()` for each. Asked, and
-  the answer was to rename only the contested prefixes for now. #129 stays open
-  for the wider change; `prefix_provenance` is the field it would key off.
+- **#135 is a three-line change.** `_is_group_entry` reads `group: true` from
+  the entry and falls back to the `" sp."` suffix, and `NHP` declares the flag.
+  `SPECIES_ENTRY_KEYS` already rejects unknown keys, so the flag cannot be
+  silently misspelled. Group-ness drives both prefix inheritance and
+  `prefix_provenance`, so the next non-taxon section added -- IPD-MHC also
+  groups by `FISH` and `CHICKEN` -- no longer has to be remembered in code.
+- **#134: a contested form now resolves only under an explicit `species=`.**
+  `ChryPict`, `LaniColl` and `LeucLeuc` are each derivable by the 4+4 rule from
+  two species. The generator already refused to emit them, but that only
+  suppressed the generated copy -- whichever claimant curated the form won
+  silently, so a caller who meant a golden pheasant and wrote `ChryPict` got a
+  painted turtle. Both claimants now list the form under
+  `context only prefixes`, which is the mechanism the ontology already uses for
+  `Moal` and `Orla`:
 
-## Review round 2 (code review found a real bug in the same PR)
+  ```
+  parse("ChryPict-B")                                   -> None
+  parse("ChryPict-B", species="Chrysolophus pictus")    -> Chrysolophus pictus
+  ```
 
-- **The 4+4 branch was missing the binomial guard.** The concatenated form was
-  guarded on `len(scientific_parts) == 2`, the 4+4 form was not, so
-  `Strix occidentalis caurina` claimed `StriOcci` and
-  `Sapajus apella macrocephalus` claimed `SapaApel` -- both derived from their
-  *parent* binomial -- while the safer concatenated form was withheld. The two
-  other trinomials escaped only because their 4+4 collides with the parent, so
-  the guard was accidental. This directly contradicted a README paragraph added
-  by the same commit. Fixed, and pinned by a test naming both species.
-- **Reverted mid-PR: classifying decorated labels as "group label".** An
-  attempt to take `MusSp`, `Cosp`, `Trsp` and `Mana` off #131's list matched
-  them with string patterns (`taxon[:2] + "sp"`, `taxon[:4]`), which is a guess
-  about nomenclature, and it was wired into prefix inheritance as well.
-  Measured against main it stripped the inherited `old prefix` from 18 species
-  -- 16 `Mus`, plus `Coregonus clupeaformis` and `Tropheus moorii` -- an
-  unmeasured behaviour change. Reverted: those four stay `None` and stay on
-  #131's list, which is the honest answer.
-- **The 4+4 collision census counted entries that cannot claim a form.** It was
-  built over every latin name including trinomials, so `Canis lupus baileyi`
-  vetoed `CaniLupu` for `Canis lupus` and `Balaenoptera musculus brevicauda`
-  vetoed `BalaMusc` -- both now resolve to their binomial. Every subspecies
-  added would otherwise have removed its parent's shorthand for free.
-- **"generated" now means the emitter would emit it**, not merely that a
-  generator function can produce the string. `LaniColl` on *Lanius collurio* is
-  a curator tie-break never auto-generated for anyone, and used to claim
-  "generated"; it reports `None`.
-- **Nine of the eleven "designated" claims shipped without a URL**, against an
-  explicit rule in CLAUDE.md and AGENTS.md. All eleven now cite one, and
-  `test_every_designated_prefix_cites_a_source` fails if a future one does not
-  -- verified by mutation.
-- **Two tests could not fail.** `test_prefix_provenance_values_are_valid`
-  asserted membership in a set that both producers are constrained to by
-  construction; it is replaced by `test_designated_is_never_inferred`, which
-  checks the invariant that actually matters. The `assert len(unknown) < 300`
-  canary tested the wrong direction -- it passes a bulk assignment and fires on
-  ordinary growth -- and is replaced by pinning the eight unknowns by name.
-- **Unknown keys in species.yaml are now rejected.** A `prefix_source` typo
-  used to load silently, leaving the YAML asserting a provenance the runtime
-  never read.
-- Also fixed from review: a docstring pointing at a nonexistent `group_node`, a
-  stale numbered comment describing the deleted 5+5 tier and the wrong emission
-  order, a `docs/curation.md` collision-table row still naming `ChryPict`, two
-  species.yaml comments citing "5+5" above 4+4 prefixes, generated aliases
-  duplicating the entry's own prefix, a duplicated trinomial test, a
-  single-element `for` loop, and a "467" that is 466.
-- **Not fixed, filed instead:** #134 (colliding 4+4 forms still resolve
-  confidently to one side -- `ChryPict` gives a turtle to a caller who meant a
-  pheasant; the README now says so, but whether to demote them to
-  `context only prefixes` is a behaviour decision) and #135 (`_is_group_entry`
-  hardcodes the string `"NHP"`; the fact belongs in the data).
-- **Known and accepted:** this is a breaking parse change. 596 generated 5+5
-  aliases and 10 curated ones stop resolving, and three species normalize to a
-  new prefix. #128 laid out the choice between removing in one minor bump and a
-  deprecation cycle, and the first was chosen. Recorded in the README tier
-  section rather than a changelog, since the repo has no changelog.
-- **Measured after the round-3 fixes:** 3 entries change `old_mhc_prefix`
-  against main, all three the intended renames, down from 21.
-- Bumped 3.41.0 to 3.42.0.
+- **Two more canonical prefixes moved to the concatenated binomial.**
+  *Lanius collurio* held `LaniColl` and *Leucogeranus leucogeranus* held
+  `LeucLeuc`; both named their species only by curation order. They are now
+  `LaniusCollurio` and `LeucogeranusLeucogeranus`, forms that were already
+  parseable as generated aliases, so the rename promotes rather than invents.
+- **The rule is written down**, since the next collision will want it: a prefix
+  two entries can derive is curated by neither as a plain alias -- context only
+  on both, concatenated binomial as each canonical prefix.
+- **Measured against a worktree of `main` (3.42.0):** 0 of 11,558 corpus names
+  change. 16 structural fields differ across the 6 species involved, and no
+  others.
+- Bumped 3.42.0 to 3.43.0 -- three forms stop resolving bare, and two species
+  normalize to a new prefix.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -189,8 +189,8 @@ def test_5_5_prefixes_are_no_longer_generated():
 def test_colliding_4_4_forms_are_never_auto_generated():
     """
     Three 4+4 forms are derivable from two binomials each. None is emitted as a
-    generated alias, so the only route to one is an entry curating it, and only
-    one side of each pair does -- which is why they still resolve. See #134.
+    generated alias, and since #134 neither claimant curates one as a plain
+    alias either, so none of the three resolves on its own.
 
     A subspecies must not veto its parent's shorthand: CaniLupu and BalaMusc
     are derivable from a binomial and its own subspecies, and belong to the
@@ -200,8 +200,7 @@ def test_colliding_4_4_forms_are_never_auto_generated():
 
     for alias in ["ChryPict", "LaniColl", "LeucLeuc"]:
         eq_(_GENERATED_LONG_PREFIX_COUNTS[alias], 2)
-        assert Species.get(alias) is not None, f"{alias} lost its curated owner"
-        eq_(len(Species.get_multiple(alias)), 1)
+        assert Species.get(alias) is None, f"{alias} resolves globally"
 
     for alias, latin_name in [("CaniLupu", "Canis lupus"), ("BalaMusc", "Balaenoptera musculus")]:
         eq_(_GENERATED_LONG_PREFIX_COUNTS[alias], 1)
@@ -225,14 +224,28 @@ def test_trinomials_mint_no_generated_alias_at_all():
         assert Species.get_by_latin_name(subspecies) is not None
 
 
-def test_curated_prefix_keeps_global_owner_when_generated_alias_would_collide():
-    for prefix, latin_name in [
-        ("ChryPict", "Chrysemys picta"),
-        ("LaniColl", "Lanius collurio"),
+def test_contested_4_4_forms_resolve_only_under_explicit_species():
+    """
+    A 4+4 form derivable from two species names neither of them. Up to 3.42.0
+    one side curated it and won silently, so a caller who meant the golden
+    pheasant and wrote ChryPict got a painted turtle. Both claimants now list
+    it under `context only prefixes`, so a bare form fails and an explicit
+    species= still resolves. See #134.
+    """
+    from mhcgnomes.species import find_matching_context_only_species_objects
+
+    for form, claimants in [
+        ("ChryPict", {"Chrysemys picta", "Chrysolophus pictus"}),
+        ("LaniColl", {"Lanius collurio", "Lanius collaris"}),
+        ("LeucLeuc", {"Leucogeranus leucogeranus", "Leuciscus leuciscus"}),
     ]:
-        species = Species.get(prefix)
-        assert species is not None
-        eq_(species.name, latin_name)
+        assert Species.get(form) is None, f"bare {form!r} still resolves"
+        eq_(Species.get_multiple(form), ())
+        eq_({s.name for s in find_matching_context_only_species_objects(form)}, claimants)
+        for latin_name in claimants:
+            result = parse(f"{form}-DAB1", species=latin_name, raise_on_error=False)
+            assert result is not None, f"{form}-DAB1 not rescued by species={latin_name}"
+            eq_(result.species.name, latin_name)
 
 
 def test_explicit_short_prefixes_beat_generated_collision_aliases():


### PR DESCRIPTION
Closes #134. Closes #135.

## #135 — group-ness moves into the data

`_is_group_entry` decided whether an entry stands for a group by reading a
hardcoded literal:

```python
return latin_name.endswith(" sp.") or latin_name == "NHP"
```

That flag drives **both** prefix inheritance and `prefix_provenance`, so the
next non-taxon section added — IPD-MHC also groups by `FISH` and `CHICKEN` —
would have been silently treated as a single species, handing its label down to
every descendant as their `old prefix`. Exactly what `NHP` did to 53 primates
before #127.

```yaml
NHP:
  group: true
  prefix: NHP
```

The `" sp."` suffix stays as the shorthand for the 49 entries that already
announce themselves, and `SPECIES_ENTRY_KEYS` (from #132) rejects a
misspelling of the flag.

## #134 — a contested prefix now names nobody

`ChryPict`, `LaniColl` and `LeucLeuc` are each derivable by the 4+4 rule from
two species. The generator already refused to emit a colliding form, but that
only suppressed the *generated* copy: whichever claimant curated it won
silently.

```python
>>> parse("ChryPict-B", raise_on_error=False)       # 3.42.0
Gene(species=Chrysemys picta, name='B')             # a turtle, if you meant a pheasant
```

Both claimants now list the form under `context only prefixes` — the mechanism
the ontology already uses for `Moal` (2 owners) and `Orla` (8):

```python
>>> parse("ChryPict-B", raise_on_error=False)
None
>>> parse("ChryPict-B", species="Chrysolophus pictus").species.name
'Chrysolophus pictus'
```

That is what #108 asks for: no confident answer to an input that justifies
none.

### Two more prefixes promoted to the concatenated binomial

*Lanius collurio* held `LaniColl` and *Leucogeranus leucogeranus* held
`LeucLeuc` — naming those species only by curation order, which is precisely
what the *Chrysemys picta* comment in `species.yaml` had already called unsafe.

| species | was | now | old spelling |
|---|---|---|---|
| *Chrysemys picta* | `ChrysemysPicta` | `ChrysemysPicta` | `ChryPict` → context only |
| *Chrysolophus pictus* | `Chpi` | `Chpi` | `ChryPict` → context only |
| *Lanius collurio* | `LaniColl` | `LaniusCollurio` | `LaniColl` → context only |
| *Lanius collaris* | `LaniusCollaris` | `LaniusCollaris` | `LaniCola` stays an alias |
| *Leucogeranus leucogeranus* | `LeucLeuc` | `LeucogeranusLeucogeranus` | `LeucLeuc` → context only |
| *Leuciscus leuciscus* | `LeuciscusLeuciscus` | `LeuciscusLeuciscus` | `LeucisLeucis` stays an alias |

Both new prefixes were already parseable as generated aliases, so the rename
promotes rather than invents. The *uncontested* old spellings stay plain
aliases — only forms two entries can derive are demoted.

### The rule, written down

`docs/curation.md` now states it, since the next collision will want it: **a
prefix two entries can derive is curated by neither as a plain alias** — context
only on both, concatenated binomial as each canonical prefix.

## Measurement

Against a `git worktree` of `main` (3.42.0):

| check | result |
|---|---|
| bundled netMHCpan 3.0/4.0, netMHCIIpan 3.1, IEDB corpora | **0 of 11,558** change |
| 15 structural fields × 672 species | **16** differ, all across the 6 species above |

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,557 passed. 3.42.0 → 3.43.0,
since three forms stop resolving bare and two species normalize differently.
