### PR TITLE
Remove two species.yaml keys nothing ever read

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -2837,8 +2837,11 @@ Sus domesticus:
 Sus scrofa:
   parent: Sus sp.
   prefix: Susc
-  # TODO: reflect this in the Species object
-  haplotype prefix: Hp
+  # Swine haplotypes are written with an "Hp" prefix. This was a
+  # `haplotype prefix: Hp` key, but nothing in the loader ever read it and no
+  # swine haplotype is curated for it to apply to -- haplotypes.yaml has no
+  # Sus scrofa entry, and Hp-1.1 does not parse. Kept as a note rather than a
+  # key that asserts support we do not have. See #143.
   name: Feral Pig
 ######################################################
 # Rodentia — rodents
@@ -5176,7 +5179,10 @@ Pan troglodytes:
   prefix: Patr
   other prefixes:
     - Ptr
-  alias: MhcPtar
+  # Was `alias: MhcPtar`, a transposition of MhcPatr that nothing read. The
+  # correct spelling already parses without an alias, because a leading "Mhc"
+  # is stripped as a fallback: parse("MhcPatr-A*01:01") gives Patr-A*01:01.
+  # See #139.
   name: Common Chimpanzee
 Pan paniscus:
   parent: Pan sp.

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -1116,21 +1116,19 @@ _EMPTY_GENE_NAMES = NormalizingSet()
 latin_name_to_own_gene_names = {}
 
 
-# Every key an entry in species.yaml may carry. Unknown keys are rejected
-# rather than ignored: a typo such as "prefix_source" would otherwise load
-# silently, leaving the YAML asserting something the runtime never read.
+# Every key an entry in species.yaml may carry, and every one of them is read
+# below. Unknown keys are rejected rather than ignored: a typo such as
+# "prefix_source" would otherwise load silently, leaving the YAML asserting
+# something the runtime never read. Whitelisting a key nothing reads has the
+# same effect with extra confidence, so do not add one here without a consumer
+# -- tests/test_ontology_hygiene.py checks that each key has one (#139).
 SPECIES_ENTRY_KEYS = frozenset(
     {
-        # "alias" and "haplotype prefix" are present in species.yaml but nothing
-        # reads them; they are listed so the file still loads, not because they
-        # do anything, and "alias" holds a transposed MhcPatr. See issue #139.
-        "alias",
         "context only prefixes",
         "gene families",
         "gene properties",
         "genes",
         "group",
-        "haplotype prefix",
         "name",
         "old prefix",
         "other prefixes",

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.43.2"
+__version__ = "3.43.3"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,60 +1,32 @@
-# Fix what the #138 review found, after it shipped
+# Remove two species.yaml keys nothing ever read
 
-Follow-up to #138 (3.43.0), which merged before its review reported.
+Tracking issue: #139
 
 ## Review
 
-- **The error message asserted something untrue.** A contested prefix reached
-  the `context only prefixes` bucket, whose message says the string is
-  "source-attested for multiple species". Nothing has ever published a
-  `ChryPict-*` allele -- the form exists only because the 4+4 rule derives it
-  from two binomials. The message now branches:
-
-  ```
-  ChryPict -> "derivable by the same naming rule from Chrysemys picta,
-               Chrysolophus pictus, so it names neither"
-  Moal     -> "source-attested for multiple species (Monopterus albus,
-               Motacilla alba)"
-  ```
-
-  `Moal` genuinely is attested for both, so it keeps the old wording.
-- **The remedy it offered had the same bug it was diagnosing.** The message
-  suggested `sp.prefix` as "a collision-free canonical prefix", which for
-  *Chrysolophus pictus* is `Chpi` -- and Klein's 2+2 rule derives `Chpi` from
-  *Chrysemys picta* too. It now offers the concatenated binomial, the only form
-  with no collisions anywhere in the ontology.
-- **An explicit non-claimant species lost the diagnostic.** The contested-prefix
-  message was only built when `species is None`, so
-  `parse("ChryPict-UA*01", species="Gallus gallus")` fell back to
-  "Could not parse" -- failing quietly in exactly the case where the caller had
-  been most explicit. It now explains, and adds which species was asked for.
-- **My README example demonstrated nothing.** It used `ChryPict-B`, but
-  *Chrysemys picta* declares no `B` gene, so that string returned `None` on
-  3.42.0 as well. The input that actually changed is `ChryPict-UA*01`. Both the
-  README and `docs/curation.md` used the vacuous one.
-- **The prefix table mixed two releases** under one "was -> now" heading, so a
-  reader on 3.42.0 would conclude *Chrysemys picta* was about to change (it had
-  already) and *Lanius collurio* had already (it was about to). Split by
-  release, and 3.43.0 now carries the breaking-change callout that 3.42.0's
-  section established.
-- **`group` accepted any truthy value.** Its neighbour `prefix source` is
-  validated against a value set, but `group` was read with a bare `.get`, so
-  `group: "false"` would have silently turned a species into a group entry --
-  stopping it handing its prefix down to every descendant. Only `true` is
-  accepted now.
-- **`Species.is_group` is public.** #135 moved group-ness into the data but
-  left it behind a module-private function reading `raw_species_dict`, so a
-  downstream consumer still had to re-derive it from `name.endswith(" sp.")` --
-  the heuristic that gets NHP wrong, which was the point of #135.
-- Also: `"group"` had been inserted directly under the comment declaring the
-  keys below it dead, so a future cleanup of #139 would have deleted it;
-  `_is_group_entry`'s docstring claimed group-ness alone decides provenance,
-  when it is one half of a conjunction; six identical four-line rationales in
-  `species.yaml` collapsed to one line each pointing at `docs/curation.md`; the
-  `context only prefixes` definition 290 lines earlier still said the bucket is
-  only for attested strings; five over-long prose lines re-wrapped; and a
-  function-local import moved to module scope.
-- **Measured:** 0 of 11,558 corpus names change against a worktree of `main`.
-  6 new tests, covering both wordings, the suggested prefix, the explicit-species
-  path, the `group` validation and `is_group`.
-- 3.43.2, since 3.43.1 is #140.
+- **I filed #139 with a wrong claim, and checking it settled the design.** The
+  issue said neither `MhcPatr` nor the transposed `MhcPtar` resolves. Only the
+  second is true: `Species.get("MhcPatr")` is `None`, but `parse` strips a
+  leading `Mhc` as a fallback, so `parse("MhcPatr-A*01:01")` gives
+  `Patr-A*01:01`. The `alias: MhcPtar` key was therefore carrying nothing --
+  a typo of a string that already works without it -- so there was no
+  behaviour to preserve and no reason to implement the key.
+- **`haplotype prefix: Hp` had nothing behind it either.** `haplotypes.yaml`
+  has no `Sus scrofa` entry, and none of `Hp-1.1`, `SLA-1.1`, `Hp1.1` or
+  `Susc-Hp-1.1` parses, so wiring the key into `Species` would have given a
+  prefix with no haplotypes under it. The fact that swine haplotypes carry an
+  `Hp` prefix is kept as a comment on the entry, and curating the haplotypes
+  themselves is #143 -- the prerequisite for any field.
+- **The hygiene rule that would have caught this.** `SPECIES_ENTRY_KEYS` exists
+  so a misspelled key cannot load silently while the YAML asserts something the
+  runtime never read. Whitelisting a key nothing reads does the same thing with
+  more confidence behind it, which is exactly what happened when I added the
+  frozenset in #132 and listed both of these to keep the file loading.
+  `tests/test_ontology_hygiene.py` now asserts every accepted key is fetched in
+  `species.py`, and that the data uses no key the loader rejects.
+- **The test caught its own first draft.** It looked for
+  `species_info.get("<key>")` and flagged `genes`, `gene properties` and
+  `gene families`, which are fetched with a default argument. Broadened, then
+  verified by mutation: adding a bogus key to the frozenset fails it.
+- **Measured:** 0 of 11,558 corpus names change.
+- Bumped to 3.43.3 -- data and hygiene only, no behaviour change.

--- a/tests/test_ontology_hygiene.py
+++ b/tests/test_ontology_hygiene.py
@@ -131,3 +131,35 @@ def test_gene_alias_entries_do_not_use_model_record_style_strings():
                         bad.append((species_key, role, value, substring))
                         break
     assert not bad, bad
+
+
+def test_every_whitelisted_species_key_has_a_consumer():
+    """
+    `SPECIES_ENTRY_KEYS` exists so a misspelled key cannot load silently while
+    the YAML asserts something the runtime never read. Whitelisting a key that
+    nothing reads has the same effect with extra confidence: `alias` and
+    `haplotype prefix` sat there unread until #139.
+
+    So every accepted key must be fetched somewhere in species.py.
+    """
+    from mhcgnomes.species import SPECIES_ENTRY_KEYS
+
+    source = (Path(__file__).parent.parent / "mhcgnomes" / "species.py").read_text()
+    # Match the call without its closing paren, since several are fetched with
+    # a default: species_info.get("genes", {}).
+    unread = sorted(key for key in SPECIES_ENTRY_KEYS if f'species_info.get("{key}"' not in source)
+    assert unread == [], (
+        f"species.yaml keys accepted but never read: {unread}. Either read them or "
+        f"drop them from SPECIES_ENTRY_KEYS -- see issue #139."
+    )
+
+
+def test_dropped_keys_are_gone_from_the_data_too():
+    """A key removed from the whitelist must not linger in species.yaml, or
+    the file stops loading."""
+    from mhcgnomes.species import SPECIES_ENTRY_KEYS
+
+    entries = load_yaml(SPECIES_PATH)
+    used = {key for entry in entries.values() for key in entry}
+    unexpected = sorted(used - set(SPECIES_ENTRY_KEYS))
+    assert unexpected == [], f"species.yaml uses keys the loader rejects: {unexpected}"


### PR DESCRIPTION
Closes #139.

## I filed this issue with a wrong claim, and checking it settled the design

The issue said neither `MhcPatr` nor the transposed `MhcPtar` resolves. Only
the second is true — I had checked with `Species.get`, which does not apply the
leading-`Mhc` strip that `parse` does:

```python
>>> Species.get("MhcPatr")
None
>>> parse("MhcPatr-A*01:01")
Allele(Patr-A*01:01)
```

So `alias: MhcPtar` was carrying nothing at all: a transposition of a string
that already works without it. There is no behaviour to preserve, which decides
between the issue's two options — remove, don't implement.

## `haplotype prefix: Hp` has nothing behind it either

`haplotypes.yaml` has no `Sus scrofa` entry, and none of the swine haplotype
spellings parses:

```python
>>> [parse(s, raise_on_error=False) for s in ("Hp-1.1", "SLA-1.1", "Hp1.1", "Susc-Hp-1.1")]
[None, None, None, None]
```

Wiring it into the `Species` object would have produced a prefix with no
haplotypes under it. The fact that swine haplotypes carry an `Hp` prefix is
kept as a comment on the entry, and curating the haplotypes — the prerequisite
for any field — is split out as **#143**.

## The hygiene rule that would have caught this

`SPECIES_ENTRY_KEYS` exists so a misspelled key cannot load silently while the
YAML asserts something the runtime never read. Whitelisting a key that nothing
reads does the same thing with more confidence behind it — which is exactly
what I did when adding the frozenset in #132 and listing both of these to keep
the file loading.

`tests/test_ontology_hygiene.py` now asserts:

- every key in `SPECIES_ENTRY_KEYS` is fetched somewhere in `species.py`
- `species.yaml` uses no key the loader would reject

The first draft of that test was itself too strict — it looked for
`species_info.get("<key>")` and flagged `genes`, `gene properties` and
`gene families`, which are fetched with a default argument. Broadened, then
verified by mutation: adding a bogus key to the frozenset fails it.

## Measurement

**0 of 11,558** corpus names change against a worktree of `main`.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,627 passed. 3.44.0 → 3.44.1 —
data and hygiene only, no behaviour change.
