### PR TITLE
Give Gene the class II chain predicates it never had

### DIFF
--- a/mhcgnomes/result_with_gene.py
+++ b/mhcgnomes/result_with_gene.py
@@ -39,16 +39,3 @@ class ResultWithGene(ResultWithMhcClass):
     @property
     def gene_name(self):
         return self.gene.name
-
-    @property
-    def is_class2_alpha(self):
-        return (
-            self.is_class2
-            and self.species.class2_gene_name_to_chain_type[self.gene_name] == "alpha"
-        )
-
-    @property
-    def is_class2_beta(self):
-        return (
-            self.is_class2 and self.species.class2_gene_name_to_chain_type[self.gene_name] == "beta"
-        )

--- a/mhcgnomes/result_with_mhc_class.py
+++ b/mhcgnomes/result_with_mhc_class.py
@@ -42,3 +42,32 @@ class ResultWithMhcClass(ResultWithSpecies):
     @property
     def is_class2(self):
         return is_class2(self.mhc_class)
+
+    @property
+    def class2_chain_type(self):
+        """
+        "alpha", "beta", or None for anything that does not name one gene.
+
+        Lives here rather than on ResultWithGene so that Gene gets it too.
+        Gene is a sibling of ResultWithGene rather than a subclass, so before
+        this it fell through to Result's `return False` stubs and every class II
+        gene reported neither chain -- which also made "HLA-DRA alpha"
+        unparseable, since the parser gates chain-suffixed candidates on these
+        predicates while listing Gene among the candidate types. See #137.
+
+        Pair has no single gene name and correctly answers None.
+        """
+        gene_name = getattr(self, "gene_name", None)
+        if not self.is_class2 or not gene_name:
+            return None
+        # .get rather than [] : a class II gene with no curated chain type is
+        # unknown, not a crash. None today, but the ontology grows.
+        return self.species.class2_gene_name_to_chain_type.get(gene_name)
+
+    @property
+    def is_class2_alpha(self):
+        return self.class2_chain_type == "alpha"
+
+    @property
+    def is_class2_beta(self):
+        return self.class2_chain_type == "beta"

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.42.0"
+__version__ = "3.43.1"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,118 +1,49 @@
-# Prefix provenance, and retiring the 5+5 tier
+# Give Gene the class II chain predicates it never had
 
-Tracking issues: #128, and #129 apart from its point 3
-
-Four changes, in increasing order of reach.
+Tracking issue: #137
 
 ## Specification
 
-- [x] Rename `_is_taxonomic_prefix` to `_prefix_is_derived_from_name`, which is
-      what it computes. Pure rename.
-- [x] Stop the tautonym false positive: only group entries hand a prefix down,
-      so `Bubo bubo` (prefix `BuboBubo`) is no longer treated as an umbrella.
-- [x] Remove the 5+5 tier: the generator, its collision index, and the ten
-      curated `other prefixes` entries that were 5+5 forms.
-- [x] Make the concatenated binomial the default generated alias.
-- [x] Rename only the contested 4+4 prefixes, retiring the off-book tie-breaks.
-- [x] Add `Species.prefix_provenance`, curated for "designated" and derived for
-      the rest.
-- [x] Measure against a worktree of `main`; update README and `docs/curation.md`.
+- [x] Reproduce: confirm `Gene.is_class2_alpha` / `is_class2_beta` are the
+      inherited `Result` stubs, and that five chain-suffixed inputs fail.
+- [x] Put one implementation where both `Gene` and `Allele` can reach it.
+- [x] Check the mismatched-suffix case still fails.
+- [x] Measure against a worktree of `main`.
 
 ## Review
 
-- **`_prefix_is_derived_from_name` says what it does.** The old name claimed a
-  taxonomic judgement it never made: it is a string test, and `NHP` passes it
-  while being a paraphyletic database section. The docstring now says so.
-- **The tautonym bug was latent, and is fixed.** Six species whose curated
-  prefix equals their own concatenated binomial -- `Naja naja` -> `NajaNaja`,
-  plus `Grus grus`, `Asio otus`, `Bubo bubo`, `Tyto alba`, `Bufo bufo` -- were
-  classified as umbrella nodes. All six are leaves, so nothing inherited
-  wrongly today, but adding a subspecies to any of them would have silently
-  broken prefix inheritance. Suppressing inheritance now requires a group
-  entry, so an ordinary species hands its prefix down like any other parent.
-- **5+5 is gone.** `_make_5_5_prefix` and `_GENERATED_5_5_PREFIX_COUNTS` are
-  deleted, along with ten curated aliases (`ChrysPicta`, `GaviaGange`, ...) all
-  added by 49e536e, the commit that introduced the scheme. Evidence it was
-  safe: its own docstring called it backward compatibility, `docs/curation.md`
-  never listed it, no name in the 11,558-name bundled corpora used one, and no
-  species token in the sibling `mhcseqs` dataset (590 distinct, 19,290 rows)
-  used one either.
-- **Three contested prefixes renamed, off-book forms retired.** `ChryPict` is
-  derivable from both a painted turtle and a golden pheasant; the pheasant
-  keeps the literature-style `Chpi` and the turtle takes `ChrysemysPicta`.
-  `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a 6+6) belonged to no
-  documented form and became `LaniusCollaris` and `LeuciscusLeuciscus`. All
-  three old spellings stay parseable as `other prefixes`.
-- **`prefix_provenance` is curated where it matters.** 467 entries derive
-  "generated", 29 derive "group label", 11 are curated "designated" with a
-  source read in this session, and 165 stay `None`. `None` is deliberately not
-  "designated": a prefix we did not generate is not proven to be in published
-  use, which is the `Caau` lesson. The remaining sweep is #131.
-- **Measured against a worktree of `main`:** 0 of 11,558 corpus names change,
-  despite three species changing their canonical prefix -- no corpus name uses
-  a generated form.
-- **Deliberately not done: #129's point 3.** That issue proposes emitting the
-  concatenated binomial for every species without an attested prefix, which
-  would rename 467 of 672 entries and change `to_string()` for each. Asked, and
-  the answer was to rename only the contested prefixes for now. #129 stays open
-  for the wider change; `prefix_provenance` is the field it would key off.
+- **`Gene` is a sibling of `ResultWithGene`, not a subclass.** Both descend
+  from `ResultWithMhcClass`. `ResultWithGene` implemented the two predicates,
+  so `Allele` and `Pair` were fine and `Gene` fell through to `Result`, where
+  both are `return False`. Every class II gene therefore reported neither
+  chain, with the answer sitting in `species.class2_gene_name_to_chain_type`.
+- **It broke parsing, not just the API.** `parser.py` gates chain-suffixed
+  candidates on these predicates and lists `Gene` among the candidate types, so
+  a `Gene` candidate could never satisfy either branch:
 
-## Review round 2 (code review found a real bug in the same PR)
+  ```
+  HLA-DRA alpha    ParseError     HLA-DR alpha         Gene HLA-DRA
+  HLA-DRB1 beta    ParseError     HLA-DRA*01:01 alpha  Allele HLA-DRA*01:01
+  ```
 
-- **The 4+4 branch was missing the binomial guard.** The concatenated form was
-  guarded on `len(scientific_parts) == 2`, the 4+4 form was not, so
-  `Strix occidentalis caurina` claimed `StriOcci` and
-  `Sapajus apella macrocephalus` claimed `SapaApel` -- both derived from their
-  *parent* binomial -- while the safer concatenated form was withheld. The two
-  other trinomials escaped only because their 4+4 collides with the parent, so
-  the guard was accidental. This directly contradicted a README paragraph added
-  by the same commit. Fixed, and pinned by a test naming both species.
-- **Reverted mid-PR: classifying decorated labels as "group label".** An
-  attempt to take `MusSp`, `Cosp`, `Trsp` and `Mana` off #131's list matched
-  them with string patterns (`taxon[:2] + "sp"`, `taxon[:4]`), which is a guess
-  about nomenclature, and it was wired into prefix inheritance as well.
-  Measured against main it stripped the inherited `old prefix` from 18 species
-  -- 16 `Mus`, plus `Coregonus clupeaformis` and `Tropheus moorii` -- an
-  unmeasured behaviour change. Reverted: those four stay `None` and stay on
-  #131's list, which is the honest answer.
-- **The 4+4 collision census counted entries that cannot claim a form.** It was
-  built over every latin name including trinomials, so `Canis lupus baileyi`
-  vetoed `CaniLupu` for `Canis lupus` and `Balaenoptera musculus brevicauda`
-  vetoed `BalaMusc` -- both now resolve to their binomial. Every subspecies
-  added would otherwise have removed its parent's shorthand for free.
-- **"generated" now means the emitter would emit it**, not merely that a
-  generator function can produce the string. `LaniColl` on *Lanius collurio* is
-  a curator tie-break never auto-generated for anyone, and used to claim
-  "generated"; it reports `None`.
-- **Nine of the eleven "designated" claims shipped without a URL**, against an
-  explicit rule in CLAUDE.md and AGENTS.md. All eleven now cite one, and
-  `test_every_designated_prefix_cites_a_source` fails if a future one does not
-  -- verified by mutation.
-- **Two tests could not fail.** `test_prefix_provenance_values_are_valid`
-  asserted membership in a set that both producers are constrained to by
-  construction; it is replaced by `test_designated_is_never_inferred`, which
-  checks the invariant that actually matters. The `assert len(unknown) < 300`
-  canary tested the wrong direction -- it passes a bulk assignment and fires on
-  ordinary growth -- and is replaced by pinning the eight unknowns by name.
-- **Unknown keys in species.yaml are now rejected.** A `prefix_source` typo
-  used to load silently, leaving the YAML asserting a provenance the runtime
-  never read.
-- Also fixed from review: a docstring pointing at a nonexistent `group_node`, a
-  stale numbered comment describing the deleted 5+5 tier and the wrong emission
-  order, a `docs/curation.md` collision-table row still naming `ChryPict`, two
-  species.yaml comments citing "5+5" above 4+4 prefixes, generated aliases
-  duplicating the entry's own prefix, a duplicated trinomial test, a
-  single-element `for` loop, and a "467" that is 466.
-- **Not fixed, filed instead:** #134 (colliding 4+4 forms still resolve
-  confidently to one side -- `ChryPict` gives a turtle to a caller who meant a
-  pheasant; the README now says so, but whether to demote them to
-  `context only prefixes` is a behaviour decision) and #135 (`_is_group_entry`
-  hardcodes the string `"NHP"`; the fact belongs in the data).
-- **Known and accepted:** this is a breaking parse change. 596 generated 5+5
-  aliases and 10 curated ones stop resolving, and three species normalize to a
-  new prefix. #128 laid out the choice between removing in one minor bump and a
-  deprecation cycle, and the first was chosen. Recorded in the README tier
-  section rather than a changelog, since the repo has no changelog.
-- **Measured after the round-3 fixes:** 3 entries change `old_mhc_prefix`
-  against main, all three the intended renames, down from 21.
-- Bumped 3.41.0 to 3.42.0.
+  The *less* specific input parsed and the more specific one did not, because
+  `HLA-DR` is a `Class2Locus` and took a different branch.
+- **The implementation moved up to `ResultWithMhcClass`** rather than being
+  copied into `Gene`, and `ResultWithGene`'s copy is deleted. One expression
+  now answers for `Gene`, `Allele` and `Pair`, and `Pair` -- which names no
+  single gene -- correctly answers `None` through the same code path instead of
+  through a stub that happened to agree.
+- **A latent KeyError fixed on the way.** The old implementation indexed the
+  chain table with `[]`, so a class II gene with no curated chain type would
+  have crashed. Nothing in the ontology hits that today (a test asserts so),
+  and `.get` now reports `None` rather than raising if one ever does.
+- **Mismatched suffixes are still rejected**: `HLA-DRA beta`, `HLA-DRB1 alpha`
+  and `HLA-DQA1 beta` all return `None`, so this answers the chain question
+  rather than accepting any trailing word. `HLA-A alpha` parses because the
+  class I heavy chain is an alpha chain, which is the existing rule.
+- **Measured against a worktree of `main`:** 0 of 11,558 corpus names change.
+  The change is purely additive -- names that failed now parse -- and no corpus
+  name carries a chain suffix.
+- 30 new tests, verified by mutation: stubbing the chain lookup back out fails
+  14 of them.
+- Bumped to 3.43.1, assuming #138 lands first as 3.43.0.

--- a/tests/test_class2_chain_predicates.py
+++ b/tests/test_class2_chain_predicates.py
@@ -1,0 +1,132 @@
+"""
+Which chain a class II result names, and the parses that depend on it.
+
+`Gene` is a sibling of `ResultWithGene` rather than a subclass, so before
+3.43.0 it fell through to `Result`'s `return False` stubs: every class II gene
+reported neither chain, even with the chain type sitting in the species table.
+That also broke parsing, because the parser gates chain-suffixed candidates on
+these predicates while listing `Gene` among the candidate types.
+
+https://github.com/pirl-unc/mhcgnomes/issues/137
+"""
+
+import pytest
+
+from mhcgnomes import Gene, parse
+
+from .common import eq_, ok_
+
+ALPHA_GENES = ["DRA", "DQA1", "DPA1"]
+BETA_GENES = ["DRB1", "DQB1", "DPB1"]
+
+
+@pytest.mark.parametrize("gene_name", ALPHA_GENES)
+def test_class2_alpha_gene_reports_alpha(gene_name):
+    gene = parse(f"HLA-{gene_name}", required_result_types=[Gene])
+    ok_(gene.is_class2)
+    eq_(gene.class2_chain_type, "alpha")
+    ok_(gene.is_class2_alpha)
+    ok_(not gene.is_class2_beta)
+
+
+@pytest.mark.parametrize("gene_name", BETA_GENES)
+def test_class2_beta_gene_reports_beta(gene_name):
+    gene = parse(f"HLA-{gene_name}", required_result_types=[Gene])
+    eq_(gene.class2_chain_type, "beta")
+    ok_(gene.is_class2_beta)
+    ok_(not gene.is_class2_alpha)
+
+
+@pytest.mark.parametrize("gene_name", ALPHA_GENES + BETA_GENES)
+def test_gene_and_allele_agree_on_chain(gene_name):
+    """
+    Allele got the real implementation from ResultWithGene while Gene got the
+    stub, so the two disagreed about the same locus.
+    """
+    gene = parse(f"HLA-{gene_name}", required_result_types=[Gene])
+    allele = parse(f"HLA-{gene_name}*01:01")
+    eq_(gene.class2_chain_type, allele.class2_chain_type)
+    eq_(gene.is_class2_alpha, allele.is_class2_alpha)
+    eq_(gene.is_class2_beta, allele.is_class2_beta)
+
+
+# A bare gene plus a chain word. Every one of these raised ParseError before
+# 3.43.0, while the *less* specific "HLA-DR alpha" parsed, because that takes
+# the Class2Locus branch instead of the Gene branch.
+CHAIN_SUFFIXED = [
+    ("HLA-DRA alpha", "HLA-DRA"),
+    ("HLA-DRB1 beta", "HLA-DRB1"),
+    ("HLA-DQA1 alpha", "HLA-DQA1"),
+    ("HLA-DQB1 beta", "HLA-DQB1"),
+    ("HLA-DPA1 alpha", "HLA-DPA1"),
+    ("HLA-DPB1 beta", "HLA-DPB1"),
+]
+
+
+@pytest.mark.parametrize("name,expected", CHAIN_SUFFIXED)
+def test_chain_suffixed_gene_parses(name, expected):
+    eq_(parse(name).to_string(), expected)
+
+
+@pytest.mark.parametrize(
+    "name", ["HLA-DR alpha", "H2-IA alpha", "HLA-DRA*01:01 alpha", "HLA-DQA1*01:01 alpha"]
+)
+def test_paths_that_already_worked_still_work(name):
+    assert parse(name, raise_on_error=False) is not None
+
+
+@pytest.mark.parametrize("name", ["HLA-DRA beta", "HLA-DRB1 alpha", "HLA-DQA1 beta", "HLA-A beta"])
+def test_a_mismatched_chain_word_is_still_rejected(name):
+    """The point is to answer the chain question, not to accept any suffix."""
+    eq_(parse(name, raise_on_error=False), None)
+
+
+def test_class1_gene_is_not_a_class2_chain():
+    gene = parse("HLA-A", required_result_types=[Gene])
+    eq_(gene.class2_chain_type, None)
+    ok_(not gene.is_class2_alpha)
+    ok_(not gene.is_class2_beta)
+
+
+def test_pair_names_no_single_chain():
+    """A Pair has an alpha and a beta, so it is neither."""
+    pair = parse("HLA-DQA1*01:01/DQB1*02:01")
+    eq_(pair.class2_chain_type, None)
+    ok_(not pair.is_class2_alpha)
+    ok_(not pair.is_class2_beta)
+
+
+def test_unknown_chain_type_reports_none_instead_of_raising():
+    """
+    The old implementation indexed the chain table with `[]`, so a class II
+    gene with no curated chain type would have raised KeyError. Nothing in the
+    ontology hits that today, so this exercises the property against a stand-in
+    rather than mutating a cached Species -- which would leak the missing entry
+    into every test that ran afterwards.
+    """
+    from mhcgnomes.result_with_mhc_class import ResultWithMhcClass
+
+    class FakeSpecies:
+        class2_gene_name_to_chain_type = {}
+
+    class ClassIIResultWithNoChainType:
+        gene_name = "DRA"
+        species = FakeSpecies()
+        is_class2 = True
+        class2_chain_type = ResultWithMhcClass.class2_chain_type
+
+    eq_(ClassIIResultWithNoChainType().class2_chain_type, None)
+
+
+def test_the_real_ontology_gives_every_class2_gene_a_chain_type():
+    """The companion to the test above: today the .get never misses."""
+    from mhcgnomes.species import latin_name_to_species_object
+
+    missing = [
+        (species.name, gene_name)
+        for species in latin_name_to_species_object.values()
+        for gene_name in species.gene_names
+        if species.get_mhc_class_of_gene(gene_name) in ("II", "IIa", "IIb")
+        and gene_name not in species.class2_gene_name_to_chain_type
+    ]
+    eq_(missing, [], f"class II genes with no curated chain type: {missing[:5]}")


### PR DESCRIPTION
Closes #137.

## The cause

`Gene` is a **sibling** of `ResultWithGene`, not a subclass — both descend from
`ResultWithMhcClass`. `ResultWithGene` implemented the two chain predicates, so
`Allele` was fine and `Gene` fell through to `Result`, where both are
`return False`. Every class II gene reported neither chain, with the answer
sitting unused in `species.class2_gene_name_to_chain_type`:

```python
>>> g = parse("HLA-DRA", required_result_types=[Gene])
>>> g.is_class2, g.is_class2_alpha, g.is_class2_beta
(True, False, False)
>>> g.species.class2_gene_name_to_chain_type["DRA"]
'alpha'
```

## Why it broke parsing

`parser.py:1822/1855` gate chain-suffixed candidates on those predicates while
listing `Gene` among the candidate types, so a `Gene` candidate could never
satisfy either branch — and the failure was inconsistent in a way that hid it:

| input | before | why |
|---|---|---|
| `HLA-DRA alpha` | **ParseError** | `Gene` branch, predicate stubbed |
| `HLA-DR alpha` | `Gene HLA-DRA` | `HLA-DR` is a `Class2Locus`, different branch |
| `HLA-DRA*01:01 alpha` | `Allele HLA-DRA*01:01` | `Allele` had the real implementation |

The *less* specific input parsed and the more specific one did not.

## The fix

The implementation moves up to `ResultWithMhcClass` rather than being copied
into `Gene`, and `ResultWithGene`'s copy is deleted — one expression now
answers for `Gene`, `Allele` and `Pair`. `Pair` names no single gene and
answers `None` through that same path, instead of through a stub that happened
to agree.

All five reported inputs parse, plus `HLA-DPB1 beta`:

```
HLA-DRA alpha   -> HLA-DRA      HLA-DQB1 beta   -> HLA-DQB1
HLA-DRB1 beta   -> HLA-DRB1     HLA-DPA1 alpha  -> HLA-DPA1
HLA-DQA1 alpha  -> HLA-DQA1     HLA-DPB1 beta   -> HLA-DPB1
```

**A mismatched suffix is still rejected** — `HLA-DRA beta`, `HLA-DRB1 alpha`
and `HLA-DQA1 beta` all return `None` — so this answers the chain question
rather than accepting any trailing word. `HLA-A alpha` parses because the class
I heavy chain is an alpha chain, which is the existing rule.

**A latent KeyError goes with it.** The old implementation indexed the chain
table with `[]`, so a class II gene with no curated chain type would have
crashed. Nothing in the ontology hits that today — a test asserts it — and
`.get` reports `None` if anything ever does.

## Measurement

Against a `git worktree` of `main`: **0 of 11,558** corpus names change. The
fix is purely additive — names that failed now parse — and no corpus name
carries a chain suffix.

30 new tests in `tests/test_class2_chain_predicates.py`, verified by mutation:
stubbing the chain lookup back out fails 14 of them.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,587 passed. Version 3.43.1,
assuming #138 lands first as 3.43.0.
