### PR TITLE
Put the four macaques under their genus node

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -4584,6 +4584,12 @@ Callicebus moloch:
         - DRB11
         - DRB3
 Callithrix pygmaea:
+  # Stays directly under NHP rather than moving to Callithrix sp.: NCBI
+  # Taxonomy accepts Cebuella pygmaea (taxid 9493, lineage ... Callitrichinae >
+  # Cebuella) and lists Callithrix pygmaea only as a homotypic synonym, which
+  # is also where the old prefix Cepy comes from. It is not a Callithrix, so
+  # the genus node would be the wrong parent even though the key says
+  # otherwise. See #123.
   parent: NHP
   prefix: Capy
   old prefix: Cepy
@@ -4818,7 +4824,7 @@ Lophocebus aterrimus:
       DQ:
         - DQA1
 Macaca arctoides:
-  parent: NHP
+  parent: Macaca sp.
   prefix: Maar
   name: Stump-tailed Macaque
   genes:
@@ -4838,7 +4844,7 @@ Macaca arctoides:
         - DRB5
 
 Macaca assamensis:
-  parent: NHP
+  parent: Macaca sp.
   prefix: Maas
   name: Assam Macaque
   genes:
@@ -4893,7 +4899,7 @@ Macaca fascicularis:
         - DRB5
         - DRB6
 Macaca fuscata:
-  parent: NHP
+  parent: Macaca sp.
   prefix: Mafu
   name: Japanese Macaque
   genes:
@@ -4911,7 +4917,7 @@ Mandrillus leucophaeus:
       DR:
         - DRB1
 Macaca leonina:
-  parent: NHP
+  parent: Macaca sp.
   prefix: Malo
   name: Northern Pig-tailed Macaque
   genes:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.44.0"
+__version__ = "3.45.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,42 +1,43 @@
-# Refuse to read a non-MHC gene name as a locus plus an allele
+# Put the four macaques under their genus node
 
-Tracking issue: #133
-
-## Specification
-
-- [x] Verify the five reported symbols against HGNC before adding them.
-- [x] Move the curated non-MHC table where both consumers can reach it.
-- [x] Stop the parser splitting such a name into a locus plus a suffix.
-- [x] Keep every name in that table that IS a declared gene parsing.
-- [x] Measure against a worktree of `main`.
+Tracking issue: #123
 
 ## Review
 
-- **Two of the five were the dangerous kind.** `Kdm5d` under a mouse species
-  parsed as `H2-K*dm5d` and `Daxx` as `H2-D*axx` -- the real mouse loci `K` and
-  `D`, with everything after them read as an allele. Both look syntactically
-  valid and get dispatched onward, so the false positive is silent. The other
-  three returned `None` from `parse_gene_class` rather than saying `non_mhc`.
-- **The table moved to `mhcgnomes/non_mhc_genes.py`.** It lived in
-  `function_api.py`, but the misparse happens in `parser.py`, and importing
-  the one from the other is backwards. The normalizer moved with it and is the
-  same rule `parse_gene_class` already used, so nothing about its behaviour
-  changes.
-- **The guard is narrow, and had to be.** 13 of the 17 pre-existing entries --
-  `TAP1`, `TAPBP`, `B2M`, `RING4`, `PSF1`, `TAP-L` and friends -- are real
-  declared genes that must keep parsing. So the parser refuses a name only when
-  the species does not declare it. A test asserts the invariant that makes this
-  safe: none of the five reported symbols is declared by any of the 672 species,
-  so refusing them cannot shadow a locus.
-- **Sources cited.** All five are HGNC-approved symbols, checked against
-  `rest.genenames.org` rather than assumed: `ARHGAP45` HGNC:17102,
-  `ATP6V1G2` HGNC:862, `COL11A2` HGNC:2187, `DAXX` HGNC:2681, `KDM5D`
-  HGNC:11115. Three of them lie inside the MHC region, which is why they turn
-  up in these downloads at all.
-- **One test of mine was wrong, not the code.** It expected bare `Kb` to parse;
-  it returns `None` on `main` too, because a bare mouse locus needs a species.
-  Checked against a worktree rather than assuming the guard had caused it.
-- **Measured:** 0 of 11,558 corpus names change. 32 new tests, verified by
-  mutation -- removing the guard fails 6 of them.
-- Bumped 3.43.2 to 3.44.0: five inputs that returned a confident wrong answer
-  now return `None`, which is a behaviour change even though it is a fix.
+- **Four of the five, not five.** #123 listed five primates sitting outside a
+  genus node that exists. Four are macaques and move under `Macaca sp.` The
+  fifth does not, and checking why was the useful part.
+- **`Callithrix pygmaea` is not a Callithrix.** NCBI Taxonomy accepts
+  *Cebuella pygmaea* (taxid 9493, lineage `... Callitrichinae > Cebuella`) and
+  lists *Callithrix pygmaea* only as a homotypic synonym -- which is also where
+  the entry's `old prefix: Cepy` comes from. Moving it under `Callithrix sp.`
+  would have been a taxonomic error dressed up as a consistency fix. The entry
+  keeps its parent, with the reason recorded on it, and the tree-shape test
+  keeps it in the allowlist with the citation rather than as an open gap.
+- **What the macaques gained.** 24-34 genes each, up to the 68 the genus node
+  provides, so the names in the issue now parse:
+
+  ```
+  Mafu-A*01:01     None  ->  Macaca fuscata A*01:01
+  Maas-DRB1*01:01  None  ->  Macaca assamensis DRB1*01:01
+  ```
+
+- **Two existing tests encoded the old inconsistency**, which is what
+  `AGENTS.md` warns to check before assuming a failing test means the change is
+  wrong:
+  - `Maar-A` normalized to `A1`, because *M. arctoides* declared `A1` but not
+    `A`. Every other macaque leaves `A` alone -- `Mamu-A`, `Mafa-A`, `Mane-A`
+    -- so the old answer was the odd one out, not the new one.
+  - An adversarial stickiness test used `Maar-A2` as a name that must not
+    parse. It parses now, but to *M. arctoides* itself rather than by switching
+    species, so it no longer exercises stickiness at all. Replaced with
+    `Maar-BLB2` and `Maar-UAA`, which do.
+- **One of my new tests was wrong too.** It asserted the reparented species
+  have the same gene count as *Macaca mulatta*, which declares its own `K` on
+  top of the genus list and so has one more. Changed to assert every gene the
+  genus declares is visible to them.
+- **Measured:** 0 of 11,558 corpus names change. Four entries change
+  `old_mhc_prefix` (`Maar`/`Maas`/`Mafu`/`Malo` -> `RhLA`), which is the
+  umbrella every other macaque already carries.
+- Bumped 3.44.0 to 3.45.0: names that returned `None` now parse, and `Maar-A`
+  normalizes differently.

--- a/tests/test_nhp.py
+++ b/tests/test_nhp.py
@@ -75,17 +75,22 @@ def test_parse_saoe_allele_alias_N_01_01():
 
 
 def test_parse_maar_gene_alias_A():
+    """
+    "Maar-A" used to normalize to A1, because Macaca arctoides declared A1 but
+    not A and sat outside Macaca sp. Since #123 it is under the genus node and
+    inherits A, so it behaves like every other macaque: Mamu-A, Mafa-A and
+    Mane-A all stay A. The old answer was the odd one out.
+    """
     result = parse("Maar-A", raise_on_error=True)
-    expected = Gene.get("Maar", "A1")
-    assert expected is not None
-    eq_(result, expected)
+    eq_(result, Gene.get("Maar", "A"))
+    eq_(parse("Mamu-A", raise_on_error=True).name, result.name)
 
 
 def test_parse_maar_allele_alias_A_01_01():
+    """The allele counterpart of the gene test above; see #123."""
     result = parse("Maar-A*01:01", raise_on_error=True)
-    expected = Allele.get("Maar", "A1", ("01", "01"))
-    assert expected is not None
-    eq_(result, expected)
+    eq_(result, Allele.get("Maar", "A", ("01", "01")))
+    eq_(result.gene.name, parse("Mamu-A*01:01", raise_on_error=True).gene.name)
 
 
 NHP_NOVEL_GENE_EXAMPLES = [

--- a/tests/test_parser_edge_cases.py
+++ b/tests/test_parser_edge_cases.py
@@ -1185,7 +1185,11 @@ class TestAdversarialSpeciesStickiness:
     """Regression tests for species-scoped parsing."""
 
     def test_explicit_species_does_not_switch_to_other_species(self):
-        for s in ["Onmy-DAA2", "Sasa-DAA2", "Maar-A2"]:
+        # "Maar-A2" used to belong here, but since #123 put Macaca arctoides
+        # under Macaca sp. it inherits the genus A1/A2/A3 loci and resolves to
+        # its own species -- which is what stickiness asks for, so it no longer
+        # exercises the rule. "Maar-BLB2" (a chicken class II gene) does.
+        for s in ["Onmy-DAA2", "Sasa-DAA2", "Maar-BLB2", "Maar-UAA"]:
             assert parse(s, raise_on_error=False) is None
 
     def test_nested_species_prefix_does_not_override_explicit_species(self):

--- a/tests/test_species_tree_shape.py
+++ b/tests/test_species_tree_shape.py
@@ -218,16 +218,17 @@ def test_only_documented_edges_point_at_another_genus_node():
     eq_(sorted(crossing), sorted(GENUS_CROSSING_EDGES))
 
 
-# Species that sit at a higher node even though their own genus has one. These
-# are curation gaps rather than decisions: reparenting them would hand them the
-# genus gene list, which needs its own check against the literature.
-# https://github.com/pirl-unc/mhcgnomes/issues/123
+# Species that sit at a higher node even though an entry named for their genus
+# exists. The four macaques were moved under Macaca sp. in #123; the one left
+# is not a curation gap:
+#
+# Callithrix pygmaea is a synonym. NCBI Taxonomy accepts Cebuella pygmaea
+# (taxid 9493, lineage ... Callitrichinae > Cebuella) and lists Callithrix
+# pygmaea as a homotypic synonym, which is where the old prefix Cepy comes
+# from. It is not a Callithrix, so Callithrix sp. would be the wrong parent
+# even though the key says otherwise.
 UNPLACED_WITHIN_GENUS = {
     "Callithrix pygmaea",
-    "Macaca arctoides",
-    "Macaca assamensis",
-    "Macaca fuscata",
-    "Macaca leonina",
 }
 
 
@@ -240,3 +241,55 @@ def test_species_sit_under_their_genus_node_when_one_exists():
         and not GENUS_NODES[species.name.split()[0]].is_ancestor_of(species)
     }
     eq_(sorted(unplaced), sorted(UNPLACED_WITHIN_GENUS))
+
+
+# ---------------------------------------------------------------------------
+# 5. The macaques placed under their genus node (#123)
+# ---------------------------------------------------------------------------
+
+REPARENTED_MACAQUES = [
+    "Macaca arctoides",
+    "Macaca assamensis",
+    "Macaca fuscata",
+    "Macaca leonina",
+]
+
+
+@pytest.mark.parametrize("latin_name", REPARENTED_MACAQUES)
+def test_every_macaque_is_under_the_genus_node(latin_name):
+    macaca = Species.get_by_latin_name("Macaca sp.")
+    ok_(Species.get_by_latin_name(latin_name).is_descendant_of(macaca))
+
+
+@pytest.mark.parametrize("latin_name", REPARENTED_MACAQUES)
+def test_reparented_macaques_behave_like_their_siblings(latin_name):
+    """
+    The point of #123: these four inherited almost nothing, so Mafu-A*01:01
+    did not parse while Mamu-A*01:01 did. They should now be indistinguishable
+    from the macaques that were already under the genus node.
+    """
+    species = Species.get_by_latin_name(latin_name)
+    genus = Species.get_by_latin_name("Macaca sp.")
+    # Every gene the genus declares is visible to them. Not an equality against
+    # a sibling: Macaca mulatta declares its own K on top of the genus list, so
+    # its gene count is one higher than everyone else's.
+    missing = sorted(g for g in genus.own_gene_names if species.find_matching_gene_name(g) is None)
+    eq_(missing, [], f"{latin_name} does not see {missing}")
+    eq_(species.old_mhc_prefix, "RhLA")
+    prefix = species.prefix
+    for gene_name in ["A", "A1", "A2", "B", "DRB1", "DQA1", "DQB1"]:
+        result = parse(f"{prefix}-{gene_name}*01:01", raise_on_error=False)
+        assert result is not None, f"{prefix}-{gene_name}*01:01 does not parse"
+        eq_(result.species.name, latin_name)
+
+
+def test_the_pygmy_marmoset_is_not_a_callithrix():
+    """
+    The fifth species #123 listed is not a curation gap. NCBI Taxonomy accepts
+    Cebuella pygmaea (taxid 9493) and lists Callithrix pygmaea as a homotypic
+    synonym, so the genus node would be the wrong parent. Its historic prefix
+    Cepy comes from the accepted name.
+    """
+    marmoset = Species.get_by_latin_name("Callithrix pygmaea")
+    ok_(not marmoset.is_descendant_of(Species.get_by_latin_name("Callithrix sp.")))
+    eq_(marmoset.old_mhc_prefix, "Cepy")


### PR DESCRIPTION
Closes #123.

## Four of the five move, and checking the fifth was the useful part

#123 listed five primates sitting outside a genus node that exists. The four
macaques move under `Macaca sp.` The pygmy marmoset does not.

**`Callithrix pygmaea` is not a *Callithrix*.** NCBI Taxonomy accepts
[*Cebuella pygmaea*](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9493)
(taxid 9493, lineage `... Callitrichinae > Cebuella`) and lists
*Callithrix pygmaea* only as a homotypic synonym — which is also where the
entry's `old prefix: Cepy` comes from. Moving it under `Callithrix sp.` would
have been a taxonomic error dressed up as a consistency fix. The entry keeps
its parent, with the reason recorded on it.

## What the macaques gained

24–34 genes each, up to the 68 the genus node provides, so the names in the
issue parse:

```
Mafu-A*01:01     None  ->  Macaca fuscata A*01:01
Maar-B*01:01     ok    ->  unchanged
Maas-DRB1*01:01  None  ->  Macaca assamensis DRB1*01:01
Malo-DQA1*01:01  None  ->  Macaca leonina DQA1*01:01
```

## Two existing tests encoded the old inconsistency

Which is the case `AGENTS.md` warns to check before assuming a failing test
means the change is wrong.

**`Maar-A` normalized to `A1`**, because *M. arctoides* declared `A1` but not
`A`. Every other macaque leaves `A` alone:

```
Mamu-A -> A     Mafa-A -> A     Mane-A -> A     Maar-A -> A1   <- the odd one
```

**An adversarial stickiness test used `Maar-A2`** as a name that must not
parse. It parses now — but to *M. arctoides itself*, by inheritance, rather
than by switching species, so it no longer exercises stickiness at all.
Replaced with `Maar-BLB2` (a chicken class II gene) and `Maar-UAA`, which do.

## One of my own new tests was wrong too

It asserted the reparented species have the same gene count as *Macaca
mulatta*. Mamu declares its own `K` on top of the genus list, so it has 69 to
everyone else's 68. Changed to assert every gene the genus declares is visible
to them.

## Measurement

**0 of 11,558** corpus names change against a worktree of `main`. Four entries
change `old_mhc_prefix` (`Maar`/`Maas`/`Mafu`/`Malo` → `RhLA`), which is the
umbrella every other macaque already carries.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,636 passed. 3.44.1 → 3.45.0,
since names that returned `None` now parse and `Maar-A` normalizes differently.
