### PR TITLE
Stop telling users a derived prefix collision is source-attested

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,29 +507,46 @@ and *Chrysolophus pictus*, `LaniColl` from two shrikes, `LeucLeuc` from a dace
 and a crane. Since 3.43.0 none of them resolves on its own:
 
 ```python
->>> parse("ChryPict-B", raise_on_error=False)
-None                       # was a painted turtle, even if you meant the pheasant
->>> parse("ChryPict-B", species="Chrysolophus pictus").species.name
+>>> parse("ChryPict-UA*01", raise_on_error=False)
+None                       # 3.42.0 gave a painted turtle, even if you meant the pheasant
+>>> parse("ChryPict-UA*01", species="Chrysolophus pictus").species.name
 'Chrysolophus pictus'      # explicit species still resolves it
 ```
 
+Raising instead of returning `None` explains the ambiguity rather than the
+symptom:
+
+```
+Prefix 'ChryPict' is derivable by the same naming rule from Chrysemys picta,
+Chrysolophus pictus, so it names neither. Use species='<latin name>' or an
+unambiguous prefix such as ChrysemysPicta (Chrysemys picta),
+ChrysolophusPictus (Chrysolophus pictus).
+```
+
 Both claimants list the form under `context only prefixes`, so it resolves
-only when the caller has already said which species they mean. The species that
-had held a contested form as their canonical prefix use their concatenated
-binomial instead — three entries did, in 3.42.0:
+only when the caller has already said which species they mean. **This is a breaking parse change.** `ChryPict`, `LaniColl` and `LeucLeuc` all
+resolved on 3.42.0 and now need an explicit `species=`. The species that had
+held a contested form as their canonical prefix use their concatenated binomial
+instead, so their normalized output changes too.
+
+Canonical prefix changed **in 3.42.0**:
 
 | species | was | now | old spelling |
 |---|---|---|---|
-| *Chrysemys picta* | `ChryPict` | `ChrysemysPicta` | context only |
-| *Chrysolophus pictus* | `Chpi` | `Chpi` | — |
-| *Lanius collurio* | `LaniColl` | `LaniusCollurio` | context only |
-| *Lanius collaris* | `LaniCola` | `LaniusCollaris` | alias |
-| *Leucogeranus leucogeranus* | `LeucLeuc` | `LeucogeranusLeucogeranus` | context only |
-| *Leuciscus leuciscus* | `LeucisLeucis` | `LeuciscusLeuciscus` | alias |
+| *Chrysemys picta* | `ChryPict` | `ChrysemysPicta` | alias, then context only in 3.43.0 |
+| *Lanius collaris* | `LaniCola` | `LaniusCollaris` | plain alias, uncontested |
+| *Leuciscus leuciscus* | `LeucisLeucis` | `LeuciscusLeuciscus` | plain alias, uncontested |
 
-Normalized output changes accordingly. The uncontested old spellings
-(`LaniCola`, `LeucisLeucis`) stay parseable as plain aliases; the contested
-ones (`ChryPict`, `LaniColl`, `LeucLeuc`) need an explicit `species=`.
+Canonical prefix changed **in 3.43.0**, because each still held a form its
+sibling derives too:
+
+| species | was | now | old spelling |
+|---|---|---|---|
+| *Lanius collurio* | `LaniColl` | `LaniusCollurio` | context only |
+| *Leucogeranus leucogeranus* | `LeucLeuc` | `LeucogeranusLeucogeranus` | context only |
+
+*Chrysolophus pictus* keeps `Chpi` throughout and gains `ChryPict` as a
+context-only prefix, since it derives that form as well.
 
 **Subspecies mint no generated alias.** A trinomial entry such as *Canis lupus
 baileyi* deliberately does not claim `CanisLupus`, which belongs to its parent

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -107,9 +107,14 @@ behavior.
 1. If the species prefix and canonical gene names are stable, add them to `species.yaml`.
 2. If a new string can normalize to an existing canonical gene, put it in `gene_aliases.yaml`.
 3. If a new string can normalize to an existing canonical allele, put it in `allele_aliases.yaml`.
-4. If the source only tells us "this clade probably has class I / class IIbeta / TAP genes" but not stable canonical names, capture it in `underrepresented_taxa_source_registry.yaml`.
-5. If the source is a survey paper with paper-local allele IDs, do not put those IDs in runtime YAML unless they map cleanly onto stable canonical names.
-6. If the data encodes a derived concept like a serotype, supertype, haplotype, or heterodimer shorthand, use the dedicated file for that concept rather than overloading `species.yaml`.
+4. If the source only tells us "this clade probably has class I / class IIbeta
+/ TAP genes" but not stable canonical names, capture it in
+`underrepresented_taxa_source_registry.yaml`.
+5. If the source is a survey paper with paper-local allele IDs, do not put
+those IDs in runtime YAML unless they map cleanly onto stable canonical names.
+6. If the data encodes a derived concept like a serotype, supertype,
+haplotype, or heterodimer shorthand, use the dedicated file for that concept
+rather than overloading `species.yaml`.
 
 ## Prefix Conflict Resolution Plan
 
@@ -136,6 +141,14 @@ but `parse(..., species="<latin name>")` may reinterpret them in the requested
 species context. This is the right bucket for cases like `Hymo`, `Moal`, and
 fish-side `Orla`, where the source string is real but the bare prefix is not a
 safe global identifier.
+
+    A second case belongs here too, added in 3.43.0: a prefix that is *not*
+    attested for anyone, because two entries derive it by the same mechanical
+    rule. `ChryPict` comes from the 4+4 rule applied to both *Chrysemys picta*
+    and *Chrysolophus pictus*, so both list it as context-only and neither owns
+    it. The error message distinguishes the two cases -- "source-attested for
+    multiple species" versus "derivable by the same naming rule ... so it names
+    neither" -- because calling a derived form attested invents provenance.
 
 Corollary: do not auto-generate new 2+2 / 4-letter runtime aliases from Latin
 names. Add a short alias only when an explicit source attests that exact
@@ -190,7 +203,8 @@ parent is a group entry labelled with its own taxon name -- `Aves sp.` with
 `Aves`, `NHP` with `NHP`. Most group entries announce themselves by ending in
 `sp.`; `NHP` cannot, since it is not a taxon, so it carries `group: true`
 instead -- and so should any future database section that is not a clade,
-rather than being named in the loader (#135). Designations are inherited (`BoLA`, `DLA`, `RhLA`),
+rather than being named in the loader (#135). Designations are inherited
+(`BoLA`, `DLA`, `RhLA`),
 and so are decorated group labels that are not simply the taxon (`Mus sp.` with
 `MusSp`). The child must also not declare an `old prefix` of its own. Note this
 is the *immediate* parent: `Macaca mulatta` inherits `RhLA` from `Macaca sp.`,
@@ -413,15 +427,18 @@ that only suppresses the generated copy -- where one side of a pair curates the
 form as its prefix or as an `other prefixes` entry, it still resolves globally
 and to that side alone -- confidently, which was the bug in #134. Since 3.43.0
 none of the three resolves on its own: both claimants list the form under
-`context only prefixes`, so `ChryPict-B` fails and
-`parse("ChryPict-B", species="Chrysolophus pictus")` works.
+`context only prefixes`, so `ChryPict-UA*01` raises with an explanation and
+`parse("ChryPict-UA*01", species="Chrysolophus pictus")` works. (`ChryPict-B`
+is not the example to reach for: *Chrysemys picta* has no `B` gene, so that
+string failed on 3.42.0 too.)
 
 **The rule this sets: a prefix two entries can derive is curated by neither as
 a plain alias.** Put it under `context only prefixes` on both, and give each
 species its concatenated binomial as the canonical prefix. Six entries follow
 it today. It also demoted two tie-breaks belonging to no documented form --
 `LaniCola` (a hand-tweaked 4+4) and `LeucisLeucis` (a 6+6) -- though those are
-uncontested, so they stay plain `other prefixes` aliases and still resolve. The concatenated binomial is the default generated alias,
+uncontested, so they stay plain `other prefixes` aliases and still resolve.
+The concatenated binomial is the default generated alias,
 and is the only form with no collisions anywhere in the ontology.
 
 `Species.prefix_provenance` records how an entry came by its prefix:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -1787,10 +1787,8 @@ Leuciscus leuciscus:
   prefix: LeuciscusLeuciscus
   other prefixes:
     - LeucisLeucis
-  # LeucLeuc is derived by the 4+4 rule from this species and from
-  # Leucogeranus leucogeranus (Siberian crane), so it can name neither on its own. Context only:
-  # it resolves under an explicit species=, and a bare LeucLeuc-* fails
-  # loudly rather than picking a side. See #134.
+  # LeucLeuc is derivable by the 4+4 rule from this species and from
+  # Leucogeranus leucogeranus (Siberian crane) so it names neither; see "contested prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LeucLeuc
   name: Common dace
@@ -2166,10 +2164,8 @@ Chrysemys picta:
   # pheasant keeps Chpi; the turtle takes the concatenated binomial, which
   # collides with nothing. See #128.
   prefix: ChrysemysPicta
-  # ChryPict is derived by the 4+4 rule from this species and from
-  # Chrysolophus pictus (golden pheasant), so it can name neither on its own. Context only:
-  # it resolves under an explicit species=, and a bare ChryPict-* fails
-  # loudly rather than picking a side. See #134.
+  # ChryPict is derivable by the 4+4 rule from this species and from
+  # Chrysolophus pictus (golden pheasant) so it names neither; see "contested prefixes" in docs/curation.md (#134).
   context only prefixes:
     - ChryPict
   name: Painted turtle
@@ -3443,10 +3439,8 @@ Leucogeranus leucogeranus:
   # LeucLeuc was the canonical prefix here, but Leuciscus leuciscus derives the
   # same 4+4 form, so it named this species only by curation order. See #134.
   prefix: LeucogeranusLeucogeranus
-  # LeucLeuc is derived by the 4+4 rule from this species and from
-  # Leuciscus leuciscus (common dace), so it can name neither on its own. Context only:
-  # it resolves under an explicit species=, and a bare LeucLeuc-* fails
-  # loudly rather than picking a side. See #134.
+  # LeucLeuc is derivable by the 4+4 rule from this species and from
+  # Leuciscus leuciscus (common dace) so it names neither; see "contested prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LeucLeuc
   name: Siberian crane
@@ -3535,10 +3529,8 @@ Lanius collurio:
   prefix: LaniusCollurio
   other prefixes:
     - Laco
-  # LaniColl is derived by the 4+4 rule from this species and from
-  # Lanius collaris (fiscal shrike), so it can name neither on its own. Context only:
-  # it resolves under an explicit species=, and a bare LaniColl-* fails
-  # loudly rather than picking a side. See #134.
+  # LaniColl is derivable by the 4+4 rule from this species and from
+  # Lanius collaris (fiscal shrike) so it names neither; see "contested prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LaniColl
   name: Red-backed shrike
@@ -3919,10 +3911,8 @@ Lanius collaris:
   prefix: LaniusCollaris
   other prefixes:
     - LaniCola
-  # LaniColl is derived by the 4+4 rule from this species and from
-  # Lanius collurio (red-backed shrike), so it can name neither on its own. Context only:
-  # it resolves under an explicit species=, and a bare LaniColl-* fails
-  # loudly rather than picking a side. See #134.
+  # LaniColl is derivable by the 4+4 rule from this species and from
+  # Lanius collurio (red-backed shrike) so it names neither; see "contested prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LaniColl
   name: Fiscal shrike
@@ -4047,10 +4037,8 @@ Gallus gallus:
 Chrysolophus pictus:
   parent: Galliformes sp.
   prefix: Chpi
-  # ChryPict is derived by the 4+4 rule from this species and from
-  # Chrysemys picta (painted turtle), so it can name neither on its own. Context only:
-  # it resolves under an explicit species=, and a bare ChryPict-* fails
-  # loudly rather than picking a side. See #134.
+  # ChryPict is derivable by the 4+4 rule from this species and from
+  # Chrysemys picta (painted turtle) so it names neither; see "contested prefixes" in docs/curation.md (#134).
   context only prefixes:
     - ChryPict
   name: Golden pheasant

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -432,7 +432,8 @@ Crocodylia sp.:
 # - http://www.imgt.org/IMGTrepertoireMHC/LocusGenes/nomenclatures/human/MHC/human_MHCnom.html
 ######################################################
 Homo sapiens:
-  # prefix source: designated -- IMGT/HLA names every human allele with it: https://hla.alleles.org/genes/index.html
+  # prefix source: designated -- IMGT/HLA names every human allele with it:
+  # https://hla.alleles.org/genes/index.html
   prefix source: designated
   prefix: HLA
   # NCBI Taxonomy places Homo sapiens (taxid 9606) in Primates (taxid 9443),

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -1788,7 +1788,8 @@ Leuciscus leuciscus:
   other prefixes:
     - LeucisLeucis
   # LeucLeuc is derivable by the 4+4 rule from this species and from
-  # Leucogeranus leucogeranus (Siberian crane) so it names neither; see "contested prefixes" in docs/curation.md (#134).
+  # Leucogeranus leucogeranus (Siberian crane) so it names neither; see "contested
+  # prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LeucLeuc
   name: Common dace
@@ -2165,7 +2166,8 @@ Chrysemys picta:
   # collides with nothing. See #128.
   prefix: ChrysemysPicta
   # ChryPict is derivable by the 4+4 rule from this species and from
-  # Chrysolophus pictus (golden pheasant) so it names neither; see "contested prefixes" in docs/curation.md (#134).
+  # Chrysolophus pictus (golden pheasant) so it names neither; see "contested
+  # prefixes" in docs/curation.md (#134).
   context only prefixes:
     - ChryPict
   name: Painted turtle
@@ -3440,7 +3442,8 @@ Leucogeranus leucogeranus:
   # same 4+4 form, so it named this species only by curation order. See #134.
   prefix: LeucogeranusLeucogeranus
   # LeucLeuc is derivable by the 4+4 rule from this species and from
-  # Leuciscus leuciscus (common dace) so it names neither; see "contested prefixes" in docs/curation.md (#134).
+  # Leuciscus leuciscus (common dace) so it names neither; see "contested
+  # prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LeucLeuc
   name: Siberian crane
@@ -3530,7 +3533,8 @@ Lanius collurio:
   other prefixes:
     - Laco
   # LaniColl is derivable by the 4+4 rule from this species and from
-  # Lanius collaris (fiscal shrike) so it names neither; see "contested prefixes" in docs/curation.md (#134).
+  # Lanius collaris (fiscal shrike) so it names neither; see "contested
+  # prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LaniColl
   name: Red-backed shrike
@@ -3912,7 +3916,8 @@ Lanius collaris:
   other prefixes:
     - LaniCola
   # LaniColl is derivable by the 4+4 rule from this species and from
-  # Lanius collurio (red-backed shrike) so it names neither; see "contested prefixes" in docs/curation.md (#134).
+  # Lanius collurio (red-backed shrike) so it names neither; see "contested
+  # prefixes" in docs/curation.md (#134).
   context only prefixes:
     - LaniColl
   name: Fiscal shrike
@@ -4038,7 +4043,8 @@ Chrysolophus pictus:
   parent: Galliformes sp.
   prefix: Chpi
   # ChryPict is derivable by the 4+4 rule from this species and from
-  # Chrysemys picta (painted turtle) so it names neither; see "contested prefixes" in docs/curation.md (#134).
+  # Chrysemys picta (painted turtle) so it names neither; see "contested
+  # prefixes" in docs/curation.md (#134).
   context only prefixes:
     - ChryPict
   name: Golden pheasant

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -31,7 +31,12 @@ from .parser import (
     Parser,
 )
 from .result import Result
-from .species import Species, infer_species_from_context_only_prefix
+from .species import (
+    Species,
+    infer_species_from_context_only_prefix,
+    prefix_is_derived_for,
+    unambiguous_prefix_for,
+)
 
 
 @cache
@@ -160,7 +165,11 @@ def _format_species_options(species_objects, max_items=4):
 
 
 def _format_canonical_prefix_options(species_objects, max_items=4):
-    shown = [f"{sp.prefix} ({sp.name})" for sp in species_objects[:max_items]]
+    # unambiguous_prefix_for, not sp.prefix: "Chpi" is Chrysolophus pictus's
+    # canonical prefix and is derivable by Klein's 2+2 rule from Chrysemys
+    # picta too, so recommending it as the way out of a collision just moves
+    # the collision to a shorter tier.
+    shown = [f"{unambiguous_prefix_for(sp)} ({sp.name})" for sp in species_objects[:max_items]]
     if len(species_objects) > max_items:
         shown.append(f"+{len(species_objects) - max_items} more")
     return ", ".join(shown)
@@ -185,10 +194,22 @@ def _context_only_prefix_error_message(raw_string: str):
             f"{canonical_options}."
         )
 
+    # A contested form is not necessarily an attested one. "ChryPict" exists
+    # only because the 4+4 rule derives it from two different binomials, and
+    # nothing has ever published a ChryPict-* allele; saying "source-attested"
+    # there asserts exactly the kind of thing AGENTS.md says not to invent.
+    if all(prefix_is_derived_for(matched_prefix, sp.name) for sp in candidate_species):
+        origin = (
+            f"Prefix '{matched_prefix}' is derivable by the same naming rule from "
+            f"{_format_species_options(candidate_species)}, so it names neither"
+        )
+    else:
+        origin = (
+            f"Prefix '{matched_prefix}' is source-attested for multiple species "
+            f"({_format_species_options(candidate_species)}) and is not globally unique"
+        )
     return (
-        f"Prefix '{matched_prefix}' is source-attested for multiple species "
-        f"({_format_species_options(candidate_species)}) and is not globally unique. "
-        f"Use species='<latin name>' or a collision-free canonical prefix such as "
+        f"{origin}. Use species='<latin name>' or an unambiguous prefix such as "
         f"{canonical_options}."
     )
 
@@ -719,9 +740,13 @@ def parse(
             parser_error = None
 
     if parser_error is not None:
-        maybe_context_message = (
-            _context_only_prefix_error_message(raw_string) if species is None else None
-        )
+        # Explain the contested prefix whether or not species= was supplied.
+        # Before this, passing a species that is not one of the claimants
+        # downgraded a specific diagnostic to a bare "Could not parse", so the
+        # form failed quietly in exactly the case the caller was most explicit.
+        maybe_context_message = _context_only_prefix_error_message(raw_string)
+        if maybe_context_message is not None and species is not None:
+            maybe_context_message += f" The requested species={species!r} is not one of them."
         if maybe_context_message is not None:
             raise ParseError(maybe_context_message) from parser_error
         raise parser_error

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -379,6 +379,20 @@ class Species(Result):
         return self == other or self.is_ancestor_of(other) or other.is_ancestor_of(self)
 
     @property
+    def is_group(self):
+        """
+        Does this entry stand for a grouping rather than one species?
+
+        True for every "<taxon> sp." node and for any entry declaring
+        `group: true` -- currently NHP, IPD-MHC's non-human primate section,
+        which is not a taxon and so cannot announce itself by name (#122).
+
+        Exposed because the alternative is every consumer re-deriving it from
+        `name.endswith(" sp.")`, which gets NHP wrong. See #135.
+        """
+        return _is_group_entry(self.name)
+
+    @property
     def historic_mhc_prefix(self):
         """
         Return older species name which is now used to group multiple
@@ -1002,9 +1016,11 @@ def _is_group_entry(latin_name):
     database section that is not a clade does the same, rather than being
     hardcoded here (#135).
 
-    Group-ness decides two things: whether a prefix that is merely the entry's
-    own name is suppressed rather than inherited, and whether provenance
-    reports "group label".
+    Group-ness alone decides nothing; it is one half of both tests that use it.
+    A prefix is suppressed rather than inherited, and reports provenance
+    "group label", only when the entry is a group *and* the prefix is merely
+    its own name. A group entry carrying a real designation is unaffected:
+    "Bos sp." reports "designated" and hands "BoLA" down.
     """
     if raw_species_dict.get(latin_name, {}).get("group"):
         return True
@@ -1036,6 +1052,39 @@ def _is_inheritable_umbrella(prefix, latin_name):
     the prefix the way any other child does.
     """
     return not (_is_group_entry(latin_name) and _prefix_is_derived_from_name(prefix, latin_name))
+
+
+def prefix_is_derived_for(prefix, latin_name):
+    """
+    Would mhcgnomes mint this prefix for that species from its latin name?
+
+    True for the concatenated binomial and for the 4+4 shorthand, whether or
+    not the emitter actually offers it -- a colliding 4+4 is withheld but is
+    still *derivable*, which is exactly what makes it contested. Used to keep
+    error messages from calling a derived form "source-attested".
+    """
+    normalized = _normalize_identifier(prefix)
+    for generator in (_make_full_scientific_prefix, _make_long_prefix):
+        generated = generator(latin_name)
+        if generated and _normalize_identifier(generated) == normalized:
+            return True
+    return False
+
+
+def unambiguous_prefix_for(species):
+    """
+    A prefix that names this species and nothing else.
+
+    The concatenated binomial where there is one -- it is the only form with no
+    collisions anywhere in the ontology -- otherwise the curated prefix. Do not
+    offer `species.prefix` blindly: "Chpi" is Chrysolophus pictus's canonical
+    prefix and is derivable by Klein's 2+2 rule from Chrysemys picta too, so
+    recommending it in a collision message just moves the collision.
+    """
+    full = _make_full_scientific_prefix(species.name)
+    if full and len(_scientific_name_parts(species.name)) == 2:
+        return full
+    return species.prefix
 
 
 def _derive_prefix_provenance(prefix, latin_name):
@@ -1076,11 +1125,11 @@ SPECIES_ENTRY_KEYS = frozenset(
         # reads them; they are listed so the file still loads, not because they
         # do anything, and "alias" holds a transposed MhcPatr. See issue #139.
         "alias",
-        "group",
         "context only prefixes",
         "gene families",
         "gene properties",
         "genes",
+        "group",
         "haplotype prefix",
         "name",
         "old prefix",
@@ -1115,6 +1164,13 @@ def create_species_for_latin_name(latin_name):
     prefix = species_info.get("prefix")
     if not prefix:
         raise ValueError(f"Missing 'prefix' for '{latin_name}' in species ontology")
+
+    group_flag = species_info.get("group")
+    if group_flag is not None and group_flag is not True:
+        raise ValueError(
+            f"'group' of '{latin_name}' is {group_flag!r}; the only accepted value is true. "
+            f"Omit the key for an ordinary species."
+        )
 
     prefix_provenance = species_info.get("prefix source")
     if prefix_provenance is not None and (

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.43.0"
+__version__ = "3.43.2"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,49 +1,60 @@
-# A contested prefix names nobody, and group-ness lives in the data
+# Fix what the #138 review found, after it shipped
 
-Tracking issues: #134, #135
-
-## Specification
-
-- [x] #135: replace the hardcoded `latin_name == "NHP"` in `_is_group_entry`
-      with a `group: true` key, keeping the `" sp."` suffix as the shorthand.
-- [x] #134: stop a 4+4 form derivable from two species resolving confidently to
-      whichever of them curated it.
-- [x] Give the two species that still held a contested form as their canonical
-      prefix their concatenated binomial instead.
-- [x] Measure against a worktree of `main`; update README and `docs/curation.md`.
+Follow-up to #138 (3.43.0), which merged before its review reported.
 
 ## Review
 
-- **#135 is a three-line change.** `_is_group_entry` reads `group: true` from
-  the entry and falls back to the `" sp."` suffix, and `NHP` declares the flag.
-  `SPECIES_ENTRY_KEYS` already rejects unknown keys, so the flag cannot be
-  silently misspelled. Group-ness drives both prefix inheritance and
-  `prefix_provenance`, so the next non-taxon section added -- IPD-MHC also
-  groups by `FISH` and `CHICKEN` -- no longer has to be remembered in code.
-- **#134: a contested form now resolves only under an explicit `species=`.**
-  `ChryPict`, `LaniColl` and `LeucLeuc` are each derivable by the 4+4 rule from
-  two species. The generator already refused to emit them, but that only
-  suppressed the generated copy -- whichever claimant curated the form won
-  silently, so a caller who meant a golden pheasant and wrote `ChryPict` got a
-  painted turtle. Both claimants now list the form under
-  `context only prefixes`, which is the mechanism the ontology already uses for
-  `Moal` and `Orla`:
+- **The error message asserted something untrue.** A contested prefix reached
+  the `context only prefixes` bucket, whose message says the string is
+  "source-attested for multiple species". Nothing has ever published a
+  `ChryPict-*` allele -- the form exists only because the 4+4 rule derives it
+  from two binomials. The message now branches:
 
   ```
-  parse("ChryPict-B")                                   -> None
-  parse("ChryPict-B", species="Chrysolophus pictus")    -> Chrysolophus pictus
+  ChryPict -> "derivable by the same naming rule from Chrysemys picta,
+               Chrysolophus pictus, so it names neither"
+  Moal     -> "source-attested for multiple species (Monopterus albus,
+               Motacilla alba)"
   ```
 
-- **Two more canonical prefixes moved to the concatenated binomial.**
-  *Lanius collurio* held `LaniColl` and *Leucogeranus leucogeranus* held
-  `LeucLeuc`; both named their species only by curation order. They are now
-  `LaniusCollurio` and `LeucogeranusLeucogeranus`, forms that were already
-  parseable as generated aliases, so the rename promotes rather than invents.
-- **The rule is written down**, since the next collision will want it: a prefix
-  two entries can derive is curated by neither as a plain alias -- context only
-  on both, concatenated binomial as each canonical prefix.
-- **Measured against a worktree of `main` (3.42.0):** 0 of 11,558 corpus names
-  change. 16 structural fields differ across the 6 species involved, and no
-  others.
-- Bumped 3.42.0 to 3.43.0 -- three forms stop resolving bare, and two species
-  normalize to a new prefix.
+  `Moal` genuinely is attested for both, so it keeps the old wording.
+- **The remedy it offered had the same bug it was diagnosing.** The message
+  suggested `sp.prefix` as "a collision-free canonical prefix", which for
+  *Chrysolophus pictus* is `Chpi` -- and Klein's 2+2 rule derives `Chpi` from
+  *Chrysemys picta* too. It now offers the concatenated binomial, the only form
+  with no collisions anywhere in the ontology.
+- **An explicit non-claimant species lost the diagnostic.** The contested-prefix
+  message was only built when `species is None`, so
+  `parse("ChryPict-UA*01", species="Gallus gallus")` fell back to
+  "Could not parse" -- failing quietly in exactly the case where the caller had
+  been most explicit. It now explains, and adds which species was asked for.
+- **My README example demonstrated nothing.** It used `ChryPict-B`, but
+  *Chrysemys picta* declares no `B` gene, so that string returned `None` on
+  3.42.0 as well. The input that actually changed is `ChryPict-UA*01`. Both the
+  README and `docs/curation.md` used the vacuous one.
+- **The prefix table mixed two releases** under one "was -> now" heading, so a
+  reader on 3.42.0 would conclude *Chrysemys picta* was about to change (it had
+  already) and *Lanius collurio* had already (it was about to). Split by
+  release, and 3.43.0 now carries the breaking-change callout that 3.42.0's
+  section established.
+- **`group` accepted any truthy value.** Its neighbour `prefix source` is
+  validated against a value set, but `group` was read with a bare `.get`, so
+  `group: "false"` would have silently turned a species into a group entry --
+  stopping it handing its prefix down to every descendant. Only `true` is
+  accepted now.
+- **`Species.is_group` is public.** #135 moved group-ness into the data but
+  left it behind a module-private function reading `raw_species_dict`, so a
+  downstream consumer still had to re-derive it from `name.endswith(" sp.")` --
+  the heuristic that gets NHP wrong, which was the point of #135.
+- Also: `"group"` had been inserted directly under the comment declaring the
+  keys below it dead, so a future cleanup of #139 would have deleted it;
+  `_is_group_entry`'s docstring claimed group-ness alone decides provenance,
+  when it is one half of a conjunction; six identical four-line rationales in
+  `species.yaml` collapsed to one line each pointing at `docs/curation.md`; the
+  `context only prefixes` definition 290 lines earlier still said the bucket is
+  only for attested strings; five over-long prose lines re-wrapped; and a
+  function-local import moved to module scope.
+- **Measured:** 0 of 11,558 corpus names change against a worktree of `main`.
+  6 new tests, covering both wordings, the suggested prefix, the explicit-species
+  path, the `group` validation and `is_group`.
+- 3.43.2, since 3.43.1 is #140.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -11,9 +11,13 @@ import pytest
 from mhcgnomes import Allele, Gene, ParseError, Species, parse
 from mhcgnomes.common import normalize_string
 from mhcgnomes.data import species as species_data
-from mhcgnomes.species import _make_long_prefix, raw_species_dict
+from mhcgnomes.species import (
+    _make_long_prefix,
+    find_matching_context_only_species_objects,
+    raw_species_dict,
+)
 
-from .common import eq_
+from .common import eq_, ok_
 
 # ---------------------------------------------------------------------------
 # 1. Species identity via latin name
@@ -232,8 +236,6 @@ def test_contested_4_4_forms_resolve_only_under_explicit_species():
     it under `context only prefixes`, so a bare form fails and an explicit
     species= still resolves. See #134.
     """
-    from mhcgnomes.species import find_matching_context_only_species_objects
-
     for form, claimants in [
         ("ChryPict", {"Chrysemys picta", "Chrysolophus pictus"}),
         ("LaniColl", {"Lanius collurio", "Lanius collaris"}),
@@ -751,3 +753,89 @@ def test_4_4_shorthand_parses_an_allele():
     eq_(result.species.prefix, "HLA")
     eq_(result.gene.name, "A")
     eq_(result.allele_fields, ("02", "01"))
+
+
+# ---------------------------------------------------------------------------
+# Error messages for a contested prefix (review of #138)
+# ---------------------------------------------------------------------------
+
+
+def test_a_derived_collision_is_not_called_source_attested():
+    """
+    ChryPict exists only because the 4+4 rule derives it from two binomials;
+    nothing has published a ChryPict-* allele. Telling the user it is
+    "source-attested" invents provenance, which AGENTS.md forbids.
+    """
+    from mhcgnomes import ParseError
+
+    with pytest.raises(ParseError) as excinfo:
+        parse("ChryPict-UA*01", raise_on_error=True)
+    message = str(excinfo.value)
+    assert "derivable by the same naming rule" in message, message
+    assert "source-attested" not in message, message
+
+
+def test_an_attested_collision_still_says_source_attested():
+    """The counterpart: Moal really is used for both species in source data."""
+    from mhcgnomes import ParseError
+
+    with pytest.raises(ParseError) as excinfo:
+        parse("Moal-DAB", raise_on_error=True)
+    assert "source-attested" in str(excinfo.value)
+
+
+def test_the_suggested_prefix_is_actually_unambiguous():
+    """
+    The message used to offer `sp.prefix`, which for Chrysolophus pictus is
+    `Chpi` -- derivable by Klein's 2+2 rule from Chrysemys picta as well, so
+    the advice moved the collision to a shorter tier instead of resolving it.
+    """
+    from mhcgnomes import ParseError
+
+    with pytest.raises(ParseError) as excinfo:
+        parse("ChryPict-UA*01", raise_on_error=True)
+    message = str(excinfo.value)
+    assert "ChrysolophusPictus" in message, message
+    assert "ChrysemysPicta" in message, message
+    assert "Chpi" not in message, message
+
+
+def test_an_explicit_non_claimant_species_still_gets_the_explanation():
+    """
+    Passing a species that is not one of the claimants used to downgrade the
+    diagnostic to a bare "Could not parse", so the form failed quietly in
+    exactly the case where the caller had been most explicit.
+    """
+    from mhcgnomes import ParseError
+
+    with pytest.raises(ParseError) as excinfo:
+        parse("ChryPict-UA*01", species="Gallus gallus", raise_on_error=True)
+    message = str(excinfo.value)
+    assert "derivable by the same naming rule" in message, message
+    assert "Gallus gallus" in message, message
+
+
+def test_group_flag_rejects_anything_but_true():
+    """`prefix source` validates its value; `group` did not, and it decides
+    whether an entry hands its prefix down to every descendant."""
+    from mhcgnomes.species import create_species_for_latin_name
+
+    for bad_value in ["true", "yes", 1, False]:
+        entry = {"prefix": "TestGroup", "name": "test", "group": bad_value}
+        with (
+            temporary_species_entry("Test group sp.", entry),
+            pytest.raises(ValueError, match="'group'"),
+        ):
+            create_species_for_latin_name("Test group sp.")
+
+
+def test_is_group_is_public_and_gets_nhp_right():
+    """
+    Consumers outside this module used to have to re-derive group-ness from
+    `name.endswith(" sp.")`, which classifies NHP as a species. See #135.
+    """
+    ok_(Species.get_by_latin_name("NHP").is_group)
+    ok_(Species.get_by_latin_name("Aves sp.").is_group)
+    ok_(Species.get_by_latin_name("Bos sp.").is_group)
+    ok_(not Species.get_by_latin_name("Homo sapiens").is_group)
+    ok_(not Species.get_by_latin_name("Bubo bubo").is_group)


### PR DESCRIPTION
Follow-up to #138, whose `/code-review` reported after it had merged and
shipped as 3.43.0. Two of these are wrong statements to the user, not style.

## 1. The error asserted provenance that does not exist

Demoting the contested 4+4 forms to `context only prefixes` routed them through
a message written for genuinely attested collisions:

```
Prefix 'ChryPict' is source-attested for multiple species (...)
```

Nothing has ever published a `ChryPict-*` allele. The form exists only because
the 4+4 rule derives it from two binomials — which is exactly the kind of
claim `AGENTS.md` says not to invent. The message now branches on whether
every claimant *derives* the form:

```
ChryPict -> "derivable by the same naming rule from Chrysemys picta,
             Chrysolophus pictus, so it names neither"
Moal     -> "source-attested for multiple species (Monopterus albus,
             Motacilla alba)"
```

`Moal` really is used for both a swamp eel and a wagtail in source data, so it
keeps the original wording.

## 2. The remedy it offered had the bug it was diagnosing

The message suggested `sp.prefix` as "a collision-free canonical prefix". For
*Chrysolophus pictus* that is `Chpi` — and Klein's 2+2 rule derives `Chpi` from
*Chrysemys picta* too, so the advice moved the collision to a shorter tier. It
now offers the concatenated binomial, the only form with no collisions anywhere
in the ontology:

```
Use species='<latin name>' or an unambiguous prefix such as
ChrysemysPicta (Chrysemys picta), ChrysolophusPictus (Chrysolophus pictus).
```

## 3. An explicit non-claimant species lost the diagnostic

The contested-prefix message was only built when `species is None`, so
`parse("ChryPict-UA*01", species="Gallus gallus")` fell back to
`Could not parse` — failing quietly in the case where the caller had been most
explicit. It now explains, and names the species that was asked for.

## 4. My README example demonstrated nothing

It used `ChryPict-B`. *Chrysemys picta* declares no `B` gene, so that string
returned `None` on 3.42.0 as well — I verified the new behaviour without
checking the old. The input that actually changed is `ChryPict-UA*01`. Both the
README and `docs/curation.md` carried the vacuous one.

The prefix table also mixed 3.42.0's renames with 3.43.0's under a single
"was → now" heading, so a reader on 3.42.0 would conclude *Chrysemys picta* was
about to change (it already had) and *Lanius collurio* already had (it was
about to). Split by release, and 3.43.0 now carries the breaking-change callout
that the 3.42.0 section established.

## 5. `group` accepted any truthy value

Its neighbour `prefix source` is validated against a value set; `group` was
read with a bare `.get`, so `group: "false"` would have silently turned a
species into a group entry — stopping it handing its prefix down to every
descendant and flipping its reported provenance. Only `true` is accepted.

## 6. `Species.is_group` is public

#135 moved group-ness into the data but left it behind a module-private
function reading `raw_species_dict`, so a downstream consumer still had to
re-derive it from `name.endswith(" sp.")` — the heuristic that gets `NHP`
wrong, which was the whole point of #135.

## Also

`"group"` had been inserted directly under the comment declaring the keys below
it dead, so a future cleanup of #139 would have deleted it; `_is_group_entry`'s
docstring claimed group-ness alone decides provenance when it is one half of a
conjunction (`Bos sp.` is a group and reports `"designated"`); six identical
four-line rationales in `species.yaml` collapsed to one line each; the
`context only prefixes` definition 290 lines earlier still said the bucket is
only for attested strings; five over-long prose lines re-wrapped; and a
function-local import moved to module scope.

## Measurement

**0 of 11,558** corpus names change against a worktree of `main`. Six new
tests cover both message wordings, the suggested prefix, the explicit-species
path, the `group` validation and `is_group`.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,593 passed. 3.43.1 → 3.43.2.
