### PR TITLE
Establish FLA and RLA; the citation for the six primate _LA codes does not check out

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -1049,6 +1049,11 @@ Canis mesomelas:
 #
 ############################
 Felis sp.:
+  # prefix source: designated -- PMID 2492667 (Winkler et al., PNAS 1989;86:943)
+  # is titled "Genetic characterization of FLA, the cat major histocompatibility
+  # complex" and writes "the major histocompatibility complex (MHC) of the
+  # domestic cat (termed FLA)".
+  prefix source: designated
   prefix: FLA
   name: Cat
   genes:
@@ -3338,6 +3343,10 @@ Pteropus alecto:
 #
 ################################################################################
 Oryctolagus sp.:
+  # prefix source: designated -- PMID 32522857 (Zhang et al., J Virol 2020;94:e00396-20)
+  # names "rabbit Major Histocompatibility Complex Class I Molecule RLA-A1" in its
+  # title, so alleles are written with the prefix.
+  prefix source: designated
   prefix: RLA
   name: Rabbit
   genes:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.48.2"
+__version__ = "3.48.3"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,79 +1,41 @@
-# Make serotype regeneration idempotent, and fix the release flow AGENTS.md documents
+# Establish FLA and RLA; correct the citation for the six primate _LA codes
 
-Tracking issues: #156, #152
+Tracking issue: #131 (46 entries still unestablished)
 
 ## Review
 
-### #156 -- and I filed it with the hazard backwards
+- **AGENTS.md names the de Groot nomenclature report as the authority for
+  primate prefixes, so I read it** rather than repeating that IPD has no group
+  page for these codes. Extracting the full text of
+  `Groot_Nomenclature_Immunogenetics_2020_3174021.pdf`:
 
-I reported that regenerating `serotypes_generated.yaml` would silently drop 15
-rows. That is wrong. I had compared `build_serotype_mappings` output -- the
-pure dictionary transform, 135 rows -- against the file, and never ran the
-script. `generate_yaml` explicitly carries forward serotypes the dictionary has
-no row for, with a comment saying so, and running it produces **170** rows, not
-135. The C locus above Cw10, the DP workshop specificities and the B17 splits
-are preserved by design.
+  ```
+  Patr 77 hits   Mamu 8   Gogo 7   Popy 3   Mafa 3
+  OmLA / MaLA / GoLA / ChLA / OrLA / RhLA : 0, case-insensitively
+  ```
 
-**The real hazard is narrower and points the other way.** Regenerating
-*re-adds* `A*2418` to `A3`, undoing a curation fix:
+  The extraction is sound -- the 2+2 codes the report does use are all there.
+  So the six primate `_LA` codes are absent from it.
 
-```
-A*24:18   WHO Assigned Type = "A24(9)/A3"
-          Comments = "A2403x3; short A24 with most A3 and A9 reactive; NN: A24"
-```
+- **That matters because the mhcseqs registry cites exactly that paper as their
+  evidence.** `mhc_prefix_aliases.csv` gives all six
+  `status: literature_historical` with the de Groot PDF as the URL, and the PDF
+  does not contain them. The citation does not check out, so they stay `None`.
+  Marking them designated on it would be the `Caau` mistake with a footnote.
 
-`parse_serotype` splits the dual type into both serotypes, so the allele lands
-in `A3` as well as `A24`. Curation had removed it from `A3` -- correctly, on
-the dictionary's own comment -- and a regeneration would put it back with
-nothing to notice.
+- **Two of the eight had different evidence, and it holds.** Read from PubMed
+  directly rather than the search summary:
+  - `FLA` -- PMID 2492667, *"Genetic characterization of FLA, the cat major
+    histocompatibility complex"*, and the abstract says "the major
+    histocompatibility complex (MHC) of the domestic cat (termed FLA)".
+  - `RLA` -- PMID 32522857, whose title names "rabbit Major Histocompatibility
+    Complex Class I Molecule **RLA-A1**", so alleles carry the prefix.
 
-So the fix is a `CURATED_EXCLUSIONS` set in the generator, carrying the pair
-and the reason. With it, regenerating reproduces the runtime table exactly:
+  Both marked `designated` with the citation on the entry.
 
-```
-regenerated == serotypes.yaml : True
-differing rows                : []
-```
+- **#131 is now 130 designated / 46 unknown**, from 11/163 when it was filed.
+  The canary list drops from eight names to six, with the reason recorded next
+  to it so the next reader does not re-follow the same broken citation.
 
-Four tests pin it, including one asserting every exclusion is a pair the
-dictionary actually asserts, so a stale entry cannot outlive its reason.
-Verified by mutation: removing the exclusion fails the suite.
-
-This also settles part of #153. `Cw15` and `Cw17` are in the carried-forward
-set -- not derived from the dictionary -- so they are not evidence about what
-the dictionary says, and a test now names them so that stays visible.
-
-### #152 -- AGENTS.md documented a command that does not exist
-
-Golden Rule 2 said `deploy.sh <version>` handles the bump. `deploy.py` has no
-positional version argument, and `deploy.sh` runs `./lint.sh` and `./test.sh`
-before passing arguments through, so following the instruction burns the full
-suite and then fails on argparse.
-
-Corrected to the flow that exists and that every release in this repo actually
-uses: bump `version.py` in the PR, then `./deploy.sh` with no arguments from a
-clean `main`. Implementing the argument instead would have made `deploy.sh`
-mutate the working tree, which its own `ensure_clean_tree` check exists to
-prevent.
-
-- **Measured:** 0 of 11,558 corpus names change. The runtime serotype table is
-  byte-identical; only the intermediate artifact and the generator changed.
-### The deeper version of #156, found when CI failed
-
-The tests pinning regeneration could not run on the runner:
-
-```
-FileNotFoundError: .../mhcgnomes/data/hla_dictionary.xlsx
-```
-
-**The dictionary was gitignored** by a blanket `*.xlsx` rule and untracked, so
-the source `serotypes.yaml` names in its own header existed only on whichever
-machine last regenerated the table. Nobody else could regenerate it, or check
-that the shipped table still matched its source -- a larger version of the
-drift this issue is about, and the reason the drift went unnoticed.
-
-Tracked now, with a targeted un-ignore and the reason recorded beside it. The
-dictionary-dependent tests keep a skip guard so a checkout without the file
-degrades to a skip rather than an error.
-
-- Bumped to 3.48.2.
+- **Measured:** 0 of 11,558 corpus names change.
+- Bumped to 3.48.3.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -676,17 +676,20 @@ def test_unestablished_provenance_stays_none():
     # them all at once has to come here and say so. A count bound would have
     # done neither -- it fires on ordinary growth and passes a bulk assignment.
     for name in [
-        # Group-level _LA codes, still unchecked. IPD-MHC has no group page for
-        # any of them -- there is no /group/FLA/ or /group/OrLA/ -- so
-        # establishing them means the primate nomenclature reports rather than
-        # a species table. That is what is left of #131 after the IPD species
-        # tables were exhausted.
+        # The six primate _LA codes. IPD-MHC has no group page for any of them,
+        # and the 2019/2020 de Groot nomenclature report -- which the mhcseqs
+        # registry cites as their evidence -- does not contain them: extracting
+        # its text finds Patr 77 times and Mamu 8, and OmLA/MaLA/GoLA/ChLA/OrLA/
+        # RhLA zero times, case-insensitively. So the citation is wrong and
+        # these stay unestablished until someone finds the actual source.
+        #
+        # Felis sp. and Oryctolagus sp. used to be on this list and are not any
+        # more: FLA and RLA are published (PMID 2492667, PMID 32522857) and are
+        # now marked designated.
         "Aotus sp.",
         "Callithrix sp.",
-        "Felis sp.",
         "Gorilla sp.",
         "Macaca sp.",
-        "Oryctolagus sp.",
         "Pan sp.",
         "Pongo sp.",
     ]:


### PR DESCRIPTION
Further progress on #131 — **130 designated / 46 unknown**, from 11/163 when it
was filed.

## I said IPD had no page for these, and left it there. AGENTS.md names the
## other authority, so I read it

`AGENTS.md` cites the de Groot primate nomenclature report. Extracting the full
text of `Groot_Nomenclature_Immunogenetics_2020_3174021.pdf`:

```
Patr 77 hits    Mamu 8    Gogo 7    Popy 3    Mafa 3
OmLA / MaLA / GoLA / ChLA / OrLA / RhLA  :  0, case-insensitively
```

The extraction is sound — every 2+2 code the report does use is there. The six
`_LA` codes are simply absent from it.

**That matters because the mhcseqs registry cites exactly that paper as their
evidence.** All six appear in `mhc_prefix_aliases.csv` as
`status: literature_historical` with the de Groot PDF as the URL, and the PDF
does not contain them. So the citation does not check out, and they stay
`None`. Marking them `designated` on it would be the `Caau` mistake with a
footnote attached.

## Two of the eight had different evidence, and it holds

Read from PubMed directly rather than from a search summary:

| prefix | source | what it says |
|---|---|---|
| `FLA` | PMID 2492667 | *"Genetic characterization of FLA, the cat major histocompatibility complex"* — abstract: "the major histocompatibility complex (MHC) of the domestic cat (termed FLA)" |
| `RLA` | PMID 32522857 | title names *"rabbit Major Histocompatibility Complex Class I Molecule **RLA-A1**"*, so alleles carry the prefix |

Both marked `designated`, citation on the entry.

## What this leaves

The canary list in `test_unestablished_provenance_stays_none` drops from eight
names to six, with the broken-citation finding recorded beside it so the next
reader does not follow the same URL to the same dead end.

## Measurement

**0 of 11,558** corpus names change — provenance metadata only.

`./format.sh`, `./lint.sh` pass; `./test.sh` 15,895 passed. 3.48.2 → 3.48.3.
