### PR TITLE
Refuse to read a non-MHC gene name as a locus plus an allele

### DIFF
--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -20,6 +20,7 @@ from .errors import ParseError
 from .gene import Gene
 from .gene_class_info import GeneClassInfo
 from .mhc_class import MhcClass
+from .non_mhc_genes import NON_MHC_REGION_GENE_NAMES, normalize_non_mhc_gene_name
 from .pair import Pair
 from .parser import (
     COLLAPSE_SINGLETON_HAPLOTYPES,
@@ -214,26 +215,6 @@ def _context_only_prefix_error_message(raw_string: str):
     )
 
 
-_NON_MHC_REGION_GENE_NAMES = {
-    "ABCB2": "TAP1",
-    "ABCB3": "TAP2",
-    "B2M": "B2M",
-    "CIITA": "CIITA",
-    "HAM1": "TAP1",
-    "HAM2": "TAP2",
-    "HM13": "HM13",
-    "PRR3": "PRR3",
-    "PSF1": "TAP1",
-    "PSF2": "TAP2",
-    "RING11": "TAP2",
-    "RING4": "TAP1",
-    "TAP-L": "TAP-L",
-    "TAPL": "TAP-L",
-    "TAP1": "TAP1",
-    "TAP2": "TAP2",
-    "TAPBP": "TAPBP",
-}
-
 _LENIENT_GENE_SUFFIX_RULES = {
     "A-U": ("I", "alpha"),
     "BLB": ("IIa", "beta"),
@@ -340,7 +321,9 @@ def _build_gene_class_info_from_parsed(parsed: Result, raw_string: str):
 
 
 def _normalize_inference_gene_token(gene_token: str):
-    return gene_token.strip().strip(",;").upper()
+    # Same rule as non_mhc_genes.normalize_non_mhc_gene_name, which is what
+    # keys the shared table.
+    return normalize_non_mhc_gene_name(gene_token)
 
 
 def _strip_gene_token(candidate_gene_string: str):
@@ -467,10 +450,10 @@ def _build_gene_class_info_from_token(species: Species, gene_token: str, raw_str
         return family_info
 
     normalized = _normalize_inference_gene_token(gene_token)
-    if normalized in _NON_MHC_REGION_GENE_NAMES:
+    if normalized in NON_MHC_REGION_GENE_NAMES:
         return GeneClassInfo(
             species=species,
-            gene_name=_NON_MHC_REGION_GENE_NAMES[normalized],
+            gene_name=NON_MHC_REGION_GENE_NAMES[normalized],
             mhc_class="other",
             chain=None,
             non_mhc=True,

--- a/mhcgnomes/non_mhc_genes.py
+++ b/mhcgnomes/non_mhc_genes.py
@@ -1,0 +1,76 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Gene names that turn up in MHC-region downloads but do not name an MHC
+molecule.
+
+Two consumers, which is why this is its own module rather than living beside
+either of them:
+
+  * `parse_gene_class` reports them as `non_mhc=True` instead of guessing.
+  * The parser refuses to split them into a locus plus an allele suffix.
+
+The second matters more than it looks. "Kdm5d" under a mouse species used to
+parse as `H2-K*dm5d` -- the valid mouse locus K, plus everything after it read
+as an allele -- and `Daxx` as `H2-D*axx`. Both look syntactically valid and get
+dispatched onward, so the failure is silent. See issue #133.
+"""
+
+# Maps a normalized name to the canonical gene it stands for. Several entries
+# are historic aliases: RING4/PSF1/HAM1/ABCB2 all named TAP1 before the
+# transporter genes were renamed.
+NON_MHC_REGION_GENE_NAMES = {
+    "ABCB2": "TAP1",
+    "ABCB3": "TAP2",
+    "B2M": "B2M",
+    "CIITA": "CIITA",
+    "HAM1": "TAP1",
+    "HAM2": "TAP2",
+    "HM13": "HM13",
+    "PRR3": "PRR3",
+    "PSF1": "TAP1",
+    "PSF2": "TAP2",
+    "RING11": "TAP2",
+    "RING4": "TAP1",
+    "TAP-L": "TAP-L",
+    "TAPL": "TAP-L",
+    "TAP1": "TAP1",
+    "TAP2": "TAP2",
+    "TAPBP": "TAPBP",
+    # Reported in #133 from a UniProt MHC-region download. All five are
+    # HGNC-approved symbols for proteins that are not MHC molecules; three of
+    # them lie inside the MHC region, which is why they arrive in these files
+    # at all. Checked against https://rest.genenames.org/search/symbol/...
+    "ARHGAP45": "ARHGAP45",  # HGNC:17102, Rho GTPase activating protein 45
+    "ATP6V1G2": "ATP6V1G2",  # HGNC:862, V-ATPase subunit G2, MHC class III
+    "COL11A2": "COL11A2",  # HGNC:2187, collagen XI alpha 2, MHC class II region
+    "DAXX": "DAXX",  # HGNC:2681, death domain associated protein
+    "KDM5D": "KDM5D",  # HGNC:11115, lysine demethylase 5D
+}
+
+
+def normalize_non_mhc_gene_name(gene_name):
+    """
+    The spelling used as a key above.
+
+    Deliberately the same rule `parse_gene_class` already applied to its gene
+    token, so moving the table here changes no behaviour: strip whitespace and
+    trailing punctuation, then upper-case.
+    """
+    if not gene_name:
+        return ""
+    return str(gene_name).strip().strip(",;").upper()
+
+
+def is_non_mhc_gene_name(gene_name):
+    return normalize_non_mhc_gene_name(gene_name) in NON_MHC_REGION_GENE_NAMES

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -31,6 +31,7 @@ from .gene import Gene
 from .haplotype import Haplotype
 from .mhc_class import MhcClass
 from .mutation import Mutation
+from .non_mhc_genes import is_non_mhc_gene_name
 from .pair import Pair, infer_class2_alpha_chain
 from .parsing_helpers import (
     contains_any_letters,
@@ -685,6 +686,22 @@ class Parser:
         Returns list of (Gene, remaining_string) pairs.
         """
         if contains_whitespace(str_after_species):
+            return []
+
+        # A curated non-MHC gene name is never split into a locus plus an
+        # allele suffix. "Kdm5d" under a mouse species would otherwise become
+        # H2-K*dm5d -- the real locus K, with everything after it read as an
+        # allele -- and "Daxx" becomes H2-D*axx. Both look valid and get
+        # dispatched onward, so the false positive is silent (#133).
+        #
+        # Only when the species does not declare the name itself: most entries
+        # in that table (TAP1, TAPBP, B2M, ...) are real genes in the ontology
+        # and must keep parsing.
+        stripped_token = self.strip_extra_chars(str_after_species)
+        if (
+            is_non_mhc_gene_name(stripped_token)
+            and species.find_matching_gene_name(stripped_token) is None
+        ):
             return []
 
         candidates = []

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.43.2"
+__version__ = "3.44.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,60 +1,42 @@
-# Fix what the #138 review found, after it shipped
+# Refuse to read a non-MHC gene name as a locus plus an allele
 
-Follow-up to #138 (3.43.0), which merged before its review reported.
+Tracking issue: #133
+
+## Specification
+
+- [x] Verify the five reported symbols against HGNC before adding them.
+- [x] Move the curated non-MHC table where both consumers can reach it.
+- [x] Stop the parser splitting such a name into a locus plus a suffix.
+- [x] Keep every name in that table that IS a declared gene parsing.
+- [x] Measure against a worktree of `main`.
 
 ## Review
 
-- **The error message asserted something untrue.** A contested prefix reached
-  the `context only prefixes` bucket, whose message says the string is
-  "source-attested for multiple species". Nothing has ever published a
-  `ChryPict-*` allele -- the form exists only because the 4+4 rule derives it
-  from two binomials. The message now branches:
-
-  ```
-  ChryPict -> "derivable by the same naming rule from Chrysemys picta,
-               Chrysolophus pictus, so it names neither"
-  Moal     -> "source-attested for multiple species (Monopterus albus,
-               Motacilla alba)"
-  ```
-
-  `Moal` genuinely is attested for both, so it keeps the old wording.
-- **The remedy it offered had the same bug it was diagnosing.** The message
-  suggested `sp.prefix` as "a collision-free canonical prefix", which for
-  *Chrysolophus pictus* is `Chpi` -- and Klein's 2+2 rule derives `Chpi` from
-  *Chrysemys picta* too. It now offers the concatenated binomial, the only form
-  with no collisions anywhere in the ontology.
-- **An explicit non-claimant species lost the diagnostic.** The contested-prefix
-  message was only built when `species is None`, so
-  `parse("ChryPict-UA*01", species="Gallus gallus")` fell back to
-  "Could not parse" -- failing quietly in exactly the case where the caller had
-  been most explicit. It now explains, and adds which species was asked for.
-- **My README example demonstrated nothing.** It used `ChryPict-B`, but
-  *Chrysemys picta* declares no `B` gene, so that string returned `None` on
-  3.42.0 as well. The input that actually changed is `ChryPict-UA*01`. Both the
-  README and `docs/curation.md` used the vacuous one.
-- **The prefix table mixed two releases** under one "was -> now" heading, so a
-  reader on 3.42.0 would conclude *Chrysemys picta* was about to change (it had
-  already) and *Lanius collurio* had already (it was about to). Split by
-  release, and 3.43.0 now carries the breaking-change callout that 3.42.0's
-  section established.
-- **`group` accepted any truthy value.** Its neighbour `prefix source` is
-  validated against a value set, but `group` was read with a bare `.get`, so
-  `group: "false"` would have silently turned a species into a group entry --
-  stopping it handing its prefix down to every descendant. Only `true` is
-  accepted now.
-- **`Species.is_group` is public.** #135 moved group-ness into the data but
-  left it behind a module-private function reading `raw_species_dict`, so a
-  downstream consumer still had to re-derive it from `name.endswith(" sp.")` --
-  the heuristic that gets NHP wrong, which was the point of #135.
-- Also: `"group"` had been inserted directly under the comment declaring the
-  keys below it dead, so a future cleanup of #139 would have deleted it;
-  `_is_group_entry`'s docstring claimed group-ness alone decides provenance,
-  when it is one half of a conjunction; six identical four-line rationales in
-  `species.yaml` collapsed to one line each pointing at `docs/curation.md`; the
-  `context only prefixes` definition 290 lines earlier still said the bucket is
-  only for attested strings; five over-long prose lines re-wrapped; and a
-  function-local import moved to module scope.
-- **Measured:** 0 of 11,558 corpus names change against a worktree of `main`.
-  6 new tests, covering both wordings, the suggested prefix, the explicit-species
-  path, the `group` validation and `is_group`.
-- 3.43.2, since 3.43.1 is #140.
+- **Two of the five were the dangerous kind.** `Kdm5d` under a mouse species
+  parsed as `H2-K*dm5d` and `Daxx` as `H2-D*axx` -- the real mouse loci `K` and
+  `D`, with everything after them read as an allele. Both look syntactically
+  valid and get dispatched onward, so the false positive is silent. The other
+  three returned `None` from `parse_gene_class` rather than saying `non_mhc`.
+- **The table moved to `mhcgnomes/non_mhc_genes.py`.** It lived in
+  `function_api.py`, but the misparse happens in `parser.py`, and importing
+  the one from the other is backwards. The normalizer moved with it and is the
+  same rule `parse_gene_class` already used, so nothing about its behaviour
+  changes.
+- **The guard is narrow, and had to be.** 13 of the 17 pre-existing entries --
+  `TAP1`, `TAPBP`, `B2M`, `RING4`, `PSF1`, `TAP-L` and friends -- are real
+  declared genes that must keep parsing. So the parser refuses a name only when
+  the species does not declare it. A test asserts the invariant that makes this
+  safe: none of the five reported symbols is declared by any of the 672 species,
+  so refusing them cannot shadow a locus.
+- **Sources cited.** All five are HGNC-approved symbols, checked against
+  `rest.genenames.org` rather than assumed: `ARHGAP45` HGNC:17102,
+  `ATP6V1G2` HGNC:862, `COL11A2` HGNC:2187, `DAXX` HGNC:2681, `KDM5D`
+  HGNC:11115. Three of them lie inside the MHC region, which is why they turn
+  up in these downloads at all.
+- **One test of mine was wrong, not the code.** It expected bare `Kb` to parse;
+  it returns `None` on `main` too, because a bare mouse locus needs a species.
+  Checked against a worktree rather than assuming the guard had caused it.
+- **Measured:** 0 of 11,558 corpus names change. 32 new tests, verified by
+  mutation -- removing the guard fails 6 of them.
+- Bumped 3.43.2 to 3.44.0: five inputs that returned a confident wrong answer
+  now return `None`, which is a behaviour change even though it is a fix.

--- a/tests/test_non_mhc_genes.py
+++ b/tests/test_non_mhc_genes.py
@@ -1,0 +1,114 @@
+"""
+Gene names from MHC-region downloads that do not name an MHC molecule.
+
+The dangerous case is a name the parser can split into a real locus plus an
+allele-like suffix: "Kdm5d" under a mouse species became `H2-K*dm5d` and
+"Daxx" became `H2-D*axx`. Both look syntactically valid and are dispatched
+onward, so the false positive is silent.
+
+https://github.com/pirl-unc/mhcgnomes/issues/133
+"""
+
+import pytest
+
+from mhcgnomes import Species, parse, parse_gene_class
+from mhcgnomes.non_mhc_genes import NON_MHC_REGION_GENE_NAMES, is_non_mhc_gene_name
+
+from .common import eq_, ok_
+
+# The five reported in #133, all HGNC-approved symbols for non-MHC proteins.
+REPORTED = ["Kdm5d", "Daxx", "Col11a2", "Atp6v1g2", "Arhgap45"]
+
+# The two that were split into a mouse locus plus an allele suffix, with what
+# they wrongly produced.
+SPLIT_INTO_MOUSE_LOCUS = [("Kdm5d", "H2-K*dm5d"), ("Daxx", "H2-D*axx")]
+
+
+@pytest.mark.parametrize("gene_name", REPORTED)
+def test_non_mhc_gene_does_not_parse_as_an_allele(gene_name):
+    eq_(parse(gene_name, species="Mus musculus", raise_on_error=False), None)
+
+
+@pytest.mark.parametrize("gene_name,was", SPLIT_INTO_MOUSE_LOCUS)
+def test_the_locus_plus_suffix_split_is_refused(gene_name, was):
+    """Named separately from the test above because this is the silent one."""
+    result = parse(gene_name, species="Mus musculus", raise_on_error=False)
+    assert result is None, f"{gene_name!r} still parses as {result.to_string()} (was {was})"
+
+
+@pytest.mark.parametrize("gene_name", REPORTED)
+def test_non_mhc_gene_is_classified_rather_than_guessed(gene_name):
+    info = parse_gene_class(gene_name, species="Mus musculus", raise_on_error=False)
+    assert info is not None, f"{gene_name!r} returned None instead of a non-MHC classification"
+    ok_(info.non_mhc)
+    eq_(info.mhc_class, "other")
+
+
+@pytest.mark.parametrize("gene_name", REPORTED)
+def test_reported_names_are_in_the_curated_table(gene_name):
+    ok_(is_non_mhc_gene_name(gene_name))
+    ok_(is_non_mhc_gene_name(gene_name.upper()))
+    ok_(is_non_mhc_gene_name(gene_name.lower()))
+
+
+# Most of the table is real genes in the ontology, so the parser guard has to
+# key on "the species does not declare it" rather than on the name alone.
+DECLARED_AND_MUST_STILL_PARSE = ["TAP1", "TAP2", "TAPBP", "B2M", "RING4", "PSF1", "TAP-L"]
+
+
+@pytest.mark.parametrize("gene_name", DECLARED_AND_MUST_STILL_PARSE)
+def test_a_declared_gene_in_the_table_still_parses(gene_name):
+    result = parse(gene_name, species="Homo sapiens", raise_on_error=False)
+    assert result is not None, f"{gene_name!r} stopped parsing"
+    eq_(result.species.name, "Homo sapiens")
+
+
+def test_the_guard_only_fires_for_names_no_species_declares():
+    """
+    The invariant behind the guard: every reported name is absent from the
+    whole ontology, so refusing it cannot shadow a real locus.
+    """
+    from mhcgnomes.species import latin_name_to_species_object
+
+    for gene_name in REPORTED:
+        owners = [
+            species.name
+            for species in latin_name_to_species_object.values()
+            if species.find_matching_gene_name(gene_name) is not None
+        ]
+        eq_(owners, [], f"{gene_name} is declared by {owners}")
+
+
+@pytest.mark.parametrize(
+    "name,species",
+    [
+        ("H2-K", None),
+        ("H2-Kb", None),
+        ("H2-D", None),
+        ("HLA-A*02:01", None),
+        # A bare locus needs a species either way -- parse("Kb") is None on
+        # 3.43.2 as well, so the guard must not be blamed for it.
+        ("Kb", "Mus musculus"),
+        ("K", "Mus musculus"),
+    ],
+)
+def test_real_mouse_and_human_names_are_unaffected(name, species):
+    result = (
+        parse(name, species=species, raise_on_error=False)
+        if species
+        else parse(name, raise_on_error=False)
+    )
+    assert result is not None, f"{name!r} stopped parsing"
+
+
+def test_table_values_name_genes_that_exist():
+    """
+    Each entry maps to the canonical gene it stands for. For the historic
+    aliases that is a different name (RING4 -> TAP1); for the #133 additions it
+    is the symbol itself, since no species declares them.
+    """
+    human = Species.get("HLA")
+    for alias, canonical in NON_MHC_REGION_GENE_NAMES.items():
+        if human.find_matching_gene_name(canonical) is not None:
+            continue
+        eq_(alias, canonical, f"{alias} maps to {canonical}, which no species declares")


### PR DESCRIPTION
Closes #133.

## Two of the five were the dangerous kind

`Kdm5d` under a mouse species parsed as `H2-K*dm5d`, and `Daxx` as `H2-D*axx` —
the real mouse loci `K` and `D`, with everything after them read as an allele.
Both look syntactically valid and get dispatched onward, so the false positive
is silent. The other three returned `None` from `parse_gene_class` rather than
saying `non_mhc`.

| input | before | after |
|---|---|---|
| `Kdm5d` | `H2-K*dm5d` | `None`, `non_mhc=True` |
| `Daxx` | `H2-D*axx` | `None`, `non_mhc=True` |
| `Col11a2` | `None`, unclassified | `None`, `non_mhc=True` |
| `Atp6v1g2` | `None`, unclassified | `None`, `non_mhc=True` |
| `Arhgap45` | `None`, unclassified | `None`, `non_mhc=True` |

## The table moved so the parser can reach it

It lived in `function_api.py`, but the misparse happens in `parser.py`, and
importing one from the other is backwards. `mhcgnomes/non_mhc_genes.py` now
holds it, along with the normalizer — which is the same rule
`parse_gene_class` already applied, so nothing about its behaviour changes.

## The guard is narrow, and had to be

**13 of the 17 pre-existing entries are real declared genes**:

```
TAP1  -> HLA-TAP1     RING4 -> HLA-TAP1     B2M   -> HLA-B2M
TAP2  -> HLA-TAP2     PSF1  -> HLA-TAP1     TAPBP -> HLA-TAPBP
```

So the parser refuses a name only when **the species does not declare it**. A
test pins the invariant that makes that safe: none of the five reported symbols
is declared by any of the 672 species, so refusing them cannot shadow a locus.

## Sources

All five checked against HGNC rather than assumed — three of them lie inside
the MHC region, which is why they turn up in these downloads at all:

| symbol | HGNC | protein |
|---|---|---|
| `ARHGAP45` | HGNC:17102 | Rho GTPase activating protein 45 |
| `ATP6V1G2` | HGNC:862 | V-ATPase subunit G2, MHC class III |
| `COL11A2` | HGNC:2187 | collagen XI alpha 2, MHC class II region |
| `DAXX` | HGNC:2681 | death domain associated protein |
| `KDM5D` | HGNC:11115 | lysine demethylase 5D |

## Measurement

**0 of 11,558** corpus names change against a worktree of `main`. 32 new tests,
verified by mutation: removing the guard fails 6 of them.

One test of mine was wrong rather than the code — it expected bare `Kb` to
parse, and that returns `None` on `main` too, because a bare mouse locus needs
a species. Checked against a worktree instead of assuming the guard caused it.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,625 passed. 3.43.2 → 3.44.0,
since five inputs that returned a confident wrong answer now return `None`.
