### PR TITLE
Build with the resolved venv, and move the workflows off Node 20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,9 +42,14 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
+          # v4 stopped including dotfiles in the artifact. v5 is still the only
+          # release whose nested actions/upload-artifact runs on Node 24 (v3
+          # pins upload-artifact@v4 and v4 pins v4.6.2, both Node 20), so the
+          # flag restores v3's behaviour rather than accepting the change.
+          include-hidden-files: true
 
   deploy:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -38,11 +38,11 @@ jobs:
 
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v3
         with:
           path: site
 

--- a/.github/workflows/external-data.yml
+++ b/.github/workflows/external-data.yml
@@ -28,16 +28,16 @@ jobs:
       MHCGNOMES_DATA_CACHE: .external-data-cache
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
 
       - name: Restore verified external-data cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .external-data-cache
           key: external-data-v1-${{ runner.os }}-${{ hashFiles('mhcgnomes/data/external_sources.json') }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -49,7 +49,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/release_testpypi.yml
+++ b/.github/workflows/release_testpypi.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/deploy.py
+++ b/deploy.py
@@ -33,7 +33,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import NoReturn, Optional
 
@@ -303,19 +303,22 @@ def clean_build_artifacts(*, cwd: Path, dry_run: bool) -> None:
 
 
 def build_distributions(cfg: Config, *, cwd: Path) -> None:
-    require_cmd("python3", env=cfg.env)
+    build_python = cfg.python
+
+    # Probe before deleting anything. clean_build_artifacts removes dist/,
+    # build/ and *.egg-info -- including the editable install's -- so failing
+    # after it leaves the checkout worse off than before the attempt.
+    note(f"Checking build availability with {build_python}...")
+    if not Path(build_python).exists() and shutil.which(build_python) is None:
+        die(f"Build interpreter does not exist: {build_python}")
+    if not interpreter_can_build(build_python, env=cfg.env):
+        die(
+            f"{build_python} cannot import both 'build' and 'setuptools', which "
+            f"`python -m build --no-isolation` needs. Install them there, or set "
+            f"DEPLOY_PYTHON to an interpreter that has them."
+        )
 
     clean_build_artifacts(cwd=cwd, dry_run=cfg.dry_run)
-
-    build_python = cfg.python
-    note(f"Checking build availability with {build_python}...")
-    run_checked(
-        [build_python, "-m", "build", "--version"],
-        cwd=cwd,
-        env=cfg.env,
-        capture_stdout=True,
-        capture_stderr=True,
-    )
 
     note(f"Building distributions with {build_python} -m build (no isolation)...")
     run_effectful(
@@ -366,15 +369,67 @@ def resolve_venv_bin(root: Path) -> Optional[Path]:
     return None
 
 
-def resolve_venv_python(venv_bin: Optional[Path]) -> Optional[str]:
+def venv_python(venv_bin: Optional[Path]) -> Optional[Path]:
     """The interpreter inside the venv whose bin directory this is."""
     if venv_bin is None:
         return None
     for name in ("python", "python3"):
         candidate = venv_bin / name
         if candidate.exists():
-            return str(candidate)
+            return candidate
     return None
+
+
+def interpreter_can_build(python: str, env: Optional[dict[str, str]] = None) -> bool:
+    """
+    Can this interpreter run `python -m build --no-isolation`?
+
+    Both imports matter. `--no-isolation` means the build backend is not
+    provisioned for us, so pyproject's `requires = ["setuptools>=61.0", "wheel"]`
+    has to already be importable here. Probing only `build` would pass on an
+    environment that then fails inside the build.
+    """
+    try:
+        result = subprocess.run(
+            [python, "-c", "import build, setuptools"],
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def resolve_build_python(
+    venv_bin: Optional[Path], env: Optional[dict[str, str]]
+) -> tuple[str, str]:
+    """
+    The interpreter that will run the build, and a phrase explaining the choice.
+
+    Issue #101 was that deploy.py resolved a venv, said so, and then built with
+    `sys.executable` -- whatever launched it. The obvious fix, always preferring
+    the venv, is worse: develop.sh installs only `.[dev,docs]`, which has no
+    `build` and no `setuptools`, so the venv usually cannot build at all. That
+    would turn a working release into one that aborts after lint and the full
+    test suite.
+
+    So prefer the venv *when it can actually build*, fall back otherwise, and
+    return the reason either way so the log can say which and why. Note there is
+    no DEPLOY_PYTHON check here: deploy.sh launches deploy.py with it
+    (`PYTHON_BIN="${DEPLOY_PYTHON:-python3}"`), so an explicit override already
+    arrives as sys.executable.
+    """
+    fallback = sys.executable or "python3"
+    candidate = venv_python(venv_bin)
+    if candidate is None:
+        return fallback, "launching interpreter; no project venv found"
+    if interpreter_can_build(str(candidate), env=env):
+        return str(candidate), "project venv"
+    return (
+        fallback,
+        f"launching interpreter; {candidate} cannot import build and setuptools",
+    )
 
 
 def build_run_env(venv_bin: Optional[Path]) -> dict[str, str]:
@@ -408,7 +463,9 @@ def parse_args(argv: Sequence[str]) -> Config:
         dry_run=bool(ns.dry_run),
         fetch=bool(ns.fetch),
         env=None,
-        python=sys.executable or "python3",
+        # Placeholder. main() resolves the real one with resolve_build_python
+        # once the repo root and venv are known.
+        python="",
     )
 
 
@@ -419,23 +476,14 @@ def main(argv: Sequence[str]) -> int:
     root = repo_root()
     venv_bin = resolve_venv_bin(root)
     run_env = build_run_env(venv_bin)
-    # DEPLOY_PYTHON, then the venv interpreter, then whatever launched us. The
-    # middle one is the fix for #101: selecting a venv has to select its
-    # interpreter too, not just prepend its bin directory to PATH.
-    build_python = (
-        os.environ.get("DEPLOY_PYTHON")
-        or resolve_venv_python(venv_bin)
-        or sys.executable
-        or "python3"
-    )
+    build_python, build_python_reason = resolve_build_python(venv_bin, run_env)
 
-    # Interpret configured paths relative to repo root so deploy.sh works from anywhere.
-    cfg = Config(
+    # Interpret configured paths relative to repo root so deploy.sh works from
+    # anywhere. dataclasses.replace rather than a field-by-field rebuild, so a
+    # future Config field cannot be silently dropped here.
+    cfg = replace(
+        cfg,
         version_file=(root / cfg.version_file).resolve(),
-        required_branch=cfg.required_branch,
-        remote=cfg.remote,
-        dry_run=cfg.dry_run,
-        fetch=cfg.fetch,
         env=run_env,
         python=build_python,
     )
@@ -445,10 +493,10 @@ def main(argv: Sequence[str]) -> int:
         ok(f"Using venv: {venv_bin.parent}")
     else:
         note("No venv found; using system PATH")
-    # Name the interpreter that will actually run the build, so a mismatch is
-    # visible in the log rather than discovered when `build` turns out to be
-    # missing (#101).
-    ok(f"Build interpreter: {cfg.python}")
+    # Name the interpreter that will actually run the build, and why it was
+    # chosen. The bug in #101 was not that the wrong one was picked, it was that
+    # the log said one thing and the build did another.
+    ok(f"Build interpreter: {cfg.python} ({build_python_reason})")
 
     # Preflight: cheap local checks first.
     ensure_remote_exists(cfg, cwd=root)

--- a/deploy.py
+++ b/deploy.py
@@ -69,12 +69,15 @@ class Config:
     dry_run: bool
     fetch: bool
     env: Optional[dict[str, str]]
-    # The interpreter that goes with `env`. Builds must use this rather than
-    # sys.executable, which is whatever launched deploy.py -- the 3.33.6
-    # release reported "Using venv: .venv" and then built with a Homebrew
-    # Python 3.14 that had no `build` module, after lint and 15,127 tests had
-    # already passed. See issue #101.
+    # The interpreter that runs the build. Not necessarily the one that goes
+    # with `env`: `env` always names the venv, while the build falls back to the
+    # launching interpreter when the venv cannot build. See issue #101.
     python: str
+    # The environment for the build subprocess, which must match `python`.
+    # `env` (venv PATH + VIRTUAL_ENV) when the venv is the build interpreter,
+    # None otherwise -- passing the venv's environment to a different
+    # interpreter is the same drift, pointed the other way.
+    build_env: Optional[dict[str, str]]
 
 
 class CommandError(RuntimeError):
@@ -302,29 +305,56 @@ def clean_build_artifacts(*, cwd: Path, dry_run: bool) -> None:
         shutil.rmtree(path, ignore_errors=True)
 
 
+def check_build_prerequisites(cfg: Config) -> None:
+    """
+    Can the resolved interpreter actually build? Separate from
+    build_distributions so `--dry-run` runs it too: a dry run exists to rehearse
+    the release, and reporting success on a checkout that cannot build is the
+    #101 experience in miniature. Also runs before anything is deleted --
+    clean_build_artifacts removes dist/, build/ and *.egg-info, including the
+    editable install's, so failing after it leaves the checkout worse off.
+    """
+    build_python = cfg.python
+    note(f"Checking build availability with {build_python}...")
+    # Not `Path(x).exists()` alone: Path("") is PosixPath("."), which exists, so
+    # an empty interpreter would slip straight past. require_cmd does the
+    # env-aware PATH lookup, so a bare name resolves against the same PATH the
+    # build will run with.
+    if not build_python:
+        die("No build interpreter was resolved.")
+    if Path(build_python).is_absolute():
+        if not Path(build_python).is_file():
+            die(f"Build interpreter does not exist: {build_python}")
+    else:
+        require_cmd(build_python, env=cfg.build_env)
+
+    can_build, why_not = interpreter_can_build(build_python, env=cfg.build_env)
+    if not can_build:
+        die(
+            f"{build_python} cannot run `python -m build --no-isolation`, which needs "
+            f"both 'build' and 'setuptools' importable.\n{why_not}\n"
+            f"Install them there:\n"
+            f"    {build_python} -m pip install build setuptools wheel\n"
+            f"or set DEPLOY_PYTHON to an interpreter that has them."
+        )
+    ok(f"{build_python} can build")
+
+
 def build_distributions(cfg: Config, *, cwd: Path) -> None:
     build_python = cfg.python
-
-    # Probe before deleting anything. clean_build_artifacts removes dist/,
-    # build/ and *.egg-info -- including the editable install's -- so failing
-    # after it leaves the checkout worse off than before the attempt.
-    note(f"Checking build availability with {build_python}...")
-    if not Path(build_python).exists() and shutil.which(build_python) is None:
-        die(f"Build interpreter does not exist: {build_python}")
-    if not interpreter_can_build(build_python, env=cfg.env):
-        die(
-            f"{build_python} cannot import both 'build' and 'setuptools', which "
-            f"`python -m build --no-isolation` needs. Install them there, or set "
-            f"DEPLOY_PYTHON to an interpreter that has them."
-        )
-
+    check_build_prerequisites(cfg)
     clean_build_artifacts(cwd=cwd, dry_run=cfg.dry_run)
 
     note(f"Building distributions with {build_python} -m build (no isolation)...")
+    # Deliberately not cfg.env. That environment names the venv -- VIRTUAL_ENV
+    # set, its bin prepended to PATH -- and when the build falls back to the
+    # launching interpreter the two disagree, so `python` and `pip` inside the
+    # build would resolve to a different interpreter than the one running it.
+    # That is the drift #101 is about, pointed the other way.
     run_effectful(
         [build_python, "-m", "build", "--no-isolation"],
         cwd=cwd,
-        env=cfg.env,
+        env=cfg.build_env,
         dry_run=cfg.dry_run,
     )
     ok("Build step complete")
@@ -380,9 +410,9 @@ def venv_python(venv_bin: Optional[Path]) -> Optional[Path]:
     return None
 
 
-def interpreter_can_build(python: str, env: Optional[dict[str, str]] = None) -> bool:
+def interpreter_can_build(python: str, env: Optional[dict[str, str]] = None) -> tuple[bool, str]:
     """
-    Can this interpreter run `python -m build --no-isolation`?
+    Can this interpreter run `python -m build --no-isolation`, and if not, why?
 
     Both imports matter. `--no-isolation` means the build backend is not
     provisioned for us, so pyproject's `requires = ["setuptools>=61.0", "wheel"]`
@@ -393,12 +423,18 @@ def interpreter_can_build(python: str, env: Optional[dict[str, str]] = None) -> 
         result = subprocess.run(
             [python, "-c", "import build, setuptools"],
             capture_output=True,
+            text=True,
             env=env,
             check=False,
         )
-    except OSError:
-        return False
-    return result.returncode == 0
+    except OSError as exc:
+        return False, str(exc)
+    if result.returncode == 0:
+        return True, ""
+    # Keep the traceback. A `build` that is installed but broken -- a stale
+    # .pth, an incompatible `packaging` -- exits non-zero for a reason the
+    # fixed message would otherwise throw away.
+    return False, (result.stderr or result.stdout or "").strip()
 
 
 def resolve_build_python(
@@ -421,10 +457,17 @@ def resolve_build_python(
     arrives as sys.executable.
     """
     fallback = sys.executable or "python3"
+    # deploy.sh runs `PYTHON_BIN="${DEPLOY_PYTHON:-python3}"; "$PYTHON_BIN" deploy.py`,
+    # so when the variable is set the launching interpreter *is* the requested
+    # one. Checking for its presence -- rather than re-reading the path -- lets
+    # an explicit request outrank a capable venv, which it must: it is the only
+    # way to force an interpreter, and the failure message points at it.
+    if os.environ.get("DEPLOY_PYTHON"):
+        return fallback, "DEPLOY_PYTHON"
     candidate = venv_python(venv_bin)
     if candidate is None:
         return fallback, "launching interpreter; no project venv found"
-    if interpreter_can_build(str(candidate), env=env):
+    if interpreter_can_build(str(candidate), env=env)[0]:
         return str(candidate), "project venv"
     return (
         fallback,
@@ -463,9 +506,10 @@ def parse_args(argv: Sequence[str]) -> Config:
         dry_run=bool(ns.dry_run),
         fetch=bool(ns.fetch),
         env=None,
-        # Placeholder. main() resolves the real one with resolve_build_python
+        # Placeholders. main() resolves the real ones with resolve_build_python
         # once the repo root and venv are known.
         python="",
+        build_env=None,
     )
 
 
@@ -477,6 +521,7 @@ def main(argv: Sequence[str]) -> int:
     venv_bin = resolve_venv_bin(root)
     run_env = build_run_env(venv_bin)
     build_python, build_python_reason = resolve_build_python(venv_bin, run_env)
+    build_env = run_env if build_python_reason == "project venv" else None
 
     # Interpret configured paths relative to repo root so deploy.sh works from
     # anywhere. dataclasses.replace rather than a field-by-field rebuild, so a
@@ -486,6 +531,7 @@ def main(argv: Sequence[str]) -> int:
         version_file=(root / cfg.version_file).resolve(),
         env=run_env,
         python=build_python,
+        build_env=build_env,
     )
 
     ok(f"Repo root: {root}")
@@ -526,8 +572,10 @@ def main(argv: Sequence[str]) -> int:
     ensure_tag_absent(cfg, tag, cwd=root)
 
     if cfg.dry_run:
+        # Rehearse the part that actually breaks releases.
+        check_build_prerequisites(cfg)
         note("Dry run summary:")
-        note("  would run: python -m build --no-isolation")
+        note(f"  would run: {cfg.python} -m build --no-isolation")
         note(f"  would run: git tag -a {tag} -m 'Release {tag} ({version})'")
         note(f"  would run: git push {cfg.remote} refs/tags/{tag}")
         ok("Dry run complete")

--- a/deploy.py
+++ b/deploy.py
@@ -69,6 +69,12 @@ class Config:
     dry_run: bool
     fetch: bool
     env: Optional[dict[str, str]]
+    # The interpreter that goes with `env`. Builds must use this rather than
+    # sys.executable, which is whatever launched deploy.py -- the 3.33.6
+    # release reported "Using venv: .venv" and then built with a Homebrew
+    # Python 3.14 that had no `build` module, after lint and 15,127 tests had
+    # already passed. See issue #101.
+    python: str
 
 
 class CommandError(RuntimeError):
@@ -301,17 +307,23 @@ def build_distributions(cfg: Config, *, cwd: Path) -> None:
 
     clean_build_artifacts(cwd=cwd, dry_run=cfg.dry_run)
 
-    build_python = sys.executable or "python3"
-    note("Checking build availability...")
+    build_python = cfg.python
+    note(f"Checking build availability with {build_python}...")
     run_checked(
         [build_python, "-m", "build", "--version"],
         cwd=cwd,
+        env=cfg.env,
         capture_stdout=True,
         capture_stderr=True,
     )
 
-    note("Building distributions with python -m build (no isolation)...")
-    run_effectful([build_python, "-m", "build", "--no-isolation"], cwd=cwd, dry_run=cfg.dry_run)
+    note(f"Building distributions with {build_python} -m build (no isolation)...")
+    run_effectful(
+        [build_python, "-m", "build", "--no-isolation"],
+        cwd=cwd,
+        env=cfg.env,
+        dry_run=cfg.dry_run,
+    )
     ok("Build step complete")
 
     dist_dir = cwd / "dist"
@@ -354,6 +366,17 @@ def resolve_venv_bin(root: Path) -> Optional[Path]:
     return None
 
 
+def resolve_venv_python(venv_bin: Optional[Path]) -> Optional[str]:
+    """The interpreter inside the venv whose bin directory this is."""
+    if venv_bin is None:
+        return None
+    for name in ("python", "python3"):
+        candidate = venv_bin / name
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
 def build_run_env(venv_bin: Optional[Path]) -> dict[str, str]:
     env = os.environ.copy()
     if venv_bin is not None:
@@ -385,6 +408,7 @@ def parse_args(argv: Sequence[str]) -> Config:
         dry_run=bool(ns.dry_run),
         fetch=bool(ns.fetch),
         env=None,
+        python=sys.executable or "python3",
     )
 
 
@@ -395,6 +419,15 @@ def main(argv: Sequence[str]) -> int:
     root = repo_root()
     venv_bin = resolve_venv_bin(root)
     run_env = build_run_env(venv_bin)
+    # DEPLOY_PYTHON, then the venv interpreter, then whatever launched us. The
+    # middle one is the fix for #101: selecting a venv has to select its
+    # interpreter too, not just prepend its bin directory to PATH.
+    build_python = (
+        os.environ.get("DEPLOY_PYTHON")
+        or resolve_venv_python(venv_bin)
+        or sys.executable
+        or "python3"
+    )
 
     # Interpret configured paths relative to repo root so deploy.sh works from anywhere.
     cfg = Config(
@@ -404,6 +437,7 @@ def main(argv: Sequence[str]) -> int:
         dry_run=cfg.dry_run,
         fetch=cfg.fetch,
         env=run_env,
+        python=build_python,
     )
 
     ok(f"Repo root: {root}")
@@ -411,6 +445,10 @@ def main(argv: Sequence[str]) -> int:
         ok(f"Using venv: {venv_bin.parent}")
     else:
         note("No venv found; using system PATH")
+    # Name the interpreter that will actually run the build, so a mismatch is
+    # visible in the log rather than discovered when `build` turns out to be
+    # missing (#101).
+    ok(f"Build interpreter: {cfg.python}")
 
     # Preflight: cheap local checks first.
     ensure_remote_exists(cfg, cwd=root)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -79,11 +79,17 @@ built with the launching interpreter anyway; the fix is that it now tells you.
 To build under the venv, install the tools there:
 
 ```bash
-.venv/bin/python -m pip install build twine
+.venv/bin/python -m pip install build setuptools wheel
 ```
 
-To choose an interpreter explicitly, set `DEPLOY_PYTHON` -- `deploy.sh` uses it
-to launch `deploy.py`, so it becomes the launching interpreter:
+`setuptools` is not optional and is not pulled in by `build`: Python 3.12
+dropped it from new venvs, and `--no-isolation` means pyproject's
+`requires = ["setuptools>=61.0", "wheel"]` must already be importable. Add
+`twine` too if you publish from that venv.
+
+To choose an interpreter explicitly, set `DEPLOY_PYTHON`. `deploy.sh` uses it
+to launch `deploy.py`, and an explicit request outranks even a venv that could
+build, so it is the way to force a specific interpreter:
 
 ```bash
 DEPLOY_PYTHON=.venv/bin/python ./deploy.sh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -53,6 +53,45 @@ These are one-time repository setup tasks outside the codebase:
 
 ## What `deploy.sh` Enforces
 
+### Which interpreter builds
+
+`deploy.py` resolves a project venv (`.venv`, then `venv`) and puts its `bin`
+on `PATH`, but the **build** runs under whichever interpreter can actually do
+it, and the log says which and why:
+
+```
+OK: Using venv: /path/to/repo/.venv
+OK: Build interpreter: /path/to/.venv/bin/python (project venv)
+```
+
+The venv is preferred only when it can import both `build` and `setuptools` --
+`python -m build --no-isolation` needs the backend already present.
+`develop.sh` installs `.[dev,docs]`, which contains neither, so on a plain
+development checkout the line reads:
+
+```
+OK: Build interpreter: /usr/local/bin/python3 (launching interpreter;
+    /path/to/.venv/bin/python cannot import build and setuptools)
+```
+
+That is not a failure. Before #101 the script printed the venv and silently
+built with the launching interpreter anyway; the fix is that it now tells you.
+To build under the venv, install the tools there:
+
+```bash
+.venv/bin/python -m pip install build twine
+```
+
+To choose an interpreter explicitly, set `DEPLOY_PYTHON` -- `deploy.sh` uses it
+to launch `deploy.py`, so it becomes the launching interpreter:
+
+```bash
+DEPLOY_PYTHON=.venv/bin/python ./deploy.sh
+```
+
+The check runs *before* `dist/`, `build/` and `*.egg-info` are cleaned, so a
+missing `build` aborts without leaving the checkout worse off than it started.
+
 `deploy.sh` still runs the full local test and lint gates before calling
 `deploy.py`. `deploy.py` then enforces:
 

--- a/format.sh
+++ b/format.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-SOURCES="mhcgnomes scripts tests"
+# Must match lint.sh, or a ruff-format violation in deploy.py or
+# release_utils.py is reported by ./lint.sh and unfixable by ./format.sh.
+SOURCES="mhcgnomes scripts tests deploy.py release_utils.py"
 
 echo "Running ruff format..."
 ruff format $SOURCES

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.47.0"
+__version__ = "3.47.1"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,38 +1,57 @@
-# Support the hyphenated class shorthand
+# Release infra: build with the venv, and get the workflows off Node 20
 
-Tracking issue: #104
+Tracking issues: #101, #94
 
 ## Review
 
-- **The reported bug is real and now fixed.** `SLA-I`, `BoLA-I`, `HLA-I`,
-  `DLA-I`, `Patr-I`, `Gaga-I` and `<prefix>-II` everywhere returned `None`,
-  while `<prefix> class I` worked. Both spellings now give the same
-  `MhcClass`, which is what a caller pulling MHC tokens out of curated text
-  needs -- the reported failure was a sample silently ending up with no
-  genotype.
-- **But two of the issue's three claims do not hold**, and checking them was
-  the point:
-  - **`Mamu-I` is not a misparse.** It is a published macaque MHC class I
-    locus: J Immunol 2000;164:1386, *"Mamu-I: A Novel Primate MHC Class I
-    B-Related Locus with Unusually Low Variability"*, and the ontology declares
-    the gene. The issue called it "wrong-but-plausible"; it is right. It stays
-    a `Gene`.
-  - **`H2-I` is a curated mouse haplotype**, `i`. The issue's observation that
-    mouse literature also writes `H2-I` for the class II region is a genuine
-    ambiguity in the source material, but the haplotype is what the ontology
-    has evidence for, so it stays. Recorded in the test rather than silently.
-- **So the shorthand is offered as a candidate, not a short-circuit.** Result
-  sorting picks the `Gene` for `Mamu-I` and the `Haplotype` for `H2-I`, and the
-  `MhcClass` everywhere else. `-II` is unambiguous for every species -- gene
-  `II` resolves nowhere in the ontology -- so it works even for those two.
-- **The digit spelling is deliberately left alone.** My first version mapped
-  `<prefix>-1` as well, and the tests caught it: `SLA-1`, `BoLA-1` and `ELA-1`
-  are real class I gene names. Mapping the digits would have shadowed genuine
-  loci for some species and not others -- recreating the exact inconsistency
-  this issue is about. `HLA-1` still returns `None`, as on `main`.
-- **A sweep test guards the boundary**: gene `I` resolves for 12 species (the
-  macaque group plus two others) and gene `II` for none, so a future addition
-  cannot quietly take the shorthand away from a prefix that has it.
-- **Measured:** 0 of 11,558 corpus names change -- no bundled corpus name uses
-  the shorthand. 48 new tests; removing the shorthand fails 42 of them.
-- Bumped 3.46.1 to 3.47.0: strings that returned `None` now parse.
+### #101 -- deploy.py announced a venv and then built with something else
+
+`build_distributions` used `sys.executable`, which is whatever interpreter
+launched `deploy.py`, not the venv the script had just resolved and reported.
+The 3.33.6 release reproduced it: "Using venv: .venv", then a build through a
+Homebrew Python 3.14 with no `build` module, after lint and 15,127 tests had
+passed.
+
+Still live on this machine, which is how I confirmed it rather than trusting
+the report:
+
+```
+sys.executable  /Users/.../shared-virtual-env/bin/python3
+venv python     /Users/.../uv/python/cpython-3.12.6-.../bin/python3.12
+same?           False
+```
+
+- `Config` carries a `python` field alongside `env`, so the interpreter and the
+  environment cannot drift apart.
+- Resolution order is `DEPLOY_PYTHON`, then the venv interpreter, then
+  `sys.executable`. The middle one is the fix: selecting a venv now selects its
+  interpreter, not just its `bin` on `PATH`.
+- The build-availability check gets `cfg.env` too; it did not before, so it
+  could pass while the real build failed.
+- `deploy.py` now prints `Build interpreter: <path>`, so a mismatch is visible
+  in the log rather than discovered when `build` turns out to be missing.
+
+### #94 -- Node 20 deprecation
+
+Every `actions/*` pin moved to the **lowest major that runs on Node 24**, read
+from each action's own `action.yml` rather than assumed:
+
+| action | was | now | `runs.using` |
+|---|---|---|---|
+| checkout | v4 | v5 | node24 |
+| setup-python | v5 | v6 | node24 |
+| upload-artifact | v4 | v6 | node24 |
+| download-artifact | v4 | v7 | node24 |
+| cache | v4 | v5 | node24 |
+| configure-pages | v5 | v6 | node24 |
+| deploy-pages | v4 | v5 | node24 |
+| upload-pages-artifact | v3 | v5 | composite |
+
+Lowest-that-qualifies rather than latest, deliberately. `download-artifact@v8`
+makes a hash mismatch a hard error and migrates to ESM, and both artifact
+actions only run on tag push and `workflow_dispatch` -- so PR CI cannot verify
+them, and taking the smallest step that clears the deprecation is the lower
+risk. `checkout`, `setup-python` and `cache` are exercised by `tests.yml` and
+`docs.yml` on this PR, so those three are proven by it.
+
+- Bumped to 3.47.1. No library code changes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -51,7 +51,70 @@ Lowest-that-qualifies rather than latest, deliberately. `download-artifact@v8`
 makes a hash mismatch a hard error and migrates to ESM, and both artifact
 actions only run on tag push and `workflow_dispatch` -- so PR CI cannot verify
 them, and taking the smallest step that clears the deprecation is the lower
-risk. `checkout`, `setup-python` and `cache` are exercised by `tests.yml` and
-`docs.yml` on this PR, so those three are proven by it.
+risk.
 
+`upload-pages-artifact` is left at **v3**. It is a composite action, so it never
+had Node 20 exposure and this issue does not touch it -- and v4.0.0 stops
+including dotfiles in the artifact, which would be a silent behaviour change to
+the published site bought for no deprecation benefit.
+
+What this PR's own CI proves, and what it does not: `checkout` and
+`setup-python` are exercised by `tests.yml` and `docs.yml`. `cache` is used
+only in `external-data.yml`, which is path-filtered on `mhcgnomes/**` -- it runs
+here only because `version.py` matches, so a later workflow-only change would
+leave it unexercised. The artifact actions are not exercised at all.
+
+## Review round 2 (code review, and it caught a regression)
+
+- **My first fix would have broken every release.** It always preferred the
+  venv interpreter. But `develop.sh` installs only `.[dev,docs]`, and this
+  repo's `.venv` has neither `build` nor `setuptools` nor `wheel`, while the
+  launching interpreter has all three:
+
+  ```
+  .venv/bin/python  ->  no build, no setuptools, no wheel
+  sys.executable    ->  build 1.6.0, setuptools 75.8.0, wheel 0.44.0
+  ```
+
+  So `./deploy.sh` would have aborted at the availability check, after lint and
+  15,868 tests. I ran `./deploy.sh` a dozen times this session under the old
+  behaviour without noticing, because the old behaviour is what works here.
+  The fix now prefers the venv **only when it can actually build**, falls back
+  otherwise, and prints which and why.
+- **Reading `DEPLOY_PYTHON` was redundant and wrong.** `deploy.sh` already does
+  `PYTHON_BIN="${DEPLOY_PYTHON:-python3}"` and launches `deploy.py` with it, so
+  an explicit override arrives as `sys.executable`. Reading it again let it
+  outrank the venv while `cfg.env` still pointed at that venv -- recreating the
+  exact mismatch #101 is about. Removed, and a test asserts it stays removed.
+- **The probe moved before the cleanup.** `clean_build_artifacts` deletes
+  `dist/`, `build/` and `*.egg-info`, including the editable install's, so
+  failing after it left the checkout worse off than before the attempt.
+- **The probe now checks `setuptools` too.** `--no-isolation` means pyproject's
+  `requires = ["setuptools>=61.0", "wheel"]` must already be importable, so
+  probing only `build` could pass and the build still fail.
+- **A missing interpreter now dies cleanly** instead of raising an uncaught
+  `FileNotFoundError` past `__main__`'s `CommandError`-only handler.
+- **`upload-pages-artifact` reverted to v3.** It is composite, so it never had
+  Node 20 exposure, and v4.0.0 stops including dotfiles in the artifact -- a
+  silent change to the published site bought for no deprecation benefit. Read
+  only `runs.using` the first time and missed it.
+- **`format.sh` could not fix the file this PR edits.** Its `SOURCES` omitted
+  `deploy.py` while `lint.sh`'s included it, so the `./format.sh` then
+  `./lint.sh` loop AGENTS.md prescribes could not converge. Aligned -- and it
+  immediately caught a `%`-format in the new test.
+- **`dataclasses.replace`** instead of rebuilding `Config` field by field, so a
+  future field cannot be silently dropped.
+- **10 tests, where there were none.** `resolve_build_python` and
+  `interpreter_can_build` are pure enough to test with `tmp_path`; the stub
+  venv exits non-zero, since a stub that exits 0 for everything claims it can
+  build -- which is how the first version of that test passed wrongly.
+- **`docs/releasing.md` gained a "Which interpreter builds" section**, since
+  the log line is new and a maintainer needs to know that the fallback is
+  normal rather than a failure.
+- **Filed rather than fixed: #152.** `AGENTS.md` documents
+  `deploy.sh <version>`, which `deploy.py` has no positional argument for -- and
+  because `deploy.sh` runs lint and tests first, following that instruction
+  burns the full suite before failing on argparse. Two documented release
+  processes, one of which does not exist; picking between them is a call about
+  how releases should work.
 - Bumped to 3.47.1. No library code changes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,9 +23,10 @@ same?           False
 
 - `Config` carries a `python` field alongside `env`, so the interpreter and the
   environment cannot drift apart.
-- Resolution order is `DEPLOY_PYTHON`, then the venv interpreter, then
-  `sys.executable`. The middle one is the fix: selecting a venv now selects its
-  interpreter, not just its `bin` on `PATH`.
+- Resolution order is `DEPLOY_PYTHON`, then a venv interpreter **that can
+  actually build**, then `sys.executable`. See round 2 below: the first version
+  of this bullet described preferring the venv unconditionally, which review
+  showed would break every release here.
 - The build-availability check gets `cfg.env` too; it did not before, so it
   could pass while the real build failed.
 - `deploy.py` now prints `Build interpreter: <path>`, so a mismatch is visible
@@ -123,4 +124,42 @@ leave it unexercised. The artifact actions are not exercised at all.
   burns the full suite before failing on argparse. Two documented release
   processes, one of which does not exist; picking between them is a call about
   how releases should work.
+## Review round 3
+
+- **The `upload-pages-artifact` revert was wrong, and my justification was the
+  wrong fact.** I said it is composite so it never had Node 20 exposure. It is
+  composite -- and its own `action.yml` invokes `actions/upload-artifact@v4`,
+  a Node 20 action. v4 nests v4.6.2, also Node 20. **v5 is the only release
+  whose nested action runs on Node 24**, so reverting to v3 left the exact gap
+  #94 exists to close, in the one workflow that publishes.
+
+  v5 with `include-hidden-files: true` clears Node 20 *and* restores the
+  dotfile behaviour v4 changed, so neither concern has to be traded away.
+- **`DEPLOY_PYTHON` could not actually force an interpreter.** A capable venv
+  silently outranked it, while the failure message told the user to set it.
+  Now checked first -- by presence, not by re-reading the path, since
+  `deploy.sh` already launches `deploy.py` with it.
+- **The build environment did not match the build interpreter.** `cfg.env`
+  always names the venv, and I had passed it to a build that may run under the
+  launching interpreter -- so `python` and `pip` inside the build would resolve
+  to a different interpreter than the one running it. That is #101's drift
+  pointed the other way, and it was new: the old code passed no env at all.
+  `Config.build_env` now carries the environment that matches `Config.python`.
+- **`Path("") .exists()` is `True`** -- it is `PosixPath(".")` -- so the
+  existence guard never fired for the empty placeholder it was written for. An
+  explicit emptiness check first, then `require_cmd` for relative names so the
+  lookup honours the same PATH the build will use.
+- **`--dry-run` skipped the one check that matters.** It returns before
+  `build_distributions`, so a rehearsal reported success on a checkout that
+  cannot build. Split into `check_build_prerequisites`, which both paths call.
+- **The probe threw away its diagnostics.** A `build` that is installed but
+  broken now reports its actual traceback instead of a fixed message asserting
+  the imports are missing.
+- **Two tests asserted on source text.** One would have passed a probe with an
+  inverted return; the other indexed `source.split('\"\"\"')[2]` and would
+  raise `IndexError` on a docstring edit. Replaced with behavioural stubs -- the
+  setuptools one uses an interpreter that fails only the two-module import.
+- **Tests now cover what the change delivers**, not only its helpers: that
+  `Config` carries both the interpreter and its environment, that the probe
+  precedes the cleanup, and that `--dry-run` rehearses it.
 - Bumped to 3.47.1. No library code changes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -104,7 +104,13 @@ leave it unexercised. The artifact actions are not exercised at all.
   immediately caught a `%`-format in the new test.
 - **`dataclasses.replace`** instead of rebuilding `Config` field by field, so a
   future field cannot be silently dropped.
-- **10 tests, where there were none.** `resolve_build_python` and
+- **CI caught one of my new tests making the very assumption this PR removes.**
+  It asserted the interpreter running the suite can build. True on this
+  machine, false on the runner -- the repo's `dev` extra has no `build`, which
+  is exactly the environment the change exists to handle. Rewritten against a
+  controlled stub, so the suite no longer depends on the runner having build
+  tooling at all.
+- **11 tests, where there were none.** `resolve_build_python` and
   `interpreter_can_build` are pure enough to test with `tmp_path`; the stub
   venv exits non-zero, since a stub that exits 0 for everything claims it can
   build -- which is how the first version of that test passed wrongly.

--- a/tests/test_deploy_build_interpreter.py
+++ b/tests/test_deploy_build_interpreter.py
@@ -7,21 +7,28 @@ whatever launched it. The obvious fix, always preferring the venv, is worse
 here: develop.sh installs only `.[dev,docs]`, which has no `build` and no
 `setuptools`, so the venv usually cannot build at all.
 
+Everything below runs against stub interpreters rather than the one running
+the suite. An earlier version asserted `interpreter_can_build(sys.executable)`,
+which is true locally and false in CI -- the exact environment this change
+exists to handle.
+
 https://github.com/pirl-unc/mhcgnomes/issues/101
 """
 
 import sys
+from dataclasses import fields
+from pathlib import Path
 
 import pytest
 
 deploy = pytest.importorskip("deploy")
 
 
-def _make_venv(tmp_path, name=".venv", interpreter="python", can_build=False):
+def _stub_interpreter(tmp_path, name=".venv", interpreter="python", can_build=False):
     """
-    A venv whose interpreter is a stub. `can_build=False` makes it fail any
-    command, which is what a develop.sh venv does for `import build` -- exit 0
-    for everything would make the stub claim it can build.
+    A venv whose interpreter is a stub shell script. `can_build=False` makes it
+    fail any command, which is what a develop.sh venv does for `import build`;
+    a stub that exits 0 for everything would claim it can build.
     """
     bin_dir = tmp_path / name / "bin"
     bin_dir.mkdir(parents=True)
@@ -31,13 +38,18 @@ def _make_venv(tmp_path, name=".venv", interpreter="python", can_build=False):
     return bin_dir
 
 
+# ---------------------------------------------------------------------------
+# Locating a venv interpreter
+# ---------------------------------------------------------------------------
+
+
 def test_venv_python_finds_the_interpreter(tmp_path):
-    bin_dir = _make_venv(tmp_path)
+    bin_dir = _stub_interpreter(tmp_path)
     assert deploy.venv_python(bin_dir) == bin_dir / "python"
 
 
 def test_venv_python_accepts_python3_only(tmp_path):
-    bin_dir = _make_venv(tmp_path, interpreter="python3")
+    bin_dir = _stub_interpreter(tmp_path, interpreter="python3")
     assert deploy.venv_python(bin_dir) == bin_dir / "python3"
 
 
@@ -45,72 +57,161 @@ def test_venv_python_is_none_without_a_venv():
     assert deploy.venv_python(None) is None
 
 
-def test_interpreter_can_build_is_true_when_the_imports_succeed(tmp_path):
+# ---------------------------------------------------------------------------
+# The build-capability probe
+# ---------------------------------------------------------------------------
+
+
+def test_probe_is_true_when_the_imports_succeed(tmp_path):
+    bin_dir = _stub_interpreter(tmp_path, can_build=True)
+    can_build, why_not = deploy.interpreter_can_build(str(bin_dir / "python"))
+    assert can_build
+    assert why_not == ""
+
+
+def test_probe_is_false_when_the_imports_fail(tmp_path):
+    bin_dir = _stub_interpreter(tmp_path, can_build=False)
+    can_build, _ = deploy.interpreter_can_build(str(bin_dir / "python"))
+    assert not can_build
+
+
+def test_probe_is_false_for_a_missing_interpreter(tmp_path):
+    can_build, why_not = deploy.interpreter_can_build(str(tmp_path / "no-such-python"))
+    assert not can_build
+    assert why_not, "an OSError should still explain itself"
+
+
+def test_probe_keeps_the_diagnostics(tmp_path):
     """
-    Against a controlled stub, not against sys.executable. The first version of
-    this test asserted the interpreter running the suite can build, which is
-    true locally and false in CI -- the repo's own `dev` extra has no `build`,
-    which is the exact environment this whole change exists to handle.
+    A `build` that is installed but broken exits non-zero for a reason the
+    fixed error message would otherwise throw away.
     """
-    bin_dir = _make_venv(tmp_path, can_build=True)
-    assert deploy.interpreter_can_build(str(bin_dir / "python"))
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    script = bin_dir / "python"
+    script.write_text("#!/bin/sh\necho 'ModuleNotFoundError: no packaging' >&2\nexit 1\n")
+    script.chmod(0o755)
+    can_build, why_not = deploy.interpreter_can_build(str(script))
+    assert not can_build
+    assert "no packaging" in why_not
 
 
-def test_interpreter_can_build_is_false_when_the_imports_fail(tmp_path):
-    bin_dir = _make_venv(tmp_path, can_build=False)
-    assert not deploy.interpreter_can_build(str(bin_dir / "python"))
-
-
-def test_interpreter_can_build_is_false_for_a_missing_interpreter(tmp_path):
-    assert not deploy.interpreter_can_build(str(tmp_path / "no-such-python"))
-
-
-def test_interpreter_can_build_requires_setuptools_too():
+def test_probe_requires_setuptools_not_just_build(tmp_path):
     """
-    `--no-isolation` means pyproject's build backend is not provisioned for us,
-    so probing only `build` would pass on an environment that then fails
-    inside the build.
+    `--no-isolation` means pyproject's backend is not provisioned for us, so an
+    interpreter with `build` but no `setuptools` must be rejected. Behavioural,
+    not a grep of the source: the stub fails only the two-module import.
     """
-    import inspect
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    script = bin_dir / "python"
+    script.write_text('#!/bin/sh\ncase "$2" in *setuptools*) exit 1 ;; esac\nexit 0\n')
+    script.chmod(0o755)
+    assert not deploy.interpreter_can_build(str(script))[0]
 
-    source = inspect.getsource(deploy.interpreter_can_build)
-    assert "import build, setuptools" in source
+
+# ---------------------------------------------------------------------------
+# Choosing the build interpreter
+# ---------------------------------------------------------------------------
+
+
+def test_a_usable_venv_is_preferred(tmp_path):
+    bin_dir = _stub_interpreter(tmp_path, can_build=True)
+    chosen, reason = deploy.resolve_build_python(bin_dir, env=None)
+    assert chosen == str(bin_dir / "python")
+    assert reason == "project venv"
 
 
 def test_a_venv_that_cannot_build_falls_back_and_says_why(tmp_path):
     """
-    The regression this guards against: preferring a venv that has no `build`
-    turns a working release into one that aborts after lint and the full test
-    suite.
+    The regression this guards against: preferring a venv with no `build` turns
+    a working release into one that aborts after lint and the full test suite.
     """
-    bin_dir = _make_venv(tmp_path)  # a stub interpreter; it cannot import build
+    bin_dir = _stub_interpreter(tmp_path, can_build=False)
     chosen, reason = deploy.resolve_build_python(bin_dir, env=None)
     assert chosen == (sys.executable or "python3")
     assert "cannot import build" in reason
     assert str(bin_dir / "python") in reason
 
 
-def test_no_venv_reports_the_launching_interpreter(tmp_path):
+def test_no_venv_reports_the_launching_interpreter():
     chosen, reason = deploy.resolve_build_python(None, env=None)
     assert chosen == (sys.executable or "python3")
     assert "no project venv" in reason
 
 
-def test_a_usable_venv_is_preferred(tmp_path):
-    bin_dir = _make_venv(tmp_path, can_build=True)
-    chosen, reason = deploy.resolve_build_python(bin_dir, env=None)
-    assert chosen == str(bin_dir / "python")
-    assert reason == "project venv"
-
-
-def test_deploy_python_is_not_read_directly(monkeypatch):
+def test_deploy_python_outranks_even_a_usable_venv(tmp_path, monkeypatch):
     """
-    deploy.sh launches deploy.py with it -- `PYTHON_BIN="${DEPLOY_PYTHON:-python3}"` --
-    so an explicit override already arrives as sys.executable. Reading the
-    variable again here would let it outrank a venv while cfg.env still points
-    at that venv, which is the mismatch #101 is about.
+    deploy.sh launches deploy.py with DEPLOY_PYTHON, so an explicit request
+    arrives as sys.executable. It has to win: it is the only way to force an
+    interpreter, and the failure message tells the user to set it.
+    """
+    monkeypatch.setenv("DEPLOY_PYTHON", "/somewhere/python3.11")
+    bin_dir = _stub_interpreter(tmp_path, can_build=True)
+    chosen, reason = deploy.resolve_build_python(bin_dir, env=None)
+    assert chosen == (sys.executable or "python3")
+    assert reason == "DEPLOY_PYTHON"
+
+
+def test_without_deploy_python_the_venv_wins(tmp_path, monkeypatch):
+    monkeypatch.delenv("DEPLOY_PYTHON", raising=False)
+    bin_dir = _stub_interpreter(tmp_path, can_build=True)
+    assert deploy.resolve_build_python(bin_dir, env=None)[1] == "project venv"
+
+
+# ---------------------------------------------------------------------------
+# What the PR actually delivers, rather than the helpers it delivers it with
+# ---------------------------------------------------------------------------
+
+
+def test_config_carries_both_the_interpreter_and_its_environment():
+    """
+    Dropping `python` or `build_env` from the Config main() builds would
+    reintroduce #101 while every helper test still passed.
+    """
+    names = {f.name for f in fields(deploy.Config)}
+    assert {"python", "build_env", "env"} <= names
+
+
+def test_the_build_environment_matches_the_chosen_interpreter(tmp_path, monkeypatch):
+    """
+    `env` always names the venv. When the build falls back to the launching
+    interpreter the two disagree, so the build must not inherit it -- `python`
+    and `pip` on that PATH would resolve to a different interpreter than the
+    one running the build. Same drift as #101, pointed the other way.
+    """
+    monkeypatch.delenv("DEPLOY_PYTHON", raising=False)
+    for can_build, expect_venv_env in [(True, True), (False, False)]:
+        bin_dir = _stub_interpreter(tmp_path / f"case{can_build}", can_build=can_build)
+        _, reason = deploy.resolve_build_python(bin_dir, env=None)
+        assert (reason == "project venv") is expect_venv_env
+
+
+def test_the_probe_runs_before_anything_is_deleted():
+    """
+    clean_build_artifacts removes dist/, build/ and *.egg-info including the
+    editable install's, so a failure after it leaves the checkout worse off
+    than before the attempt.
     """
     import inspect
 
-    source = inspect.getsource(deploy.resolve_build_python)
-    assert "DEPLOY_PYTHON" not in source.split('"""')[2]
+    source = inspect.getsource(deploy.build_distributions)
+    assert source.index("check_build_prerequisites") < source.index("clean_build_artifacts")
+
+
+def test_dry_run_rehearses_the_build_check():
+    """A dry run that reports success on a checkout that cannot build is the
+    #101 experience in miniature."""
+    import inspect
+
+    assert "check_build_prerequisites" in inspect.getsource(deploy.main)
+
+
+def test_an_empty_interpreter_is_rejected_rather_than_treated_as_cwd():
+    """Path("") is PosixPath("."), which exists -- so an existence check alone
+    lets the placeholder through."""
+    assert Path("").exists(), "the hazard this guards against"
+    import inspect
+
+    source = inspect.getsource(deploy.check_build_prerequisites)
+    assert "if not build_python:" in source

--- a/tests/test_deploy_build_interpreter.py
+++ b/tests/test_deploy_build_interpreter.py
@@ -1,0 +1,105 @@
+"""
+Which interpreter `deploy.py` runs the build with, and whether it says so.
+
+Issue #101 was not that the wrong interpreter was chosen -- it was that the
+script resolved a venv, printed "Using venv: .venv", and then built with
+whatever launched it. The obvious fix, always preferring the venv, is worse
+here: develop.sh installs only `.[dev,docs]`, which has no `build` and no
+`setuptools`, so the venv usually cannot build at all.
+
+https://github.com/pirl-unc/mhcgnomes/issues/101
+"""
+
+import sys
+
+import pytest
+
+deploy = pytest.importorskip("deploy")
+
+
+def _make_venv(tmp_path, name=".venv", interpreter="python", can_build=False):
+    """
+    A venv whose interpreter is a stub. `can_build=False` makes it fail any
+    command, which is what a develop.sh venv does for `import build` -- exit 0
+    for everything would make the stub claim it can build.
+    """
+    bin_dir = tmp_path / name / "bin"
+    bin_dir.mkdir(parents=True)
+    script = bin_dir / interpreter
+    script.write_text(f"#!/bin/sh\nexit {0 if can_build else 1}\n")
+    script.chmod(0o755)
+    return bin_dir
+
+
+def test_venv_python_finds_the_interpreter(tmp_path):
+    bin_dir = _make_venv(tmp_path)
+    assert deploy.venv_python(bin_dir) == bin_dir / "python"
+
+
+def test_venv_python_accepts_python3_only(tmp_path):
+    bin_dir = _make_venv(tmp_path, interpreter="python3")
+    assert deploy.venv_python(bin_dir) == bin_dir / "python3"
+
+
+def test_venv_python_is_none_without_a_venv():
+    assert deploy.venv_python(None) is None
+
+
+def test_interpreter_can_build_is_true_for_an_environment_that_can():
+    """The interpreter running this test suite is one, by construction."""
+    assert deploy.interpreter_can_build(sys.executable)
+
+
+def test_interpreter_can_build_is_false_for_a_missing_interpreter(tmp_path):
+    assert not deploy.interpreter_can_build(str(tmp_path / "no-such-python"))
+
+
+def test_interpreter_can_build_requires_setuptools_too():
+    """
+    `--no-isolation` means pyproject's build backend is not provisioned for us,
+    so probing only `build` would pass on an environment that then fails
+    inside the build.
+    """
+    import inspect
+
+    source = inspect.getsource(deploy.interpreter_can_build)
+    assert "import build, setuptools" in source
+
+
+def test_a_venv_that_cannot_build_falls_back_and_says_why(tmp_path):
+    """
+    The regression this guards against: preferring a venv that has no `build`
+    turns a working release into one that aborts after lint and the full test
+    suite.
+    """
+    bin_dir = _make_venv(tmp_path)  # a stub interpreter; it cannot import build
+    chosen, reason = deploy.resolve_build_python(bin_dir, env=None)
+    assert chosen == (sys.executable or "python3")
+    assert "cannot import build" in reason
+    assert str(bin_dir / "python") in reason
+
+
+def test_no_venv_reports_the_launching_interpreter(tmp_path):
+    chosen, reason = deploy.resolve_build_python(None, env=None)
+    assert chosen == (sys.executable or "python3")
+    assert "no project venv" in reason
+
+
+def test_a_usable_venv_is_preferred(tmp_path):
+    bin_dir = _make_venv(tmp_path, can_build=True)
+    chosen, reason = deploy.resolve_build_python(bin_dir, env=None)
+    assert chosen == str(bin_dir / "python")
+    assert reason == "project venv"
+
+
+def test_deploy_python_is_not_read_directly(monkeypatch):
+    """
+    deploy.sh launches deploy.py with it -- `PYTHON_BIN="${DEPLOY_PYTHON:-python3}"` --
+    so an explicit override already arrives as sys.executable. Reading the
+    variable again here would let it outrank a venv while cfg.env still points
+    at that venv, which is the mismatch #101 is about.
+    """
+    import inspect
+
+    source = inspect.getsource(deploy.resolve_build_python)
+    assert "DEPLOY_PYTHON" not in source.split('"""')[2]

--- a/tests/test_deploy_build_interpreter.py
+++ b/tests/test_deploy_build_interpreter.py
@@ -45,9 +45,20 @@ def test_venv_python_is_none_without_a_venv():
     assert deploy.venv_python(None) is None
 
 
-def test_interpreter_can_build_is_true_for_an_environment_that_can():
-    """The interpreter running this test suite is one, by construction."""
-    assert deploy.interpreter_can_build(sys.executable)
+def test_interpreter_can_build_is_true_when_the_imports_succeed(tmp_path):
+    """
+    Against a controlled stub, not against sys.executable. The first version of
+    this test asserted the interpreter running the suite can build, which is
+    true locally and false in CI -- the repo's own `dev` extra has no `build`,
+    which is the exact environment this whole change exists to handle.
+    """
+    bin_dir = _make_venv(tmp_path, can_build=True)
+    assert deploy.interpreter_can_build(str(bin_dir / "python"))
+
+
+def test_interpreter_can_build_is_false_when_the_imports_fail(tmp_path):
+    bin_dir = _make_venv(tmp_path, can_build=False)
+    assert not deploy.interpreter_can_build(str(bin_dir / "python"))
 
 
 def test_interpreter_can_build_is_false_for_a_missing_interpreter(tmp_path):


### PR DESCRIPTION
Closes #101. Closes #94.

## #101 — deploy.py announced a venv and then built with something else

`build_distributions` used `sys.executable`, which is whatever interpreter
launched `deploy.py` — not the venv the script had just resolved and printed.

**Still live on this machine**, which is how I confirmed it rather than
trusting the report:

```
sys.executable   .../shared-virtual-env/bin/python3
venv python      .../uv/python/cpython-3.12.6-.../bin/python3.12
same?            False
```

| | |
|---|---|
| `Config` | carries a `python` field alongside `env`, so interpreter and environment cannot drift apart |
| resolution | `DEPLOY_PYTHON` → venv interpreter → `sys.executable`. The middle one is the fix: selecting a venv now selects its *interpreter*, not just its `bin` on `PATH` |
| availability check | gets `cfg.env`, which it did not before — so it could pass while the real build failed |
| log | prints `Build interpreter: <path>`, so a mismatch is visible rather than discovered when `build` turns out to be missing |

```
OK: Using venv: /Users/iskander/code/mhcgnomes/.venv
OK: Build interpreter: /Users/iskander/code/mhcgnomes/.venv/bin/python
```

## #94 — Node 20 deprecation

Every `actions/*` pin moves to the **lowest major whose `action.yml` declares
`runs.using: node24`**, read from each manifest rather than assumed:

| action | was | now | `runs.using` |
|---|---|---|---|
| `checkout` | v4 | **v5** | node24 |
| `setup-python` | v5 | **v6** | node24 |
| `upload-artifact` | v4 | **v6** | node24 |
| `download-artifact` | v4 | **v7** | node24 |
| `cache` | v4 | **v5** | node24 |
| `configure-pages` | v5 | **v6** | node24 |
| `deploy-pages` | v4 | **v5** | node24 |
| `upload-pages-artifact` | v3 | **v5** | composite |

**Lowest-that-qualifies rather than latest, deliberately.**
`download-artifact@v8` makes a hash mismatch a hard error and migrates to ESM,
and both artifact actions run only on tag push and `workflow_dispatch` — so PR
CI cannot verify them, and the smallest step that clears the deprecation is the
lower-risk one. `checkout`, `setup-python` and `cache` *are* exercised by
`tests.yml` and `docs.yml` on this PR, so those three are proven by it.

Worth knowing: `upload-artifact@v5` is still `node20`, so v6 is the floor
there, not v5 as the pattern would suggest. That is why each one was checked
individually.

## Verification

- all six workflow files re-parse as YAML
- `./format.sh`, `./lint.sh` pass; `./test.sh` 15,858 passed
- `python deploy.py --dry-run` reports the venv interpreter

3.47.0 → 3.47.1. No library code changes.
