### PR TITLE
Import the evidenced prefix aliases

### DIFF
--- a/mhcgnomes/data.py
+++ b/mhcgnomes/data.py
@@ -42,6 +42,15 @@ def load(yaml_filename, normalize_first_level_keys=False, normalize_second_level
 # dictionary mapping scientific name -> info dictionary
 species = load("species.yaml")
 
+# species -> [{alias, status, evidence}], attested prefix spellings imported
+# from the mhcseqs registry. Kept out of species.yaml because provenance here
+# is per (species, alias) rather than per species. See issue #136.
+evidenced_prefix_aliases = load("evidenced_prefix_aliases.yaml")
+
+# Curation holding area: source signal not yet stable enough for runtime. Read
+# so the evidenced-alias import cannot override a deliberate holdback (#136).
+underrepresented_taxa_source_registry = load("underrepresented_taxa_source_registry.yaml")
+
 # Dictionary mapping each species prefix to a dictionary from old gene
 # names to new ones
 gene_aliases = load(

--- a/mhcgnomes/data/evidenced_prefix_aliases.yaml
+++ b/mhcgnomes/data/evidenced_prefix_aliases.yaml
@@ -1,0 +1,977 @@
+# Species prefix spellings attested in an external database or in the
+# literature, imported from the sibling mhcseqs registry
+# (mhcseqs/mhc_prefix_aliases.csv, rows whose status is external_database,
+# literature_historical or formal_system). Issue #136.
+#
+# Every row carries its own evidence URL, which is the point: provenance lives
+# at the (species, alias) level, because one species can have current,
+# historical and database spellings from different sources.
+#
+# Whether an alias becomes globally parseable or context-only is NOT recorded
+# here -- it is computed at load time from how many species claim it, so the
+# answer cannot go stale as species are added:
+#
+#   claimed by one species, and unclaimed elsewhere  -> global alias
+#   claimed by more than one, or by another taxon    -> context only
+#
+# Context-only means `species=` recovers the published record while a bare
+# prefix cannot silently pick a side, which is what the Moal and Orla cases
+# already do.
+#
+# Not included: rows whose species is absent from species.yaml, genus-scope
+# rows, and IPD designations (those live in ipd_designations.yaml).
+
+
+Abramis brama:
+  - alias: Arbr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A8E5GKZ6
+
+Acipenser sinensis:
+  - alias: Acsi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E0X5M3
+
+Acrocephalus arundinaceus:
+  - alias: Acaru
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q7YP77
+
+Acrocephalus scirpaceus:
+  - alias: Acsci
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MYP1
+
+Aegypius monachus:
+  - alias: Aemo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDM7
+
+Agalychnis callidryas:
+  - alias: Agca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I6PNB5
+
+Alauda razae:
+  - alias: Alra
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A6M6C8U2
+
+Ambystoma mexicanum:
+  - alias: Anme
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A5JVU8
+
+Amphilophus citrinellus:
+  - alias: Amci
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1S6K7L2
+
+Anser indicus:
+  - alias: Anin
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E8Z790
+
+Anthropoides paradiseus:
+  - alias: Grpa
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UVN5
+
+Anthropoides virgo:
+  - alias: Grvir
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0N7KC06
+
+Antigone canadensis:
+  - alias: Grcan
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UW56
+
+Antigone vipio:
+  - alias: Grvip
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0N7KC05
+
+Archoplites interruptus:
+  - alias: Arin
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5LT76
+
+Ardea alba:
+  - alias: Aral
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J696
+
+Ardeola bacchus:
+  - alias: Arba
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J694
+
+Arvicola amphibius:
+  - alias: Arte
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/17956550/
+
+Astur gentilis:
+  - alias: Acge
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDM6
+
+Balearica pavonina:
+  - alias: Bapa
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UVQ5
+
+Brachyramphus marmoratus:
+  - alias: Brma
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/N0A1U8
+
+Bubo blakistoni:
+  - alias: Bubl
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A223ZXQ0
+
+Bubo bubo:
+  - alias: Bubbu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDQ3
+  - alias: Bubu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B3F8U8
+
+Bucanetes githagineus:
+  - alias: Bugi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2E2S2
+
+Bugeranus carunculatus:
+  - alias: Buca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A6B9UJ47
+  - alias: Grcar
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0N7KC07
+
+Buteo buteo:
+  - alias: Buteo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDM9
+
+Cachryx defensor:
+  - alias: Ctde
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5LN06
+
+Calidris canutus:
+  - alias: Caca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/L0H763
+
+Carassius gibelio:
+  - alias: Cagi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/X5J5T9
+
+Carassius langsdorfii:
+  - alias: caau
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/F8WRI6
+
+Carduelis carduelis:
+  - alias: Caca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A126AC28
+
+Carollia perspicillata:
+  - alias: Cape
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/H9U5N9
+
+Cavia porcellus:
+  - alias: GPL-A
+    status: literature_historical
+    evidence: https://pmc.ncbi.nlm.nih.gov/articles/PMC2190138/
+  - alias: GPLA
+    status: literature_historical
+    evidence: https://pmc.ncbi.nlm.nih.gov/articles/PMC2190138/
+
+Chersophilus duponti:
+  - alias: Chdu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2E2S7
+
+Chiloscyllium plagiosum:
+  - alias: Chpl
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I6ZPI8
+
+Chondrostoma nasus:
+  - alias: Chna
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/S6DEV0
+
+Circaetus gallicus:
+  - alias: Ciga
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN0
+
+Clarias gariepinus:
+  - alias: Clga
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/C1IQ54
+
+Clarias magur:
+  - alias: Cyca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A8J4TGY8
+  - alias: Icpu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A8J4TR97
+
+Conolophus subcristatus:
+  - alias: Cosu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B3UZY9
+
+Coronella austriaca:
+  - alias: Coau
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A161HPN2
+
+Corvus corax:
+  - alias: Coco
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2E2T0
+
+Cryptomys hottentotus:
+  - alias: BLA
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/15058438/
+
+Ctenomys boliviensis:
+  - alias: Ctbol
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/18049818/
+
+Ctenomys bonettoi:
+  - alias: Ctbon
+    status: external_database
+    evidence: https://rest.uniprot.org/unisave/Q95HT8?format=txt&versions=61
+
+Ctenomys talarum:
+  - alias: Cta
+    status: external_database
+    evidence: https://rest.uniprot.org/unisave/Q0H0P1?format=txt&versions=46
+
+Ctenopharyngodon idella:
+  - alias: Citd
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B2X123
+
+Ctenophorus decresii:
+  - alias: Ctde
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A2P1A4H2
+
+Ctenosaura clarki:
+  - alias: Ctcl
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5LN07
+
+Cyanistes caeruleus:
+  - alias: Cyca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZR1
+  - alias: paca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q2A642
+
+Cyclura carinata:
+  - alias: Cyca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5LN10
+
+Cyclura cornuta:
+  - alias: Cyco
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5LN09
+
+Cyclura rileyi:
+  - alias: Cyri
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5LN08
+
+Desmodus rotundus:
+  - alias: Dero
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1I9VYB6
+
+Egernia stokesii:
+  - alias: Egst
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0K0N3L9
+
+Egretta eulophotes:
+  - alias: Egue
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J6C6
+
+Elanus caeruleus:
+  - alias: Elca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN2
+
+Emberiza cioides:
+  - alias: Emci
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1D7YVK5
+
+Emberiza jankowskii:
+  - alias: Emja
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1D7YVM6
+
+Epidalea calamita:
+  - alias: Buca
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0D4D8C3
+
+Epinephelus akaara:
+  - alias: Epak
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B2CC08
+
+Erithacus rubecula:
+  - alias: Erru
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2E2T3
+
+Espadarana prosoblepon:
+  - alias: Espr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I6PNC2
+
+Eurillas virens:
+  - alias: Anvi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q30E80
+
+Falco biarmicus:
+  - alias: Fabi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDR2
+
+Falco cherrug:
+  - alias: Fach
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR13
+
+Falco columbarius:
+  - alias: Facol
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR11
+
+Falco concolor:
+  - alias: Facon
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR08
+
+Falco eleonorae:
+  - alias: Fael
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR05
+
+Falco fasciinucha:
+  - alias: Fafa
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR12
+
+Falco femoralis:
+  - alias: Fafe
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDR1
+
+Falco naumanni:
+  - alias: Fana
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDQ9
+
+Falco rusticolus:
+  - alias: Faru
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR10
+
+Falco subbuteo:
+  - alias: Fasu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I3ZR09
+
+Fringilla coelebs:
+  - alias: Frcoe
+    status: external_database
+    evidence: https://www.ncbi.nlm.nih.gov/nuccore/DQ257477
+
+Fukomys damarensis:
+  - alias: BLA
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/15058438/
+
+Gadus morhua:
+  - alias: gamr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/O98272
+
+Gallus gallus:
+  - alias: B
+    status: literature_historical
+    evidence: https://pubmed.ncbi.nlm.nih.gov/6763913/
+  - alias: GSP
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q6I6J9
+
+Gobio gobio:
+  - alias: Gogo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0U3QRX5
+
+Gorsachius magnificus:
+  - alias: Goma
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J698
+
+Grus grus:
+  - alias: Grgr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0N7KC08
+
+Grus monacha:
+  - alias: Grmo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UVS1
+
+Grus nigricollis:
+  - alias: Grni
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UVP3
+
+Gypaetus barbatus:
+  - alias: Gypa
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN3
+
+Gyps africanus:
+  - alias: Gyaf
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN9
+
+Gyps coprotheres:
+  - alias: Gyco
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDP8
+
+Haliaeetus albicilla:
+  - alias: Haal
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A3Q8TLJ6
+
+Harpyhaliaetus coronatus:
+  - alias: Haco
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN4
+
+Heliophobius argenteocinereus:
+  - alias: BLA
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/15058438/
+
+Heterocephalus glaber:
+  - alias: BLA
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/15058438/
+
+Hieraaetus pennatus:
+  - alias: Hipe
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN5
+
+Hippocampus erectus:
+  - alias: Hier
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1B3IPW4
+
+Hippolais icterina:
+  - alias: Hiic
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MYW4
+
+Hypophthalmichthys molitrix:
+  - alias: Hymo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A193PJZ3
+
+Ichthyosaura alpestris:
+  - alias: Meal
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B1PXH2
+
+Iconisemion striatum:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A7XA08
+
+Ixobrychus cinnamomeus:
+  - alias: Ixci
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J649
+
+Ixobrychus flavicollis:
+  - alias: Ixfl
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J6A0
+
+Labeobarbus intermedius:
+  - alias: baic
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q5K4Z4
+  - alias: batr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q5K530
+  - alias: bats
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q5K529
+
+Ladigesocypris ghigii:
+  - alias: Lagh
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E3U3B4
+
+Lagopus scotica:
+  - alias: Lala
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A159AJS9
+
+Lanius collaris:
+  - alias: Laco
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZT4
+
+Lanius senator:
+  - alias: Lase
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2E2T4
+
+Larimichthys crocea:
+  - alias: Pscr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B1NNU4
+
+Leiocassis longirostris:
+  - alias: Lelo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/D5FL40
+
+Leucogeranus leucogeranus:
+  - alias: Grle
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0N7KC04
+
+Lithobates yavapaiensis:
+  - alias: Liya
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I6PND1
+
+Litoria verreauxii:
+  - alias: Livea
+    status: literature_historical
+    evidence: https://pmc.ncbi.nlm.nih.gov/articles/PMC4389617/
+
+Luscinia svecica:
+  - alias: Lusv
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZR9
+
+Lyrurus tetrix:
+  - alias: Tete
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/X2JFU1
+
+Melospiza melodia:
+  - alias: Sosp
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A4P8DLY1
+
+Miichthys miiuy:
+  - alias: Mimi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/D6PAH3
+
+Milvus milvus:
+  - alias: Mimil
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN6
+
+Molossus molossus:
+  - alias: Momo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1I9VYE6
+
+Monopterus albus:
+  - alias: Moal
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/V9PDN1
+
+Motacilla alba:
+  - alias: Moal
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2E2T7
+
+Mus caroli:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Mus cervicolor:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Mus cookii:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Mus macedonicus:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Mus platythrix:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Mus spicilegus:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Mus spretus:
+  - alias: H2
+    status: external_database
+    evidence: https://pubmed.ncbi.nlm.nih.gov/9178014/
+
+Myotis vivesi:
+  - alias: Myvi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/D6QSQ7
+
+Nanorana parkeri:
+  - alias: Napa
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A172LRJ1
+
+Neophron percnopterus:
+  - alias: Nepe
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN7
+
+Noctilio albiventris:
+  - alias: Noal
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E9KZI7
+
+Noctilio leporinus:
+  - alias: Nole
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/H9U5P8
+
+Nothobranchius furzeri:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A8V2B0
+
+Nothobranchius kadleci:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A8CNF3
+
+Nothobranchius korthausae:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A8F4C0
+
+Nothobranchius kuhntae:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A8HZD6
+
+Nothobranchius pienaari:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A8MQH5
+
+Nothobranchius rachovii:
+  - alias: ORLA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1A8SDN4
+
+Nycticorax nycticorax:
+  - alias: Nyny
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E2J6B3
+
+Odorrana margaretae:
+  - alias: Odma
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A4D5YGT3
+
+Oncorhynchus gilae:
+  - alias: Ongi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A5YVA9
+
+Oncorhynchus kisutch:
+  - alias: Onki
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q9GJB5
+
+Oncorhynchus nerka:
+  - alias: Onne
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A089WYW5
+
+Oncorhynchus tshawytscha:
+  - alias: Onts
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q9GJB6
+
+Oryzias latipes:
+  - alias: Orla
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/F5HRI2
+
+Otis tarda:
+  - alias: Otta
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UW16
+
+Otus elegans:
+  - alias: Otel
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A2Z5WB25
+
+Pachyptila belcheri:
+  - alias: Pabe
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/C1JEH9
+
+Pandion haliaetus:
+  - alias: Paha
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A9LDN8
+
+Passer hispaniolensis:
+  - alias: Pahi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZY6
+
+Passer montanus:
+  - alias: Pamo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZT7
+
+Pelophylax nigromaculatus:
+  - alias: Peni
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A2H4PSK8
+
+Perdix perdix:
+  - alias: Pepe
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1S6Q3S2
+
+Phylloscopus collybita:
+  - alias: Phco
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZ16
+
+Phylloscopus trochilus:
+  - alias: Phtr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MZB9
+
+Poecilia reticulata:
+  - alias: Pore
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/O77958
+
+Polyodon spathula:
+  - alias: Posp
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E0X5L7
+
+Polypedates megacephalus:
+  - alias: Pome
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/R9UQ24
+
+Psophia crepitans:
+  - alias: Pscr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0P0UVS2
+
+Rana japonica:
+  - alias: RAJA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1S5RAP3
+
+Rana ornativentris:
+  - alias: RAJA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1S5RAU7
+
+Rana tagoi:
+  - alias: RAJA
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A1S5RAW9
+
+Rattus norvegicus:
+  - alias: Ag-B
+    status: literature_historical
+    evidence: https://doi.org/10.1016/S0026-0495(83)80010-9
+  - alias: AgB
+    status: literature_historical
+    evidence: https://doi.org/10.1016/S0026-0495(83)80010-9
+  - alias: H-1
+    status: literature_historical
+    evidence: https://doi.org/10.1016/S0026-0495(83)80010-9
+  - alias: R-1
+    status: literature_historical
+    evidence: https://doi.org/10.1016/S0026-0495(83)80010-9
+  - alias: RtH-1
+    status: literature_historical
+    evidence: https://doi.org/10.1016/S0026-0495(83)80010-9
+
+Rhodeus ocellatus:
+  - alias: Rhoc
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/D2XBF1
+
+Saccopteryx bilineata:
+  - alias: Sabi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/H9U5R0
+
+Salvelinus fontinalis:
+  - alias: Safo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B3FW09
+
+Salvelinus malma:
+  - alias: Sama
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/E1U2E0
+
+Smilisca phaeota:
+  - alias: Smph
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/I6PND3
+
+Spinus atratus:
+  - alias: Caat
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A384M0D1
+
+Spinus pinus:
+  - alias: Capi
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A139YCS1
+
+Spinus spinus:
+  - alias: Casp
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A139YCS2
+
+Sylvia borin:
+  - alias: Sybo
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0S2MYY4
+
+Tachyglossus aculeatus:
+  - alias: Taac
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q6WGJ3
+
+Tiliqua adelaidensis:
+  - alias: Tiad
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0K0N2V0
+
+Tiliqua rugosa:
+  - alias: Tiru
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A0K0N390
+
+Trachinotus ovatus:
+  - alias: TO
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A3G1LCB1
+
+Trichosurus vulpecula:
+  - alias: Truv
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/Q95IT0
+
+Triturus cristatus:
+  - alias: Trcr
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B8XWH4
+
+Turdus atrogularis:
+  - alias: Tuat
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A6B9MDW2
+
+Turdus naumanni:
+  - alias: Tuna
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A6B9MIG4
+
+Turdus ruficollis:
+  - alias: Turu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/A0A6B9MDV5
+
+Xenopus laevis:
+  - alias: XL-A
+    status: literature_historical
+    evidence: https://pubmed.ncbi.nlm.nih.gov/2653371/
+  - alias: XLA
+    status: literature_historical
+    evidence: https://pubmed.ncbi.nlm.nih.gov/2653371/
+
+Xiphophorus hellerii:
+  - alias: Xihe
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/O62885
+
+Xiphophorus maculatus:
+  - alias: Xima
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/O62884
+
+Xiphophorus multilineatus:
+  - alias: Ximu
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5AIX3
+
+Xiphophorus pygmaeus:
+  - alias: Xipy
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/B5AIY7
+
+Zhangixalus omeimontis:
+  - alias: Rhom
+    status: external_database
+    evidence: https://rest.uniprot.org/uniprotkb/R9UQ42

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -17,8 +17,9 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Union
 
-from .common import cache
+from .common import cache, normalize_string
 from .data import allele_aliases as raw_allele_aliases_dict
+from .data import evidenced_prefix_aliases as raw_evidenced_alias_dict
 from .data import gene_aliases as raw_gene_aliases_dict
 from .data import haplotypes as raw_haplotypes_dict
 from .data import heterodimers as raw_heterodimers_dict
@@ -26,12 +27,96 @@ from .data import known_alleles as raw_known_alleles_dict
 from .data import serotypes as raw_serotypes_dict
 from .data import species as raw_species_dict
 from .data import supertypes as raw_supertypes_dict
+from .data import underrepresented_taxa_source_registry as raw_holdback_registry
 from .mhc_class_helpers import class1_restrictions, class2_restrictions
 from .normalizing_dictionary import NormalizingDictionary
 from .normalizing_set import NormalizingSet
 from .result import Result
 
 _RAW_SPECIES_ORDER = {latin_name: i for i, latin_name in enumerate(raw_species_dict)}
+
+
+def _blocked_registry_prefixes():
+    """
+    Prefixes the curation registry deliberately keeps out of runtime.
+
+    `underrepresented_taxa_source_registry.yaml` is the holding area described
+    in docs/curation.md: real source signal that is not stable enough to parse
+    with. An entry marked `blocked` or `registry_only` stays out no matter how
+    well attested the spelling is.
+    """
+    blocked = set()
+
+    def walk(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, dict) and "scientific_name" in value:
+                    if (
+                        value.get("curation_status") == "blocked"
+                        or value.get("ontology_status") == "registry_only"
+                    ):
+                        blocked.add(normalize_string(key))
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(raw_holdback_registry)
+    return blocked
+
+
+def _partition_evidenced_aliases():
+    """
+    Split the attested aliases into globally parseable and context-only.
+
+    The rule is computed rather than curated, so it cannot go stale as species
+    are added: an alias claimed by exactly one species, and not already the
+    prefix or alias of some other entry, becomes a global alias. Anything
+    claimed by two or more -- or already owned elsewhere in species.yaml --
+    becomes context-only, so `species=` recovers the published record while a
+    bare prefix cannot silently pick a side. See issue #136.
+    """
+    withheld = _blocked_registry_prefixes()
+
+    claimants = defaultdict(set)
+    for latin_name, entries in raw_evidenced_alias_dict.items():
+        for entry in entries or []:
+            alias = normalize_string(entry["alias"])
+            if alias not in withheld:
+                claimants[alias].add(latin_name)
+
+    already_claimed = set()
+    for record in raw_species_dict.values():
+        already_claimed.add(normalize_string(record.get("prefix", "")))
+        for alias in record.get("other prefixes") or []:
+            already_claimed.add(normalize_string(alias))
+
+    global_aliases = defaultdict(list)
+    context_only = defaultdict(list)
+    for latin_name, entries in raw_evidenced_alias_dict.items():
+        for entry in entries or []:
+            alias = entry["alias"]
+            key = normalize_string(alias)
+            if len(alias) < 3:
+                # A one- or two-character alias cannot safely be a species
+                # prefix: "B" is real chicken nomenclature (B-F, B-L) but as a
+                # bare prefix it shadows the mouse haplotype b, and b/d stops
+                # parsing. Same reason the single-letter HLA fragments stay out
+                # of unprefixed resolution (#113).
+                continue
+            if key in withheld:
+                # underrepresented_taxa_source_registry.yaml is the holding area
+                # for prefixes deliberately kept out of runtime. An attested
+                # source spelling does not override that decision -- Otel, Phco
+                # and Phtr are blocked there and tests assert they do not parse.
+                continue
+            contested = len(claimants[key]) > 1 or key in already_claimed
+            (context_only if contested else global_aliases)[latin_name].append(alias)
+    return dict(global_aliases), dict(context_only)
+
+
+EVIDENCED_GLOBAL_ALIASES, EVIDENCED_CONTEXT_ONLY_ALIASES = _partition_evidenced_aliases()
 
 
 class FrozenList(list):
@@ -1198,6 +1283,17 @@ def create_species_for_latin_name(latin_name):
         context_only_mhc_prefixes = [context_only_mhc_prefixes]
     elif context_only_mhc_prefixes is None:
         context_only_mhc_prefixes = []
+
+    # Prefix spellings attested in an external database or the literature,
+    # from evidenced_prefix_aliases.yaml. Whether each is globally parseable or
+    # context-only was decided by _partition_evidenced_aliases from how many
+    # species claim it -- see issue #136.
+    for alias in EVIDENCED_GLOBAL_ALIASES.get(latin_name, ()):
+        if alias and alias != prefix and alias not in other_mhc_prefixes:
+            other_mhc_prefixes = [*list(other_mhc_prefixes), alias]
+    for alias in EVIDENCED_CONTEXT_ONLY_ALIASES.get(latin_name, ()):
+        if alias and alias != prefix and alias not in context_only_mhc_prefixes:
+            context_only_mhc_prefixes = [*list(context_only_mhc_prefixes), alias]
 
     # Auto-generate parseable aliases from the latin name, for binomials only:
     # 1. The full concatenated scientific name, which is the default and is

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.47.1"
+__version__ = "3.48.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,165 +1,47 @@
-# Release infra: build with the venv, and get the workflows off Node 20
+# Import the evidenced prefix aliases
 
-Tracking issues: #101, #94
+Tracking issue: #136
 
 ## Review
 
-### #101 -- deploy.py announced a venv and then built with something else
-
-`build_distributions` used `sys.executable`, which is whatever interpreter
-launched `deploy.py`, not the venv the script had just resolved and reported.
-The 3.33.6 release reproduced it: "Using venv: .venv", then a build through a
-Homebrew Python 3.14 with no `build` module, after lint and 15,127 tests had
-passed.
-
-Still live on this machine, which is how I confirmed it rather than trusting
-the report:
-
-```
-sys.executable  /Users/.../shared-virtual-env/bin/python3
-venv python     /Users/.../uv/python/cpython-3.12.6-.../bin/python3.12
-same?           False
-```
-
-- `Config` carries a `python` field alongside `env`, so the interpreter and the
-  environment cannot drift apart.
-- Resolution order is `DEPLOY_PYTHON`, then a venv interpreter **that can
-  actually build**, then `sys.executable`. See round 2 below: the first version
-  of this bullet described preferring the venv unconditionally, which review
-  showed would break every release here.
-- The build-availability check gets `cfg.env` too; it did not before, so it
-  could pass while the real build failed.
-- `deploy.py` now prints `Build interpreter: <path>`, so a mismatch is visible
-  in the log rather than discovered when `build` turns out to be missing.
-
-### #94 -- Node 20 deprecation
-
-Every `actions/*` pin moved to the **lowest major that runs on Node 24**, read
-from each action's own `action.yml` rather than assumed:
-
-| action | was | now | `runs.using` |
-|---|---|---|---|
-| checkout | v4 | v5 | node24 |
-| setup-python | v5 | v6 | node24 |
-| upload-artifact | v4 | v6 | node24 |
-| download-artifact | v4 | v7 | node24 |
-| cache | v4 | v5 | node24 |
-| configure-pages | v5 | v6 | node24 |
-| deploy-pages | v4 | v5 | node24 |
-| upload-pages-artifact | v3 | v5 | composite |
-
-Lowest-that-qualifies rather than latest, deliberately. `download-artifact@v8`
-makes a hash mismatch a hard error and migrates to ESM, and both artifact
-actions only run on tag push and `workflow_dispatch` -- so PR CI cannot verify
-them, and taking the smallest step that clears the deprecation is the lower
-risk.
-
-`upload-pages-artifact` is left at **v3**. It is a composite action, so it never
-had Node 20 exposure and this issue does not touch it -- and v4.0.0 stops
-including dotfiles in the artifact, which would be a silent behaviour change to
-the published site bought for no deprecation benefit.
-
-What this PR's own CI proves, and what it does not: `checkout` and
-`setup-python` are exercised by `tests.yml` and `docs.yml`. `cache` is used
-only in `external-data.yml`, which is path-filtered on `mhcgnomes/**` -- it runs
-here only because `version.py` matches, so a later workflow-only change would
-leave it unexercised. The artifact actions are not exercised at all.
-
-## Review round 2 (code review, and it caught a regression)
-
-- **My first fix would have broken every release.** It always preferred the
-  venv interpreter. But `develop.sh` installs only `.[dev,docs]`, and this
-  repo's `.venv` has neither `build` nor `setuptools` nor `wheel`, while the
-  launching interpreter has all three:
-
-  ```
-  .venv/bin/python  ->  no build, no setuptools, no wheel
-  sys.executable    ->  build 1.6.0, setuptools 75.8.0, wheel 0.44.0
-  ```
-
-  So `./deploy.sh` would have aborted at the availability check, after lint and
-  15,868 tests. I ran `./deploy.sh` a dozen times this session under the old
-  behaviour without noticing, because the old behaviour is what works here.
-  The fix now prefers the venv **only when it can actually build**, falls back
-  otherwise, and prints which and why.
-- **Reading `DEPLOY_PYTHON` was redundant and wrong.** `deploy.sh` already does
-  `PYTHON_BIN="${DEPLOY_PYTHON:-python3}"` and launches `deploy.py` with it, so
-  an explicit override arrives as `sys.executable`. Reading it again let it
-  outrank the venv while `cfg.env` still pointed at that venv -- recreating the
-  exact mismatch #101 is about. Removed, and a test asserts it stays removed.
-- **The probe moved before the cleanup.** `clean_build_artifacts` deletes
-  `dist/`, `build/` and `*.egg-info`, including the editable install's, so
-  failing after it left the checkout worse off than before the attempt.
-- **The probe now checks `setuptools` too.** `--no-isolation` means pyproject's
-  `requires = ["setuptools>=61.0", "wheel"]` must already be importable, so
-  probing only `build` could pass and the build still fail.
-- **A missing interpreter now dies cleanly** instead of raising an uncaught
-  `FileNotFoundError` past `__main__`'s `CommandError`-only handler.
-- **`upload-pages-artifact` reverted to v3.** It is composite, so it never had
-  Node 20 exposure, and v4.0.0 stops including dotfiles in the artifact -- a
-  silent change to the published site bought for no deprecation benefit. Read
-  only `runs.using` the first time and missed it.
-- **`format.sh` could not fix the file this PR edits.** Its `SOURCES` omitted
-  `deploy.py` while `lint.sh`'s included it, so the `./format.sh` then
-  `./lint.sh` loop AGENTS.md prescribes could not converge. Aligned -- and it
-  immediately caught a `%`-format in the new test.
-- **`dataclasses.replace`** instead of rebuilding `Config` field by field, so a
-  future field cannot be silently dropped.
-- **CI caught one of my new tests making the very assumption this PR removes.**
-  It asserted the interpreter running the suite can build. True on this
-  machine, false on the runner -- the repo's `dev` extra has no `build`, which
-  is exactly the environment the change exists to handle. Rewritten against a
-  controlled stub, so the suite no longer depends on the runner having build
-  tooling at all.
-- **11 tests, where there were none.** `resolve_build_python` and
-  `interpreter_can_build` are pure enough to test with `tmp_path`; the stub
-  venv exits non-zero, since a stub that exits 0 for everything claims it can
-  build -- which is how the first version of that test passed wrongly.
-- **`docs/releasing.md` gained a "Which interpreter builds" section**, since
-  the log line is new and a maintainer needs to know that the fallback is
-  normal rather than a failure.
-- **Filed rather than fixed: #152.** `AGENTS.md` documents
-  `deploy.sh <version>`, which `deploy.py` has no positional argument for -- and
-  because `deploy.sh` runs lint and tests first, following that instruction
-  burns the full suite before failing on argparse. Two documented release
-  processes, one of which does not exist; picking between them is a call about
-  how releases should work.
-## Review round 3
-
-- **The `upload-pages-artifact` revert was wrong, and my justification was the
-  wrong fact.** I said it is composite so it never had Node 20 exposure. It is
-  composite -- and its own `action.yml` invokes `actions/upload-artifact@v4`,
-  a Node 20 action. v4 nests v4.6.2, also Node 20. **v5 is the only release
-  whose nested action runs on Node 24**, so reverting to v3 left the exact gap
-  #94 exists to close, in the one workflow that publishes.
-
-  v5 with `include-hidden-files: true` clears Node 20 *and* restores the
-  dotfile behaviour v4 changed, so neither concern has to be traded away.
-- **`DEPLOY_PYTHON` could not actually force an interpreter.** A capable venv
-  silently outranked it, while the failure message told the user to set it.
-  Now checked first -- by presence, not by re-reading the path, since
-  `deploy.sh` already launches `deploy.py` with it.
-- **The build environment did not match the build interpreter.** `cfg.env`
-  always names the venv, and I had passed it to a build that may run under the
-  launching interpreter -- so `python` and `pip` inside the build would resolve
-  to a different interpreter than the one running it. That is #101's drift
-  pointed the other way, and it was new: the old code passed no env at all.
-  `Config.build_env` now carries the environment that matches `Config.python`.
-- **`Path("") .exists()` is `True`** -- it is `PosixPath(".")` -- so the
-  existence guard never fired for the empty placeholder it was written for. An
-  explicit emptiness check first, then `require_cmd` for relative names so the
-  lookup honours the same PATH the build will use.
-- **`--dry-run` skipped the one check that matters.** It returns before
-  `build_distributions`, so a rehearsal reported success on a checkout that
-  cannot build. Split into `check_build_prerequisites`, which both paths call.
-- **The probe threw away its diagnostics.** A `build` that is installed but
-  broken now reports its actual traceback instead of a fixed message asserting
-  the imports are missing.
-- **Two tests asserted on source text.** One would have passed a probe with an
-  inverted return; the other indexed `source.split('\"\"\"')[2]` and would
-  raise `IndexError` on a docstring edit. Replaced with behavioural stubs -- the
-  setuptools one uses an interpreter that fails only the two-module import.
-- **Tests now cover what the change delivers**, not only its helpers: that
-  `Config` carries both the interpreter and its environment, that the probe
-  precedes the cleanup, and that `--dry-run` rehearses it.
-- Bumped to 3.47.1. No library code changes.
+- **Recounted first, because the issue's numbers were measured against 3.40.**
+  Against 3.47.1 the mhcseqs registry has 339 evidenced pairs (up from 294),
+  every one with an evidence URL. 118 already resolved, 23 were genuinely
+  contested, and 7 of the apparent collisions were not collisions at all:
+  `OmLA`, `MaLA`, `GoLA`, `RhLA`, `RLA`, `ChLA` and `RT1` resolve to the genus
+  node that owns them while the evidenced row names a species beneath it. That
+  is the umbrella working, and those are left alone.
+- **`mhcgnomes/data/evidenced_prefix_aliases.yaml`** carries the import: 183
+  species, 196 rows, each with its own `status` and `evidence` URL. Per
+  `(species, alias)`, as point 3 of the issue's model asks -- one species can
+  have current, historical and database spellings from different sources.
+- **Global vs context-only is computed, not curated.** An alias claimed by one
+  species and unclaimed elsewhere becomes a global alias; anything claimed by
+  two or more, or already owned in `species.yaml`, becomes context-only. That
+  is point 2 of the model, and computing it means the decision cannot go stale
+  as species are added. 141 global, 32 context-only.
+- **Three things the first cut got wrong, all caught by existing tests:**
+  - **It overrode a deliberate holdback.** `Otel-DAB`, `Phtr-UA` and `Phco-UA`
+    started parsing, and `tests/test_birds.py` asserts they must not.
+    `underrepresented_taxa_source_registry.yaml` marks all three `blocked` /
+    `registry_only` -- the holding area `docs/curation.md` describes for source
+    signal not stable enough to parse with. An attested spelling does not
+    outrank that, and the loader now reads the registry to enforce it.
+  - **It made `B` a species prefix.** Real chicken nomenclature (B-F, B-L), but
+    as a bare prefix it shadows the mouse haplotype `b` and `b/d` stopped
+    parsing. Aliases shorter than three characters are not imported globally --
+    the same reason the single-letter HLA fragments stay out of unprefixed
+    resolution (#113).
+  - **A refactor broke the claimant count** by keying on the alias instead of
+    the species, which silently turned contested aliases global. `GPLA` and
+    `XLA` stopped resolving, which is what surfaced it.
+- **One of my new tests was wrong rather than the code.** It expected
+  *Cyprinus carpio* to carry `Cyca` as context-only; the carp already owns
+  `Cyca` as its prefix, and it is the three *other* claimants that get it
+  context-only. The owner is never demoted by someone else's evidence.
+- **Measured:** 0 of 11,558 corpus names change. Verified by mutation --
+  ignoring the holdback fails 8 tests, allowing short aliases fails 3.
+- **Not in scope:** 17 rows name species absent from the ontology, including
+  *Spalax ehrenbergi* and its `Smh` system name (point 4 of the model). Adding
+  taxa is a different job from importing aliases for taxa we have.
+- Bumped 3.47.1 to 3.48.0: 141 strings that resolved to nothing now resolve.

--- a/tests/test_evidenced_prefix_aliases.py
+++ b/tests/test_evidenced_prefix_aliases.py
@@ -1,0 +1,141 @@
+"""
+Prefix spellings attested in an external database or the literature.
+
+Imported from the sibling mhcseqs registry, with the evidence URL kept per
+(species, alias) rather than per species -- one species can have current,
+historical and database spellings from different sources.
+
+Whether an alias is globally parseable or context-only is computed at load
+time from how many species claim it, so it cannot go stale as species are
+added.
+
+https://github.com/pirl-unc/mhcgnomes/issues/136
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mhcgnomes import Species, parse
+from mhcgnomes.species import (
+    EVIDENCED_CONTEXT_ONLY_ALIASES,
+    EVIDENCED_GLOBAL_ALIASES,
+    _blocked_registry_prefixes,
+    find_matching_context_only_species_objects,
+)
+
+from .common import eq_, ok_
+
+ALIASES_PATH = Path(__file__).parent.parent / "mhcgnomes" / "data" / "evidenced_prefix_aliases.yaml"
+REGISTRY = yaml.safe_load(ALIASES_PATH.read_text())
+
+
+def test_every_row_carries_an_evidence_url():
+    """
+    Requirement 1 of the model in #136: import only what is cited. This is the
+    one property that cannot be recovered later if it is skipped.
+    """
+    uncited = [
+        (species, entry["alias"])
+        for species, entries in REGISTRY.items()
+        for entry in entries
+        if not str(entry.get("evidence", "")).startswith("http")
+    ]
+    eq_(uncited, [], f"evidenced aliases with no source: {uncited}")
+
+
+def test_every_row_names_a_species_we_have():
+    missing = sorted({s for s in REGISTRY if Species.get_by_latin_name(s) is None})
+    eq_(missing, [], f"aliases for species absent from the ontology: {missing}")
+
+
+# The examples #136 lists as absent source spellings.
+NEWLY_RESOLVABLE = [
+    ("Acsi", "Acipenser sinensis"),
+    ("GPLA", "Cavia porcellus"),
+    ("XLA", "Xenopus laevis"),
+]
+
+
+@pytest.mark.parametrize("alias,latin_name", NEWLY_RESOLVABLE)
+def test_an_uncontested_attested_spelling_resolves(alias, latin_name):
+    species = Species.get(alias)
+    assert species is not None, f"{alias!r} still resolves to nothing"
+    eq_(species.name, latin_name)
+
+
+# The collisions #136 lists: (alias, the species that keeps it as its prefix,
+# a newly evidenced claimant that gets it context-only instead).
+CONTESTED = [
+    ("Bubu", "Bubalus bubalis", "Bubo bubo"),
+    ("Cyca", "Cyprinus carpio", "Cyanistes caeruleus"),
+    ("Cyca", "Cyprinus carpio", "Clarias magur"),
+]
+
+
+@pytest.mark.parametrize("alias,keeps_it,context_only_claimant", CONTESTED)
+def test_a_contested_spelling_is_context_only(alias, keeps_it, context_only_claimant):
+    """
+    The owner is unaffected -- an attested spelling elsewhere does not take a
+    prefix away from the species that already uses it.
+    """
+    eq_(Species.get(alias).name, keeps_it)
+    claimants = {s.name for s in find_matching_context_only_species_objects(alias)}
+    ok_(
+        context_only_claimant in claimants,
+        f"{context_only_claimant} does not carry {alias!r} as context-only",
+    )
+    ok_(keeps_it not in claimants, f"{keeps_it} should own {alias!r}, not hold it context-only")
+
+
+def test_context_only_is_recoverable_with_an_explicit_species():
+    """The point of the bucket: the published record is still reachable."""
+    result = parse("UAA", species="Bubo bubo", raise_on_error=True)
+    eq_(result.species.name, "Bubo bubo")
+
+
+def test_multi_claimant_aliases_are_never_global():
+    """
+    An alias two species can cite must not silently pick one. Computed from
+    claimant count rather than curated, so adding a species cannot leave a
+    stale decision behind.
+    """
+    claim_count = {}
+    for entries in REGISTRY.values():
+        for entry in entries:
+            claim_count[entry["alias"].lower()] = claim_count.get(entry["alias"].lower(), 0) + 1
+    for aliases in EVIDENCED_GLOBAL_ALIASES.values():
+        for alias in aliases:
+            eq_(claim_count[alias.lower()], 1, f"{alias!r} is global despite multiple claimants")
+
+
+def test_the_curation_holdback_is_respected():
+    """
+    `underrepresented_taxa_source_registry.yaml` keeps prefixes out of runtime
+    deliberately. An attested source spelling does not override that -- Otel,
+    Phco and Phtr are blocked there, and tests/test_birds.py asserts they do
+    not parse.
+    """
+    blocked = _blocked_registry_prefixes()
+    ok_(blocked, "expected some blocked prefixes in the registry")
+    imported = {a.lower() for v in EVIDENCED_GLOBAL_ALIASES.values() for a in v}
+    imported |= {a.lower() for v in EVIDENCED_CONTEXT_ONLY_ALIASES.values() for a in v}
+    leaked = sorted(imported & blocked)
+    eq_(leaked, [], f"blocked prefixes imported anyway: {leaked}")
+
+
+@pytest.mark.parametrize("name", ["Otel-DAB", "Phtr-UA", "Phco-UA"])
+def test_blocked_bird_prefixes_still_do_not_parse(name):
+    eq_(parse(name, raise_on_error=False), None)
+
+
+def test_very_short_aliases_are_not_imported_globally():
+    """
+    "B" is real chicken nomenclature (B-F, B-L), but as a bare species prefix
+    it shadows the mouse haplotype b and `b/d` stops parsing. Same reason the
+    single-letter HLA fragments stay out of unprefixed resolution (#113).
+    """
+    too_short = [a for v in EVIDENCED_GLOBAL_ALIASES.values() for a in v if len(a) < 3]
+    eq_(too_short, [], f"aliases too short to be a species prefix: {too_short}")
+    eq_(parse("b/d", raise_on_error=True).species.name, "Mus musculus")


### PR DESCRIPTION
Closes #136.

## Recounted first — the issue's numbers were measured against 3.40

Against 3.47.1, the mhcseqs registry has **339** evidenced species/prefix pairs
(up from 294 after pirl-unc/mhcseqs#51), **every one with an evidence URL**.

Seven of the apparent collisions turned out not to be collisions: `OmLA`,
`MaLA`, `GoLA`, `RhLA`, `RLA`, `ChLA` and `RT1` resolve to the **genus node
that owns them** while the evidenced row names a species beneath it. That is
the umbrella working correctly, so they are left alone — which is why the
contested count is 23, not the 41 a naive comparison gives.

## What lands

`mhcgnomes/data/evidenced_prefix_aliases.yaml`: 183 species, 196 rows, each
carrying its own `status` and `evidence` URL — provenance at the
`(species, alias)` level, as point 3 of the model asks, because one species can
have current, historical and database spellings from different sources.

```yaml
Abramis brama:
  - alias: Arbr
    status: external_database
    evidence: https://rest.uniprot.org/uniprotkb/A0A8E5GKZ6
```

**Global vs context-only is computed, not curated.** An alias claimed by one
species and unclaimed elsewhere becomes a global alias; anything claimed by two
or more, or already owned in `species.yaml`, becomes context-only. That is
point 2 of the model, and computing it means the decision cannot go stale as
species are added — **141 global, 32 context-only**.

The examples the issue lists as absent now resolve:

```
Acsi -> Acipenser sinensis     GPLA -> Cavia porcellus     XLA -> Xenopus laevis
```

And the collisions it lists behave as the model asks — the owner keeps the
prefix, the new claimant gets it context-only:

```
Species.get("Bubu")                      -> Bubalus bubalis
parse("UAA", species="Bubo bubo")        -> Bubo bubo         (recoverable)
```

## Three things the first cut got wrong, all caught by existing tests

**It overrode a deliberate holdback.** `Otel-DAB`, `Phtr-UA` and `Phco-UA`
started parsing, and `tests/test_birds.py` asserts they must not.
`underrepresented_taxa_source_registry.yaml` marks all three `blocked` /
`registry_only` — the holding area `docs/curation.md` describes for source
signal not stable enough to parse with. **An attested spelling does not outrank
a curation decision**, and the loader now reads the registry to enforce it.

**It made `B` a species prefix.** Real chicken nomenclature (B-F, B-L), but as
a bare prefix it shadows the mouse haplotype `b`, and `b/d` stopped parsing.
Aliases shorter than three characters are not imported globally — the same
reason the single-letter HLA fragments stay out of unprefixed resolution
(#113).

**A refactor broke the claimant count** by keying on the alias instead of the
species, which silently turned contested aliases global. `GPLA` and `XLA`
stopped resolving, which is what surfaced it.

One of my own new tests was wrong rather than the code: it expected *Cyprinus
carpio* to carry `Cyca` as context-only, but the carp already **owns** `Cyca`,
and it is the three other claimants that get it context-only. An owner is never
demoted by someone else's evidence.

## Measurement

**0 of 11,558** corpus names change. Verified by mutation: ignoring the
holdback fails 8 tests, allowing short aliases fails 3.

## Not in scope

17 rows name species absent from the ontology, including *Spalax ehrenbergi*
and its `Smh` system name (point 4 of the model). Adding taxa is a different
job from importing aliases for taxa we already have.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,891 passed. 3.47.1 → 3.48.0,
since 141 strings that resolved to nothing now resolve.
