### PR TITLE
Add the nine HLA class I gene fragments (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,40 @@ False
 True
 ```
 
+### Loci that name no alleles
+
+A few loci are named by a nomenclature authority which then deposits no
+sequence under them. IMGT/HLA names the class I gene fragments `X` and `Z`, the
+class II pseudogenes `DQB3` and `DPA3`, and `MICC`/`MICD`/`MICE`/`PSMB8`/
+`PSMB9`, and IPD-IMGT/HLA gives every one of them zero alleles. The gene
+resolves; an allele built on top of it does not.
+
+```python
+>>> mhcgnomes.parse("HLA-Z")
+Gene(species=Species(name='Homo sapiens', mhc_prefix='HLA'), name='Z', mutations=())
+>>> mhcgnomes.parse("HLA-Z*01:01", raise_on_error=False) is None
+True
+>>> mhcgnomes.parse("HLA-W*01:01:01:01").gene.name  # W has 13 deposited alleles
+'W'
+```
+
+### Genes which need the species named
+
+Every HLA class I gene fragment is a single letter, and a bare `N`, `R`, `S`,
+`U` or `Z` is mouse or rat haplotype shorthand long before it is a human gene.
+These genes are marked `context only` in the ontology: they resolve when the
+species is named -- by prefix or by `species=` -- and stay out of species-less
+lookup, so the shorthand keeps its meaning.
+
+```python
+>>> mhcgnomes.parse("N").to_string()      # rat haplotype, as it always was
+'RT1-n'
+>>> mhcgnomes.parse("HLA-N").to_string()
+'HLA-N'
+>>> mhcgnomes.parse("N", species="Homo sapiens").to_string()
+'HLA-N'
+```
+
 ### Mutations
 
 MHC proteins are sometimes described in terms of mutations to a known allele.

--- a/mhcgnomes/allele.py
+++ b/mhcgnomes/allele.py
@@ -225,6 +225,11 @@ class Allele(ResultWithGene):
         if gene is None:
             return None
 
+        # A locus its own nomenclature authority gives no alleles cannot have
+        # one built for it -- see Species.gene_has_no_alleles and issue #113.
+        if gene.species is not None and gene.species.gene_has_no_alleles(gene.name):
+            return None
+
         allele_fields = cls.split_allele_fields(allele_fields)
 
         if len(allele_fields) == 0:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -469,22 +469,31 @@ Homo sapiens:
       - CD1e
       - MR1
     I:
-      # pseudogenes
-      #
-      # IMGT/HLA (https://hla.alleles.org/genes/index.html) also names the
-      # class I gene fragments N, R, S, T, U, W, X, Y and Z. They are
-      # deliberately not listed here: every one is a single letter, and
-      # adding them flips bare "n", "s", "t", "u" and "w" from the
-      # mouse/rat haplotype shorthand they resolve to today into human gene
-      # fragments, and lets allele-less fragments accept allele fields
-      # ("Z*01:01"). The same shadowing already affects H/J/K/L/P/V versus
-      # H2-k and friends, which needs resolving first. See issue #113.
+      # Non-functional class I loci. IMGT/HLA
+      # (https://hla.alleles.org/genes/index.html) splits these two ways in its
+      # Description column: H, J, K and L are "HLA class I pseudogene", while
+      # N, P, R, S, T, U, V, W, X, Y and Z are "HLA class I gene fragment".
+      # Our `pseudogene` flag is the coarser not-expressed/expressed
+      # distinction, so both kinds carry it -- as P and V already did.
       - H
       - J
       - K
       - L
       - P
       - V
+      # The eleven single-letter fragments are all `context only`, because a
+      # bare "N", "R", "S", "U" or "Z" is mouse or rat haplotype shorthand
+      # long before it is a human gene fragment. See the gene properties
+      # below, Species.gene_is_context_only, and issue #113.
+      - N
+      - R
+      - S
+      - T
+      - U
+      - W
+      - X
+      - Y
+      - Z
     IIa:
       DR:
         - DRA
@@ -527,6 +536,23 @@ Homo sapiens:
       - PSMB8
       - PSMB9
   # Source: https://www.ebi.ac.uk/ipd/imgt/hla/about/statistics/
+  #
+  # `alleles: none` marks a locus IMGT/HLA names and deposits no sequence for.
+  # The counts below are from IPD-IMGT/HLA 3.65.0 Allelelist.txt (dated
+  # 2026-07-14, https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/Allelelist.txt),
+  # which is the authority on what has actually been deposited: HLA-X, HLA-Z,
+  # HLA-DQB3, HLA-DPA3, MICC, MICD, MICE, PSMB8 and PSMB9 have zero alleles
+  # each. Every other fragment does have them -- W has 13, T 9, S and U 7 each,
+  # N and P 5, V 4, Y 3, R 2 -- so "HLA-W*01:01:01:01" is a real allele name
+  # and parses.
+  #
+  # `context only: true` keeps a gene out of species-less lookup; it still
+  # resolves under "HLA-" or an explicit species= argument. It is on the nine
+  # loci added for #113 and not on P or V, which are equally single letters:
+  # bare "P" and "V" have resolved to HLA-P and HLA-V since long before this,
+  # and flipping them to the H2-p and H2-v haplotypes is a parser policy
+  # change about ambiguous bare tokens, which is issue #130. Adding data
+  # should not quietly move parses that already exist.
   gene properties:
     G: {pseudogene: false}
     H: {pseudogene: true}
@@ -535,18 +561,29 @@ Homo sapiens:
     L: {pseudogene: true}
     P: {pseudogene: true}
     V: {pseudogene: true}
+    N: {pseudogene: true, context only: true}
+    R: {pseudogene: true, context only: true}
+    S: {pseudogene: true, context only: true}
+    T: {pseudogene: true, context only: true}
+    U: {pseudogene: true, context only: true}
+    W: {pseudogene: true, context only: true}
+    X: {pseudogene: true, context only: true, alleles: none}
+    Y: {pseudogene: true, context only: true}
+    Z: {pseudogene: true, context only: true, alleles: none}
     DRB2: {pseudogene: true}
     DRB6: {pseudogene: true}
     DRB7: {pseudogene: true}
     DRB8: {pseudogene: true}
     DRB9: {pseudogene: true}
-    DQB3: {pseudogene: true}
+    DQB3: {pseudogene: true, alleles: none}
     DPA2: {pseudogene: true}
-    DPA3: {pseudogene: true}
+    DPA3: {pseudogene: true, alleles: none}
     DPB2: {pseudogene: true}
-    MICC: {pseudogene: true}
-    MICD: {pseudogene: true}
-    MICE: {pseudogene: true}
+    MICC: {pseudogene: true, alleles: none}
+    MICD: {pseudogene: true, alleles: none}
+    MICE: {pseudogene: true, alleles: none}
+    PSMB8: {alleles: none}
+    PSMB9: {alleles: none}
 ######################################################
 #
 # Mouse

--- a/mhcgnomes/function_api.py
+++ b/mhcgnomes/function_api.py
@@ -157,6 +157,50 @@ def _reparse_with_context_only_prefix(
     return reparsed.copy(raw_string=raw_string)
 
 
+def _reparse_context_only_gene(
+    parser: Parser,
+    raw_string: str,
+    expected_species: Species,
+    infer_class2_pairing: bool,
+    required_result_types,
+    preferred_result_types,
+    only_class1: bool,
+    only_class2: bool,
+    max_allele_fields,
+):
+    """
+    Rescue a gene which resolves only once the species is known.
+
+    A gene marked `context only` stays out of species-less lookup, so bare "N"
+    parses as the rat haplotype rather than the human class I fragment (see
+    Species.gene_is_context_only). But `species=` is the strict form: the
+    caller has named the species, so there is nothing left to guess, and the
+    string is retried as the parser would have needed to see it -- "N" under
+    Homo sapiens as "HLA-N". Mirrors _reparse_with_context_only_prefix, which
+    does the same for a contested species prefix. See issue #113.
+    """
+    gene_token = raw_string.split("*")[0].strip()
+    if not gene_token:
+        return None
+    gene_name = expected_species.find_matching_gene_name(gene_token)
+    if gene_name is None or not expected_species.gene_is_context_only(gene_name):
+        return None
+    reparsed = parser.parse(
+        f"{expected_species.prefix}-{raw_string}",
+        default_species=expected_species,
+        infer_class2_pairing=infer_class2_pairing,
+        raise_on_error=False,
+        required_result_types=required_result_types,
+        preferred_result_types=preferred_result_types,
+        only_class1=only_class1,
+        only_class2=only_class2,
+        max_allele_fields=max_allele_fields,
+    )
+    if reparsed is None:
+        return None
+    return reparsed.copy(raw_string=raw_string)
+
+
 def _format_species_options(species_objects, max_items=4):
     names = [sp.name for sp in species_objects]
     shown = names[:max_items]
@@ -721,6 +765,24 @@ def parse(
         if rescued is not None:
             result = rescued
             parser_error = None
+        # Also when something else claimed the string: bare "N" parses as the
+        # rat haplotype, so a caller who asked for Homo sapiens gets a species
+        # mismatch rather than nothing at all.
+        if result is None or getattr(result, "species", None) != expected_species:
+            rescued = _reparse_context_only_gene(
+                parser=parser,
+                raw_string=raw_string,
+                expected_species=expected_species,
+                infer_class2_pairing=infer_class2_pairing,
+                required_result_types=required_result_types,
+                preferred_result_types=preferred_result_types,
+                only_class1=only_class1,
+                only_class2=only_class2,
+                max_allele_fields=max_allele_fields,
+            )
+            if rescued is not None:
+                result = rescued
+                parser_error = None
 
     if parser_error is not None:
         # Explain the contested prefix whether or not species= was supplied.

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -64,6 +64,20 @@ _MHC_REGION_RE = re.compile(
 )
 
 
+def _names_context_only_gene(result):
+    """
+    Does this parse result rest on a gene that needs the species named first?
+
+    See Species.gene_is_context_only: the gene is real, but the string is
+    contested enough that it should not be handed to a caller who never said
+    which species they meant.
+    """
+    gene = result if isinstance(result, Gene) else getattr(result, "gene", None)
+    if gene is None or gene.species is None:
+        return False
+    return gene.species.gene_is_context_only(gene.name)
+
+
 def _parse_mhc_region_label(seq):
     """
     Parse MHC region labels like MHCIIB, mhc2a, MHC-IA, mhc1.
@@ -1581,6 +1595,13 @@ class Parser:
 
         species, str_after_species = self.parse_species(name=seq, default_species=default_species)
 
+        # When nothing in the token named a species, parse_species hands back
+        # the default species and the whole token as the remainder. A gene
+        # marked `context only` must not be resolved on that assumption: bare
+        # "N" is rat haplotype shorthand, and only "HLA-N" or an explicit
+        # species= argument makes it the human class I fragment. See #113.
+        species_was_named = strict_default_species or str_after_species != seq
+
         if species is not None:
             if len(str_after_species) == 0:
                 parse_candidates.append(species)
@@ -1621,6 +1642,12 @@ class Parser:
                         raise ParseError(
                             f"Unexpected result '{result}' while parsing '{raw_string}'"
                         )
+                if not species_was_named:
+                    parse_candidates = [
+                        candidate
+                        for candidate in parse_candidates
+                        if not _names_context_only_gene(candidate)
+                    ]
         parse_candidates = unique(parse_candidates)
         # update all the objects to set their raw_string field to raw_string
         # and also perform optional transformations

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -777,6 +777,44 @@ class Species(Result):
             return None
         return self.gene_name_to_properties.get(gene_name, MappingProxyType({}))
 
+    def gene_has_no_alleles(self, gene_name):
+        """
+        Does this locus name alleles at all?
+
+        A few loci are named by a nomenclature authority that deposits no
+        sequence for them: IPD-IMGT/HLA 3.65.0 lists HLA-X, HLA-Z, HLA-DQB3,
+        HLA-DPA3, MICC, MICD, MICE, PSMB8 and PSMB9 as genes and gives every
+        one of them zero alleles. Building "HLA-Z*01:01" out of such a name is
+        the pattern issue #108 ruled out -- a confidently structured answer for
+        an input that justifies nothing -- so the entry carries
+        `alleles: none` and `Allele.get_with_gene` refuses it.
+
+        Absence from IPD-IMGT/HLA is *not* what this flag means: CD1a-e, MR1
+        and BTN3A1 are absent from it too because it does not curate them, and
+        they vary. The flag says the authority names the locus and publishes no
+        alleles under it. See issue #113.
+        """
+        properties = self.get_gene_properties(gene_name)
+        return properties is not None and properties.get("alleles") == "none"
+
+    def gene_is_context_only(self, gene_name):
+        """
+        Does this gene name resolve only once the species is already known?
+
+        The species-level analogue is `context only prefixes`, and the reason
+        is the same: the string is real but too contested to hand out to a
+        caller who has not said which species they mean. Every HLA class I gene
+        fragment is a single letter, and bare "N", "R", "S", "U" and "Z" are
+        mouse and rat haplotype shorthand long before they are human gene
+        fragments. Marked genes stay out of `get_species_with_gene_name`, so
+        they never win a species-less parse, while `HLA-N` and
+        `parse("N", species="Homo sapiens")` resolve normally. See issue #113.
+        """
+        # get_gene_properties returns None for a name this species does not
+        # carry, and both callers ask about arbitrary strings.
+        properties = self.get_gene_properties(gene_name)
+        return properties is not None and properties.get("context only") is True
+
     def get_pseudogene_status_of_gene(self, gene_name):
         """Return explicit pseudogene status, or ``None`` when it is not curated."""
         properties = self.get_gene_properties(gene_name)
@@ -843,14 +881,19 @@ class Species(Result):
         return None
 
     @classmethod
-    def get_species_with_gene_name(self, gene_name):
+    def get_species_with_gene_name(self, gene_name, include_context_only: bool = False):
         """
-        Returns list of Species which have the given gene name
+        Returns list of Species which have the given gene name.
+
+        Both callers use this to guess a species from a bare gene name, so by
+        default genes marked `context only` are left out: they are real names
+        which are too contested to imply a species on their own. Pass
+        `include_context_only=True` to ask the raw ontology question instead.
         """
-        if gene_name in gene_name_to_species_objects:
-            return list(gene_name_to_species_objects[gene_name])
-        else:
-            return []
+        species_objects = list(gene_name_to_species_objects.get(gene_name, []))
+        if include_context_only:
+            return species_objects
+        return [s for s in species_objects if not s.gene_is_context_only(gene_name)]
 
     @property
     def is_mouse(self):
@@ -1390,7 +1433,9 @@ def create_species_for_latin_name(latin_name):
             raise ValueError(
                 f"Malformed properties for gene '{canonical_gene_name}' of '{latin_name}'"
             )
-        unexpected_properties = set(raw_properties).difference({"pseudogene"})
+        unexpected_properties = set(raw_properties).difference(
+            {"pseudogene", "alleles", "context only"}
+        )
         if unexpected_properties:
             raise ValueError(
                 f"Unknown properties for gene '{canonical_gene_name}' of '{latin_name}': "
@@ -1400,6 +1445,15 @@ def create_species_for_latin_name(latin_name):
             raise ValueError(
                 f"Pseudogene status for gene '{canonical_gene_name}' of '{latin_name}' "
                 "must be boolean"
+            )
+        if "alleles" in raw_properties and raw_properties["alleles"] != "none":
+            raise ValueError(
+                f"'alleles' for gene '{canonical_gene_name}' of '{latin_name}' is "
+                f"{raw_properties['alleles']!r}; the only accepted value is 'none'"
+            )
+        if "context only" in raw_properties and type(raw_properties["context only"]) is not bool:
+            raise ValueError(
+                f"'context only' for gene '{canonical_gene_name}' of '{latin_name}' must be boolean"
             )
         combined_properties = dict(gene_name_to_properties.get(canonical_gene_name, {}))
         combined_properties.update(raw_properties)

--- a/mhcgnomes/standard_format.py
+++ b/mhcgnomes/standard_format.py
@@ -73,6 +73,12 @@ def parse_standard_allele_format(
 
     if species_prefix is None:
         species = Species.get(default_species)
+        # An assumed species cannot resolve a gene marked `context only`:
+        # "N*01:01" names no species, and bare "N" is rodent haplotype
+        # shorthand. The caller who writes "HLA-N*01:01", or passes
+        # species=, gets it. See Species.gene_is_context_only and issue #113.
+        if species is not None and species.gene_is_context_only(gene_name):
+            return None
     elif len(species_prefix) >= 2 and species_prefix[-1] == "-":
         species = Species.get(species_prefix[:-1])
     else:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.48.3"
+__version__ = "3.49.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,41 +1,45 @@
-# Establish FLA and RLA; correct the citation for the six primate _LA codes
-
-Tracking issue: #131 (46 entries still unestablished)
+# Add the nine HLA class I gene fragments (#113)
 
 ## Review
 
-- **AGENTS.md names the de Groot nomenclature report as the authority for
-  primate prefixes, so I read it** rather than repeating that IPD has no group
-  page for these codes. Extracting the full text of
-  `Groot_Nomenclature_Immunogenetics_2020_3174021.pdf`:
+- **The issue's premise had gone stale, and my own reading of it was wrong.**
+  Fourteen of the nineteen genes it lists were added by #114 and already parse.
+  What remained were the nine class I fragments `N R S T U W X Y Z`, which
+  `species.yaml` deliberately held back with a comment giving two reasons.
 
-  ```
-  Patr 77 hits   Mamu 8   Gogo 7   Popy 3   Mafa 3
-  OmLA / MaLA / GoLA / ChLA / OrLA / RhLA : 0, case-insensitively
-  ```
+- **I had recorded that these nine have no alleles. They do.** IPD-IMGT/HLA
+  3.65.0 `Allelelist.txt` (2026-07-14) gives W 13, T 9, S and U 7 each, N 5,
+  Y 3, R 2 -- only X and Z have none. So `HLA-W*01:01:01:01` is a real allele
+  name that should parse, and a blanket "these name no alleles" rule would
+  have been wrong for seven of the nine. Read the allele list, not the gene
+  list.
 
-  The extraction is sound -- the 2+2 codes the report does use are all there.
-  So the six primate `_LA` codes are absent from it.
+- **Two properties, because the held-back comment named two distinct hazards.**
+  - `alleles: none` -- the authority names the locus and deposits nothing under
+    it. `Allele.get_with_gene` refuses to build on such a gene, so `HLA-Z`
+    resolves and `HLA-Z*01:01` is None. This also closes a live gap: today
+    `HLA-MICC*01:01` and `HLA-DQB3*01:01` mint alleles for loci with zero
+    deposited sequences. Nine loci carry it.
+  - `context only: true` -- the gene stays out of species-less lookup, the
+    gene-level analogue of `context only prefixes`. Bare `N` stays `RT1-n` and
+    bare `S` stays `H2-s`; `HLA-N` and `parse("N", species="Homo sapiens")`
+    resolve.
 
-- **That matters because the mhcseqs registry cites exactly that paper as their
-  evidence.** `mhc_prefix_aliases.csv` gives all six
-  `status: literature_historical` with the de Groot PDF as the URL, and the PDF
-  does not contain them. The citation does not check out, so they stay `None`.
-  Marking them designated on it would be the `Caau` mistake with a footnote.
+- **The guard had to go in three places, not one.** The bare-token path, the
+  species-inference path in `parse_species`, and `parse_standard_allele_format`
+  -- which returns before either, so `N*01:01` was still resolving to human
+  after the first two were done.
 
-- **Two of the eight had different evidence, and it holds.** Read from PubMed
-  directly rather than the search summary:
-  - `FLA` -- PMID 2492667, *"Genetic characterization of FLA, the cat major
-    histocompatibility complex"*, and the abstract says "the major
-    histocompatibility complex (MHC) of the domestic cat (termed FLA)".
-  - `RLA` -- PMID 32522857, whose title names "rabbit Major Histocompatibility
-    Complex Class I Molecule **RLA-A1**", so alleles carry the prefix.
+- **A test encoded the gap as a fact.** `test_nonsense_inputs.py` listed
+  `HLA-X` under "X is not a valid gene". IMGT/HLA names it. Replaced with
+  positive coverage and a note.
 
-  Both marked `designated` with the citation on the entry.
+- **P and V are deliberately not `context only`.** They are equally single
+  letters, but bare `P` and `V` have meant `HLA-P`/`HLA-V` since long before
+  this; flipping them to `H2-p`/`H2-v` is a parser policy question about
+  ambiguous bare tokens, which is #130. Adding data should not quietly move
+  parses that already exist.
 
-- **#131 is now 130 designated / 46 unknown**, from 11/163 when it was filed.
-  The canary list drops from eight names to six, with the reason recorded next
-  to it so the next reader does not re-follow the same broken citation.
-
-- **Measured:** 0 of 11,558 corpus names change.
-- Bumped to 3.48.3.
+- **Measured:** 0 of 25,200 corpus names change. 15,996 tests pass. Disabling
+  either new mechanism fails 29 of the new tests, so they are not vacuous.
+- Bumped to 3.49.0.

--- a/tests/test_hla_class1_fragments.py
+++ b/tests/test_hla_class1_fragments.py
@@ -1,0 +1,248 @@
+"""
+The HLA class I gene fragments, and the two properties they needed.
+
+IMGT/HLA names nine class I loci we did not carry -- N, R, S, T, U, W, X, Y and
+Z -- and the reason they stayed out was never that they are unattested. It was
+that adding them naively does two wrong things: it flips bare "N", "R", "S",
+"U" and "Z" from mouse and rat haplotype shorthand into human gene fragments,
+and it lets loci with no deposited sequence accept allele fields.
+
+So the entries carry `context only: true` (stay out of species-less lookup) and,
+where IPD-IMGT/HLA deposits nothing at all, `alleles: none`.
+
+Allele counts checked against IPD-IMGT/HLA 3.65.0 Allelelist.txt (2026-07-14),
+https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/Allelelist.txt
+
+https://github.com/pirl-unc/mhcgnomes/issues/113
+"""
+
+import contextlib
+
+import pytest
+
+from mhcgnomes import Allele, Gene, Species, parse
+
+from .common import eq_, ok_
+
+
+@contextlib.contextmanager
+def temporary_species_entry(latin_name, entry):
+    """
+    Add an entry to the loaded ontology for the body of a test and take it out
+    again, so a failing assertion cannot leave a synthetic species behind.
+    """
+    from mhcgnomes.species import raw_species_dict
+
+    raw_species_dict[latin_name] = entry
+    try:
+        yield
+    finally:
+        del raw_species_dict[latin_name]
+
+
+# Every class I locus IMGT/HLA calls a "gene fragment" in its Description
+# column: https://hla.alleles.org/genes/index.html
+FRAGMENTS = ["N", "P", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+
+# The nine added for #113; P and V were already here.
+CONTEXT_ONLY = ["N", "R", "S", "T", "U", "W", "X", "Y", "Z"]
+
+# Loci IMGT/HLA names and IPD-IMGT/HLA gives zero alleles.
+NO_ALLELES = ["X", "Z", "DQB3", "DPA3", "MICC", "MICD", "MICE", "PSMB8", "PSMB9"]
+
+# One real allele name per fragment that has them, from Allelelist.txt.
+ATTESTED_ALLELES = {
+    "N": "N*01:01:01:01",
+    "P": "P*01:01:01:01",
+    "R": "R*01:01:01:01",
+    "S": "S*01:01:01:01",
+    "T": "T*01:01:01:01",
+    "U": "U*01:01:01:01",
+    "V": "V*01:01:01:01",
+    "W": "W*01:01:01:01",
+    "Y": "Y*01:01",
+}
+
+
+@pytest.mark.parametrize("gene_name", FRAGMENTS)
+def test_fragment_resolves_under_the_hla_prefix(gene_name):
+    gene = parse(f"HLA-{gene_name}", required_result_types=[Gene])
+    eq_(gene.name, gene_name)
+    ok_(gene.species.is_human)
+
+
+@pytest.mark.parametrize("gene_name", FRAGMENTS)
+def test_every_fragment_is_a_pseudogene(gene_name):
+    ok_(Species.get("HLA").get_pseudogene_status_of_gene(gene_name))
+
+
+@pytest.mark.parametrize("gene_name,allele_name", sorted(ATTESTED_ALLELES.items()))
+def test_attested_allele_names_parse(gene_name, allele_name):
+    allele = parse(f"HLA-{allele_name}", required_result_types=[Allele])
+    eq_(allele.gene.name, gene_name)
+
+
+@pytest.mark.parametrize("gene_name", NO_ALLELES)
+def test_locus_without_deposited_alleles_names_no_allele(gene_name):
+    # The gene itself is a real name and still resolves...
+    gene = parse(f"HLA-{gene_name}", required_result_types=[Gene])
+    eq_(gene.name, gene_name)
+    # ...but nothing may be built on top of it. Issue #108: a confidently
+    # structured answer for an input that justifies nothing is worse than None.
+    eq_(parse(f"HLA-{gene_name}*01:01", raise_on_error=False), None)
+    eq_(parse(f"HLA-{gene_name}*01", raise_on_error=False), None)
+
+
+@pytest.mark.parametrize("gene_name", NO_ALLELES)
+def test_allele_factory_refuses_a_locus_with_no_alleles(gene_name):
+    # Not just the parser: the object cannot be constructed either, or callers
+    # would route around the check.
+    eq_(Allele.get("HLA", gene_name, "01", "01"), None)
+
+
+@pytest.mark.parametrize("gene_name", CONTEXT_ONLY)
+def test_context_only_fragment_never_wins_a_speciesless_parse(gene_name):
+    result = parse(gene_name, raise_on_error=False)
+    if result is None:
+        return
+    ok_(
+        not (isinstance(result, Gene) and result.species.is_human),
+        f"bare {gene_name!r} resolved to the human fragment: {result}",
+    )
+
+
+def test_bare_letters_that_are_haplotype_shorthand_stay_haplotypes():
+    # The regression the nine genes had to avoid. Mouse and rat rodent
+    # haplotype letters are what these strings have always meant.
+    for letter, expected in [
+        ("N", "RT1-n"),
+        ("R", "H2-r"),
+        ("S", "H2-s"),
+        ("U", "H2-u"),
+        ("Z", "H2-z"),
+    ]:
+        eq_(parse(letter).to_string(), expected)
+
+
+def test_bare_letters_with_no_other_claimant_stay_unparsed():
+    for letter in ["T", "W", "X", "Y"]:
+        eq_(parse(letter, raise_on_error=False), None)
+
+
+@pytest.mark.parametrize("gene_name", CONTEXT_ONLY)
+def test_naming_the_species_resolves_a_context_only_fragment(gene_name):
+    # species= is the strict form, so there is nothing left to guess.
+    gene = parse(gene_name, species="Homo sapiens", required_result_types=[Gene])
+    eq_(gene.name, gene_name)
+
+
+@pytest.mark.parametrize("gene_name,allele_name", sorted(ATTESTED_ALLELES.items()))
+def test_allele_of_a_context_only_fragment_needs_the_species_too(gene_name, allele_name):
+    # "N*01:01" is standard allele format, which resolves the species from the
+    # default rather than from the string, so it needs the same guard as the
+    # bare gene name -- and P and V, which are not context only, keep working.
+    parsed = parse(allele_name, raise_on_error=False)
+    if gene_name in CONTEXT_ONLY:
+        eq_(parsed, None)
+    else:
+        eq_(parsed.gene.name, gene_name)
+    eq_(parse(f"HLA-{allele_name}", required_result_types=[Allele]).gene.name, gene_name)
+    eq_(
+        parse(allele_name, species="Homo sapiens", required_result_types=[Allele]).gene.name,
+        gene_name,
+    )
+
+
+def test_naming_the_species_also_resolves_alleles_of_a_fragment():
+    allele = parse("W*01:01:01:01", species="Homo sapiens", required_result_types=[Allele])
+    eq_(allele.gene.name, "W")
+    eq_(allele.to_string(), "HLA-W*01:01:01:01")
+
+
+def test_naming_a_different_species_does_not_resolve_the_fragment():
+    # The rescue is not a licence to ignore species=.
+    eq_(parse("W", species="Mus musculus", raise_on_error=False), None)
+    eq_(parse("N", species="Rattus norvegicus").to_string(), "Rano-n")
+
+
+@pytest.mark.parametrize("gene_name", CONTEXT_ONLY)
+def test_context_only_genes_are_hidden_from_species_inference(gene_name):
+    human = Species.get("HLA")
+    ok_(human not in Species.get_species_with_gene_name(gene_name))
+    ok_(human in Species.get_species_with_gene_name(gene_name, include_context_only=True))
+
+
+def test_properties_answer_for_the_genes_that_carry_them():
+    human = Species.get("HLA")
+    for gene_name in CONTEXT_ONLY:
+        ok_(human.gene_is_context_only(gene_name))
+    for gene_name in NO_ALLELES:
+        ok_(human.gene_has_no_alleles(gene_name))
+    # A gene absent from IPD-IMGT/HLA is not thereby allele-less: CD1 and MR1
+    # vary, IMGT/HLA just does not curate them. The flag means the authority
+    # names the locus and publishes nothing under it.
+    for gene_name in ["A", "DRB1", "CD1a", "MR1", "N", "W"]:
+        ok_(not human.gene_has_no_alleles(gene_name))
+    for gene_name in ["A", "DRB1", "P", "V", "H"]:
+        ok_(not human.gene_is_context_only(gene_name))
+
+
+# ---------------------------------------------------------------------------
+# The two new `gene properties` keys validate their values
+#
+# A property the loader silently ignores is worse than no property, because
+# species.yaml then asserts something the runtime never reads -- the same trap
+# `prefix_source` vs `prefix source` set in test_species_identity.py.
+# ---------------------------------------------------------------------------
+
+BAD_PROPERTIES = [
+    # key,             value,        expected message fragment
+    ("allele", "none", "Unknown properties"),  # near-miss spelling
+    ("context_only", True, "Unknown properties"),  # underscore, not a space
+    ("alleles", "None", "alleles"),  # capitalized: not the accepted literal
+    ("alleles", "some", "alleles"),
+    ("alleles", True, "alleles"),
+    ("alleles", ["none"], "alleles"),
+    ("context only", "true", "context only"),  # string, not a boolean
+    ("context only", 1, "context only"),
+]
+
+
+@pytest.mark.parametrize("key,value,message", BAD_PROPERTIES)
+def test_malformed_gene_properties_are_rejected(key, value, message):
+    from mhcgnomes.species import create_species_for_latin_name
+
+    entry = {
+        "prefix": "TestProp",
+        "name": "test",
+        "genes": {"I": ["Q"]},
+        "gene properties": {"Q": {key: value}},
+    }
+    with (
+        temporary_species_entry("Test property sp.", entry),
+        pytest.raises(ValueError, match=message),
+    ):
+        create_species_for_latin_name("Test property sp.")
+
+
+@pytest.mark.parametrize(
+    "latin_name,key,value",
+    [
+        ("Test alleles sp.", "alleles", "none"),
+        ("Test context sp.", "context only", True),
+    ],
+)
+def test_well_formed_gene_properties_load(latin_name, key, value):
+    # A distinct latin name per case: create_species_for_latin_name memoizes,
+    # so reusing one name would hand the second case the first one's species.
+    from mhcgnomes.species import create_species_for_latin_name
+
+    entry = {
+        "prefix": "TestProp",
+        "name": "test",
+        "genes": {"I": ["Q"]},
+        "gene properties": {"Q": {key: value}},
+    }
+    with temporary_species_entry(latin_name, entry):
+        species = create_species_for_latin_name(latin_name)
+        eq_(species.get_gene_properties("Q").get(key), value)

--- a/tests/test_nonsense_inputs.py
+++ b/tests/test_nonsense_inputs.py
@@ -88,15 +88,30 @@ class TestPartialInputs:
     @pytest.mark.parametrize(
         "inp",
         [
-            "HLA-X",  # X is not a valid gene
             "HLA-Z99",
-            "Z*01:01",  # Z is not a valid gene letter
+            # Z is a real locus, but IPD-IMGT/HLA deposits no sequence under
+            # it, so it names no allele -- and a bare "Z*01:01" does not name
+            # a species either. See tests/test_hla_class1_fragments.py.
+            "Z*01:01",
+            "HLA-Z*01:01",
         ],
     )
     def test_invalid_genes_rejected(self, inp):
         """Invalid gene names should be rejected."""
         with pytest.raises(ParseError):
             parse(inp)
+
+    def test_class1_gene_fragments_are_valid_genes(self):
+        """
+        "HLA-X" was listed as an invalid gene here until #113. IMGT/HLA names
+        it, and eight more class I fragments, at
+        https://hla.alleles.org/genes/index.html -- the test was encoding a gap
+        in our ontology as a fact about the nomenclature.
+        """
+        for gene_name in ["N", "R", "S", "T", "U", "W", "X", "Y", "Z"]:
+            result = parse(f"HLA-{gene_name}")
+            assert isinstance(result, Gene)
+            assert result.name == gene_name
 
 
 class TestMalformedAlleles:


### PR DESCRIPTION
Closes #113.

IMGT/HLA names class I gene fragments `N R S T U W X Y Z`, and `species.yaml`
held them back with a comment giving two reasons: adding them flips bare `n`,
`s`, `u` from mouse and rat haplotype shorthand into human genes, and lets
fragments with no deposited sequence accept allele fields. Both are real, and
they need different answers.

### `alleles: none`

A locus whose own authority deposits nothing under it names no allele.
[IPD-IMGT/HLA 3.65.0 `Allelelist.txt`](https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/Allelelist.txt)
(2026-07-14) gives zero alleles to `HLA-X`, `HLA-Z`, `HLA-DQB3`, `HLA-DPA3`,
`MICC`, `MICD`, `MICE`, `PSMB8` and `PSMB9`. `Allele.get_with_gene` refuses to
build on those, so `HLA-Z` resolves and `HLA-Z*01:01` is `None` — issue #108's
principle. That also closes a live gap: `HLA-MICC*01:01` and `HLA-DQB3*01:01`
mint alleles on `main` today.

**I had this backwards on the issue.** I wrote that all nine fragments were
allele-less; that came from reading the gene list rather than the allele list.
Seven of them have alleles — W 13, T 9, S and U 7 each, N 5, Y 3, R 2 — so
`HLA-W*01:01:01:01` is a real name and now parses.

### `context only: true`

The gene-level analogue of `context only prefixes`: the gene stays out of
species-less lookup and resolves once the species is named.

| input | `main` | here |
|---|---|---|
| `N` | `RT1-n` | `RT1-n` |
| `S` | `H2-s` | `H2-s` |
| `HLA-N` | `None` | `HLA-N` |
| `parse("N", species="Homo sapiens")` | `None` | `HLA-N` |
| `HLA-W*01:01:01:01` | `None` | `HLA-W*01:01:01:01` |
| `HLA-Z*01:01` | `None` | `None` |
| `HLA-MICC*01:01` | `HLA-MICC*01:01` | `None` |

The guard is needed in three places, not one: the bare-token path, species
inference from a gene name, and `parse_standard_allele_format`, which returns
before either and was still resolving `N*01:01` to human after the first two
were done.

`P` and `V` are equally single letters and stay resolvable bare. That
behaviour predates this PR, and flipping them to `H2-p`/`H2-v` is a parser
policy question about ambiguous bare tokens — #130 — not a side effect of
adding data.

### Also

`tests/test_nonsense_inputs.py` listed `HLA-X` under "X is not a valid gene",
encoding our own gap as a fact about the nomenclature. Replaced with positive
coverage over all nine.

### Measurement

- 0 of 25,200 corpus names change.
- 15,996 tests pass; 91 new ones.
- Disabling either mechanism fails 29 of the new tests, so they are not vacuous.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH