### PR TITLE
Curate prefix provenance from the IPD-MHC species tables (163 unknown to 113)

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -880,12 +880,18 @@ Rattus sp.:
         - DMB
 Rattus norvegicus:
   parent: Rattus sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # RT1 group: https://www.ebi.ac.uk/ipd/mhc/group/RT1/species
+  prefix source: designated
   prefix: Rano
   name:
     - Norway Rat
     - Norwegian Rat
 Rattus rattus:
   parent: Rattus sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # RT1 group: https://www.ebi.ac.uk/ipd/mhc/group/RT1/species
+  prefix source: designated
   prefix: Rara
   name: Black Rat
 Rattus fuscipes:
@@ -933,10 +939,16 @@ Canidae sp.:
   name: Canid
 Cuon alpinus:
   parent: Canidae sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Cual
   name: Dhole
 Lycaon pictus:
   parent: Canidae sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Lypi
   name: African wild dog
 Canis sp.:
@@ -965,14 +977,23 @@ Canis sp.:
         - DRB1
 Canis lupus baileyi:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Caba
   name: Mexican Gray Wolf
 Canis latrans:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Cala
   name: Coyote
 Canis lupus:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Calu
   name:
     - Gray Wolf
@@ -980,10 +1001,16 @@ Canis lupus:
     - Dog
 Canis rufus:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Caru
   name: Red Wolf
 Canis simensis:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Casi
   name: Ethiopian Wolf
 Canis aureus:
@@ -1001,10 +1028,16 @@ Canis aureus:
   name: Golden Jackal
 Canis adustus:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Caad
   name: Side-striped jackal
 Canis mesomelas:
   parent: Canis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # DLA group: https://www.ebi.ac.uk/ipd/mhc/group/DLA/species
+  prefix source: designated
   prefix: Came
   name: Black-backed jackal
 ############################
@@ -2345,11 +2378,17 @@ Ovis sp.:
         - DRB1
 Ovis aries:
   parent: Ovis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # OLA group: https://www.ebi.ac.uk/ipd/mhc/group/OLA/species
+  prefix source: designated
   prefix: Ovar
   name:
     - Domestic Sheep
 Ovis canadensis:
   parent: Ovis sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # OLA group: https://www.ebi.ac.uk/ipd/mhc/group/OLA/species
+  prefix source: designated
   prefix: Ovca
   name:
     - Bighorn Sheep
@@ -2438,10 +2477,16 @@ Bos indicus:
   name: Zebu
 Bos frontalis:
   parent: Bos sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # BoLA group: https://www.ebi.ac.uk/ipd/mhc/group/BoLA/species
+  prefix source: designated
   prefix: Bofr
   name: Gayal
 Bos grunniens:
   parent: Bos sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # BoLA group: https://www.ebi.ac.uk/ipd/mhc/group/BoLA/species
+  prefix source: designated
   prefix: Bogr
   name:
     - Domestic Yak
@@ -2455,6 +2500,9 @@ Bubalus bubalis:
   # read it as licence to move others around; see the species tree section of
   # docs/curation.md.
   parent: Bos sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # BoLA group: https://www.ebi.ac.uk/ipd/mhc/group/BoLA/species
+  prefix source: designated
   prefix: Bubu
   name: Water Buffalo
   genes:
@@ -2524,70 +2572,121 @@ Cetacea sp.:
         - DMB
 Balaenoptera musculus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Bamu
   name: Blue whale
 Balaenoptera acutorostrata:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Baac
   name: Minke whale
 Balaenoptera edeni:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Baed
   name: Bryde's whale
 Cephalorhynchus hectori:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Cehe
   name: Hector's dolphin
 Delphinus delphis:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Dede
   name: Common dolphin
 Eubalaena australis:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Euau
   name: Southern right whale
 Globicephala melas:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Glme
   name: Long-finned pilot whale
 Grampus griseus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Grgr
   name: Risso's dolphin
 Kogia breviceps:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Kobr
   name: Pygmy sperm whale
 Lagenorhynchus obscurus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Laob
   name: Dusky dolphin
 Mesoplodon densirostris:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Mede
   name: Blainville's beaked whale
 Mesoplodon europaeus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Meeu
   name: Gervais' beaked whale
 Mesoplodon grayi:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Megr
   name: Gray's beaked whale
 Megaptera novaeangliae:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Meno
   name: Humpback whale
 Steno bredanensis:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Stbr
   name: Rough-toothed dolphin
 Stenella coeruleoalba:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Stco
   name: Striped dolphin
 Tursiops truncatus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Tutr
   name: Bottlenose dolphin
 Hyperoodon ampullatus:
@@ -2602,6 +2701,9 @@ Hyperoodon ampullatus:
   name: Northern bottlenose whale
 Ziphius cavirostris:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Zica
   name: Cuvier's beaked whale
 ############################
@@ -2613,46 +2715,79 @@ Ziphius cavirostris:
 ############################
 Balaenoptera musculus brevicauda:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Bamubr
   name: Pygmy blue whale
 Balaenoptera ricei:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Bari
   name: Rice's whale
 Eschrichtius robustus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Esro
   name: Gray whale
 Eubalaena glacialis:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Eugl
   name: North Atlantic right whale
 Inia geoffrensis:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Inge
   name: Amazon river dolphin
 Kogia sima:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Kosi
   name: Dwarf sperm whale
 Lagenorhynchus albirostris:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Laal
   name: White-beaked dolphin
 Lipotes vexillifer:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Live
   name: Baiji
 Monodon monoceros:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Momo
   name: Narwhal
 Phocoena phocoena:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Phph
   name: Harbor porpoise
 Phocoena sinus:
   parent: Cetacea sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CeLA group: https://www.ebi.ac.uk/ipd/mhc/group/CeLA/species
+  prefix source: designated
   prefix: Phsi
   name: Vaquita
 Caperea marginata:
@@ -2706,6 +2841,9 @@ Capra sp.:
         - DRB1
 Capra hircus:
   parent: Capra sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # CLA group: https://www.ebi.ac.uk/ipd/mhc/group/CLA/species
+  prefix source: designated
   prefix: Cahi
   name:
     - Domestic goat
@@ -2759,6 +2897,9 @@ Equus sp.:
         - DMB
 Equus caballus:
   parent: Equus sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # ELA group: https://www.ebi.ac.uk/ipd/mhc/group/ELA/species
+  prefix source: designated
   prefix: Eqca
   name: Horse
 Equus burchelli:
@@ -2784,6 +2925,9 @@ Suidae sp.:
   name: Suid
 Phacochoerus africanus:
   parent: Suidae sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # SLA group: https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
+  prefix source: designated
   prefix: Phaf
   name: Common warthog
 Sus sp.:
@@ -2832,10 +2976,16 @@ Sus sp.:
         - DMB
 Sus domesticus:
   parent: Sus sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # SLA group: https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
+  prefix source: designated
   prefix: Sudo
   name: Domestic Pig
 Sus scrofa:
   parent: Sus sp.
+  # prefix source: designated -- listed with this code in the IPD-MHC
+  # SLA group: https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
+  prefix source: designated
   prefix: Susc
   # Swine haplotypes are written with an "Hp" prefix. This was a
   # `haplotype prefix: Hp` key, but nothing in the loader ever read it and no

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.44.1"
+__version__ = "3.44.2"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,32 +1,57 @@
-# Remove two species.yaml keys nothing ever read
+# Curate prefix provenance from the IPD-MHC species tables
 
-Tracking issue: #139
+Tracking issue: #131 (partial -- 113 entries still unestablished)
 
 ## Review
 
-- **I filed #139 with a wrong claim, and checking it settled the design.** The
-  issue said neither `MhcPatr` nor the transposed `MhcPtar` resolves. Only the
-  second is true: `Species.get("MhcPatr")` is `None`, but `parse` strips a
-  leading `Mhc` as a fallback, so `parse("MhcPatr-A*01:01")` gives
-  `Patr-A*01:01`. The `alias: MhcPtar` key was therefore carrying nothing --
-  a typo of a string that already works without it -- so there was no
-  behaviour to preserve and no reason to implement the key.
-- **`haplotype prefix: Hp` had nothing behind it either.** `haplotypes.yaml`
-  has no `Sus scrofa` entry, and none of `Hp-1.1`, `SLA-1.1`, `Hp1.1` or
-  `Susc-Hp-1.1` parses, so wiring the key into `Species` would have given a
-  prefix with no haplotypes under it. The fact that swine haplotypes carry an
-  `Hp` prefix is kept as a comment on the entry, and curating the haplotypes
-  themselves is #143 -- the prerequisite for any field.
-- **The hygiene rule that would have caught this.** `SPECIES_ENTRY_KEYS` exists
-  so a misspelled key cannot load silently while the YAML asserts something the
-  runtime never read. Whitelisting a key nothing reads does the same thing with
-  more confidence behind it, which is exactly what happened when I added the
-  frozenset in #132 and listed both of these to keep the file loading.
-  `tests/test_ontology_hygiene.py` now asserts every accepted key is fetched in
-  `species.py`, and that the data uses no key the loader rejects.
-- **The test caught its own first draft.** It looked for
-  `species_info.get("<key>")` and flagged `genes`, `gene properties` and
-  `gene families`, which are fetched with a default argument. Broadened, then
-  verified by mutation: adding a bogus key to the frozenset fails it.
-- **Measured:** 0 of 11,558 corpus names change.
-- Bumped to 3.44.1 -- data and hygiene only, no behaviour change.
+- **50 entries marked `designated`, each citing an IPD-MHC group species
+  table.** The count goes 11 -> 61, and the unestablished tail 163 -> 113.
+  Rather than 163 individual lookups, the group tables list every species and
+  its designation in one page each, so this is eight fetches:
+
+  | group | rows | marked |
+  |---|---|---|
+  | DLA | 10 | 9 |
+  | CeLA | 33 | 29 |
+  | SLA | 3 | 3 |
+  | BoLA | 4 | 3 |
+  | OLA | 2 | 2 |
+  | RT1 | 2 | 2 |
+  | CLA | 1 | 1 |
+  | ELA | 1 | 1 |
+
+  Each was read verbatim rather than from a summary, per `AGENTS.md`, and every
+  row was checked against our prefix before marking.
+
+- **Zero of the 56 species IPD lists in these groups is missing from our
+  ontology**, and the prefixes agree everywhere except five.
+
+- **Four of the five disagreements are known or newly filed:**
+  - `Canis aureus`: IPD designates `Caau`, which is in published use for the
+    goldfish *Carassius auratus*. Our entry keeps `CaniAure` and holds `Caau`
+    as a context-only prefix -- #112's resolution, working as intended.
+  - `Hyperoodon ampullatus`: IPD designates `Hyam`, which resolves to the Rio
+    Grande silvery minnow. Same shape, same resolution.
+  - `Delphinapterus leucas`, `Neophocaena asiaeorientalis`, `Orcinus orca`: our
+    canonical prefix is a generated 4+4 (`DeleLuca`, `NeopAsia`, `OrciOrca`)
+    while IPD designates `Dele`, `Neas`, `Oror` -- and those already resolve to
+    the right species as aliases, with nothing else claiming them. So we emit a
+    name we invented in preference to the published one. Filed as **#146**,
+    since swapping them changes normalized output for three species.
+
+- **The remaining 113 are the harder half**, and the eight pinned in
+  `test_unestablished_provenance_stays_none` show why: `OmLA`, `FLA`, `GoLA`,
+  `MaLA`, `RhLA`, `RLA`, `ChLA`, `OrLA` are group-level `_LA` codes, and
+  IPD-MHC publishes no group page for any of them -- `/group/FLA/` is a 404.
+  Establishing those means the primate nomenclature reports rather than a
+  species table.
+
+- **A new test pins the citations themselves.** Every IPD group named in a
+  `species.yaml` URL must be one of the eleven IPD publishes, read off
+  `https://www.ebi.ac.uk/ipd/mhc/`. Its first draft failed on `FISH` and
+  `CHICKEN`, which are real groups I had left out of the set -- so it caught my
+  error rather than a data error. Verified by mutation: mistyping `CeLA` as
+  `CELA` in a citation fails it.
+
+- **Measured:** 0 of 11,558 corpus names change. Provenance only.
+- Bumped to 3.44.2.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -676,6 +676,11 @@ def test_unestablished_provenance_stays_none():
     # them all at once has to come here and say so. A count bound would have
     # done neither -- it fires on ordinary growth and passes a bulk assignment.
     for name in [
+        # The eight group-level _LA codes, still unchecked. IPD-MHC has no
+        # group page for any of them (there is no /group/FLA/, /group/OrLA/,
+        # ...), so establishing them means the primate nomenclature reports
+        # rather than a species table -- which is why they are the tail of
+        # #131 rather than part of the batch that was easy.
         "Aotus sp.",
         "Callithrix sp.",
         "Felis sp.",
@@ -839,3 +844,35 @@ def test_is_group_is_public_and_gets_nhp_right():
     ok_(Species.get_by_latin_name("Bos sp.").is_group)
     ok_(not Species.get_by_latin_name("Homo sapiens").is_group)
     ok_(not Species.get_by_latin_name("Bubo bubo").is_group)
+
+
+def test_designated_marks_match_the_ipd_group_they_cite():
+    """
+    Every `prefix source: designated` comment names where the claim came from.
+    For the batch curated in #131 that is an IPD-MHC group species table, and
+    the group in the URL has to be one IPD actually publishes -- a typo there
+    would send the next curator to a 404, which is how `/group/FLA/` was found
+    not to exist.
+    """
+    import re
+    from pathlib import Path
+
+    # The groups IPD-MHC publishes, read verbatim off https://www.ebi.ac.uk/ipd/mhc/
+    known_groups = {
+        "NHP",
+        "DLA",
+        "FISH",
+        "OLA",
+        "BoLA",
+        "ELA",
+        "SLA",
+        "RT1",
+        "CHICKEN",
+        "CLA",
+        "CeLA",
+    }
+    text = (Path(__file__).parent.parent / "mhcgnomes" / "data" / "species.yaml").read_text()
+    cited = re.findall(r"ebi\.ac\.uk/ipd/mhc/group/([A-Za-z0-9]+)/", text)
+    assert cited, "no IPD group citations found at all"
+    unknown = sorted(set(cited) - known_groups)
+    eq_(unknown, [], f"species.yaml cites IPD groups that are not in the published set: {unknown}")


### PR DESCRIPTION
Partial progress on #131 — leaves it open with 113 entries to go.

## 50 entries marked, each citing an IPD-MHC species table

Designated goes **11 → 61**; the unestablished tail **163 → 113**.

Rather than 163 individual lookups, IPD's group pages list every species with
its designation on one page each — eight fetches, read verbatim rather than
from a summary:

| group | rows on the page | marked |
|---|---|---|
| `DLA` | 10 | 9 |
| `CeLA` | 33 | 29 |
| `SLA` | 3 | 3 |
| `BoLA` | 4 | 3 |
| `OLA` | 2 | 2 |
| `RT1` | 2 | 2 |
| `CLA` | 1 | 1 |
| `ELA` | 1 | 1 |

**Zero of the 56 species IPD lists in these groups is missing from our
ontology**, and the prefixes agree everywhere except five.

## The five disagreements

Two are #112's documented resolution, working as intended:

- *Canis aureus* — IPD designates `Caau`, which is in published use for the
  goldfish *Carassius auratus*. The entry keeps `CaniAure` and holds `Caau` as
  a context-only prefix.
- *Hyperoodon ampullatus* — IPD designates `Hyam`, which resolves to the Rio
  Grande silvery minnow. Same shape, same resolution.

Three are new, and filed as **#146**: *Delphinapterus leucas*,
*Neophocaena asiaeorientalis* and *Orcinus orca* carry generated 4+4 prefixes
(`DeleLuca`, `NeopAsia`, `OrciOrca`) while IPD designates `Dele`, `Neas`,
`Oror` — and those already resolve to the right species, with nothing else
claiming them. So `parse("Oror-DQB1")` normalizes to `OrciOrca-DQB1`: a name we
invented, in preference to the published one. Swapping them changes normalized
output for three species, so it wants its own measurement.

## Why the remaining 113 are the harder half

The eight pinned in `test_unestablished_provenance_stays_none` show why:
`OmLA`, `FLA`, `GoLA`, `MaLA`, `RhLA`, `RLA`, `ChLA`, `OrLA` are group-level
`_LA` codes, and IPD-MHC publishes no group page for any of them —
`/group/FLA/` is a 404. Establishing those means the primate nomenclature
reports rather than a species table.

## A new test pins the citations themselves

Every IPD group named in a `species.yaml` URL must be one of the eleven IPD
publishes, read off https://www.ebi.ac.uk/ipd/mhc/. A typo would send the next
curator to a 404 — which is how `/group/FLA/` was found not to exist.

Its first draft failed on `FISH` and `CHICKEN`, which are real groups I had
left out of the set, so it caught my error rather than a data error. Verified
by mutation: mistyping `CeLA` as `CELA` in a citation fails it.

## Measurement

**0 of 11,558** corpus names change against a worktree of `main` — provenance
metadata only.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,637 passed. 3.45.0 → 3.45.1.
