### PR TITLE
Do not assign a species to a gene symbol shared across lineages (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,23 @@ Provenance is not part of a result's identity: two alleles that differ only in
 how their species was determined still compare equal and hash the same. It is
 also computed only when asked, so it costs nothing if you never look.
 
+A gene symbol only carries a species when it belongs to one lineage. `DRB1` is
+declared by 45 species across humans, cattle, dogs and horses, so on its own it
+names none of them:
+
+```python
+>>> parse("DRB1*01:01", default_species=None, raise_on_error=False) is None
+True
+>>> parse("DRB1*01:01").to_string()  # with the default species, as before
+'HLA-DRB1*01:01'
+>>> parse("BLB2*02").to_string()  # chicken and the Galliformes node: one lineage
+'Gaga-BLB2*02'
+```
+
+A species that uses a shared symbol but does not own its bare form says so in
+the ontology with `context only`, which is why `BF2*02:01` still resolves to
+the chicken although the guineafowl also has a BF2.
+
 ## How many digits per field?
 
 Originally alleles for many genes were numbered with two digits:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -4342,7 +4342,20 @@ Numida meleagris:
   name: Helmeted guineafowl
   genes:
     Ia:
+      # Real, and deposited under exactly this name: GenBank EU430728.1 and
+      # EF643463.1 are both "Numida meleagris MHC class I antigen (BF2) mRNA,
+      # partial cds".
+      #
+      # `context only` because the bare form belongs to the chicken. BF2 is
+      # chicken B-F nomenclature, and the bare spelling is what IEDB publishes
+      # chicken alleles under -- BF2*2101, BF2*0401, BF2*1301 and more, 170
+      # assay entries between them (tests/iedb_allele_counts.csv). Nothing is
+      # published as a guineafowl BF2 allele. So "NumiMele-BF2" resolves and a
+      # bare "BF2*21:01" stays with Gallus gallus rather than becoming
+      # ambiguous between the two. See issue #130.
       - BF2
+  gene properties:
+    BF2: {context only: true}
 Perdix perdix:
   parent: Galliformes sp.
   prefix: PerdPerd

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import re
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
@@ -62,6 +63,22 @@ _MHC_REGION_RE = re.compile(
     r"^mhc[-_]?(I{1,3}|1|2)(a|b)?$",
     re.IGNORECASE,
 )
+
+
+def _lie_in_one_lineage(species_objects):
+    """
+    Is every one of these species an ancestor or descendant of every other?
+
+    A gene declared by a group node and by species beneath it names one lineage,
+    however many entries see it. A gene declared by a chicken and a guineafowl
+    names two, and picking between them is a guess.
+    """
+    for first, second in itertools.combinations(species_objects, 2):
+        if first is second:
+            continue
+        if not (first.is_ancestor_of(second) or second.is_ancestor_of(first)):
+            return False
+    return True
 
 
 def _names_context_only_gene(result):
@@ -1380,18 +1397,32 @@ class Parser:
         # "Ia1" belongs to Paralichthys olivaceus and "IA1" to Chrysolophus
         # pictus.  Prefer the species that spells the gene the way the caller
         # did before falling back to a case-insensitive match.
+        #
+        # Ranking the declarers was enough for BLB2, where the two are a group
+        # node and its own descendant, but it silently answered DRB1 too --
+        # ranking 45 unrelated declarers by gene-list size and returning
+        # Macaca fascicularis for a symbol shared by humans, cattle, dogs and
+        # horses. So the ranking now only runs when the declarers lie in a
+        # single lineage; otherwise the name names no species and this returns
+        # None, which is what issue #108 established for input that justifies
+        # nothing. A species which does use the name but does not own its bare
+        # form says so with `context only` in the ontology. See issue #130.
         if species is None and len(species_candidates) > 1 and any(c.isdigit() for c in gene_name):
-            species = max(
-                species_candidates,
-                key=lambda s: (
-                    s.declares_gene_with_same_case(gene_name),
-                    s.declares_gene(gene_name),
-                    s.num_genes,
-                    # purely so a genuine tie resolves the same way every run;
-                    # a later latin name is not a better answer
-                    s.name,
-                ),
-            )
+            declarers = [s for s in species_candidates if s.declares_gene_with_same_case(gene_name)]
+            if not declarers:
+                declarers = [s for s in species_candidates if s.declares_gene(gene_name)]
+            if len(declarers) == 1:
+                species = declarers[0]
+            elif len(declarers) > 1 and _lie_in_one_lineage(declarers):
+                species = max(
+                    declarers,
+                    key=lambda s: (
+                        s.num_genes,
+                        # purely so a genuine tie resolves the same way every
+                        # run; a later latin name is not a better answer
+                        s.name,
+                    ),
+                )
         if species is None:
             return None
         return Gene.get(species, gene_name)

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -1661,7 +1661,13 @@ def species_named_in(name):
     matches = []
 
     species_from_prefix = infer_species_from_prefix(name)
-    if species_from_prefix is not None:
+    # The second element is the part of the string that matched. It is empty
+    # when infer_species_from_prefix fell through to its last resort and
+    # inferred the species from a gene name unique to one entry, which is the
+    # opposite of naming it: "A8*01:01" reported its species as explicit, so
+    # require_explicit_species accepted a string that names no species at all.
+    # 98 gene names took that route. See issue #130.
+    if species_from_prefix is not None and species_from_prefix[1]:
         matches.append(species_from_prefix[0])
 
     tokenization_result = tokenize(name)

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.49.0"
+__version__ = "3.50.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,45 +1,44 @@
-# Add the nine HLA class I gene fragments (#113)
+# Do not assign a species to a gene symbol shared across lineages (#130)
 
 ## Review
 
-- **The issue's premise had gone stale, and my own reading of it was wrong.**
-  Fourteen of the nineteen genes it lists were added by #114 and already parse.
-  What remained were the nine class I fragments `N R S T U W X Y Z`, which
-  `species.yaml` deliberately held back with a comment giving two reasons.
+- **The rule.** `Parser.parse_gene_without_species` ranked every species that
+  declares a digit-bearing gene name and returned the one with the longest gene
+  list. That was written for `BLB2`, whose two declarers are `Galliformes sp.`
+  and its own descendant `Gallus gallus`. Applied to `DRB1` it ranked 45
+  unrelated declarers and returned *Macaca fascicularis*. The ranking now runs
+  only when the declarers lie in a single lineage; otherwise the name names no
+  species, per #108.
 
-- **I had recorded that these nine have no alleles. They do.** IPD-IMGT/HLA
-  3.65.0 `Allelelist.txt` (2026-07-14) gives W 13, T 9, S and U 7 each, N 5,
-  Y 3, R 2 -- only X and Z have none. So `HLA-W*01:01:01:01` is a real allele
-  name that should parse, and a blanket "these name no alleles" rule would
-  have been wrong for seven of the nine. Read the allele list, not the gene
-  list.
+- **`BF2` was the one real casualty, and it is real.** IEDB publishes chicken
+  alleles under the bare form -- `BF2*2101` (82 assay entries), `BF2*0401`
+  (33), `BF2*1301` (30), and more. But GenBank EU430728.1 and EF643463.1 are
+  both "Numida meleagris MHC class I antigen (BF2) mRNA", so the guineafowl's
+  BF2 is not a curation error either and could not just be deleted.
 
-- **Two properties, because the held-back comment named two distinct hazards.**
-  - `alleles: none` -- the authority names the locus and deposits nothing under
-    it. `Allele.get_with_gene` refuses to build on such a gene, so `HLA-Z`
-    resolves and `HLA-Z*01:01` is None. This also closes a live gap: today
-    `HLA-MICC*01:01` and `HLA-DQB3*01:01` mint alleles for loci with zero
-    deposited sequences. Nine loci carry it.
-  - `context only: true` -- the gene stays out of species-less lookup, the
-    gene-level analogue of `context only prefixes`. Bare `N` stays `RT1-n` and
-    bare `S` stays `H2-s`; `HLA-N` and `parse("N", species="Homo sapiens")`
-    resolve.
+  Resolved with the `context only` property #113 added: the guineafowl declares
+  BF2, `NumiMele-BF2` resolves, and the bare form stays with the chicken. The
+  attested side gets the bare name, the same rule AGENTS.md states for prefixes.
 
-- **The guard had to go in three places, not one.** The bare-token path, the
-  species-inference path in `parse_species`, and `parse_standard_allele_format`
-  -- which returns before either, so `N*01:01` was still resolving to human
-  after the first two were done.
+- **My corpus was lying to me.** The 25,200-name set I had been measuring
+  against did not include `tests/iedb_allele_counts.csv` or the bundled
+  netMHCpan lists. It reported 0 differences for this change while 17 tests
+  failed, nearly all of them BF2. Rebuilt to 36,752 names; the rebuilt corpus
+  showed the 8 BF2 forms immediately.
 
-- **A test encoded the gap as a fact.** `test_nonsense_inputs.py` listed
-  `HLA-X` under "X is not a valid gene". IMGT/HLA names it. Replaced with
-  positive coverage and a note.
+- **A pre-existing provenance bug, found on the way.**
+  `infer_species_from_prefix` falls back to a gene name unique to one species
+  and returns an empty matched string to say nothing in the input matched.
+  `species_named_in` counted it anyway, so `species_source` reported
+  **"explicit"** for `A8*01:01`, and `require_explicit_species=True` -- whose
+  entire job is rejecting an inferred species -- accepted it. 98 gene names
+  took that route. Fixed by honouring the sentinel.
 
-- **P and V are deliberately not `context only`.** They are equally single
-  letters, but bare `P` and `V` have meant `HLA-P`/`HLA-V` since long before
-  this; flipping them to `H2-p`/`H2-v` is a parser policy question about
-  ambiguous bare tokens, which is #130. Adding data should not quietly move
-  parses that already exist.
+- **Filed #160** for the reason `Ia1` can no longer resolve: the tokenizer
+  lower-cases before `declares_gene_with_same_case` is ever consulted, so the
+  case-aware ranking key the code comments describe has never fired in the
+  normal path.
 
-- **Measured:** 0 of 25,200 corpus names change. 15,996 tests pass. Disabling
-  either new mechanism fails 29 of the new tests, so they are not vacuous.
-- Bumped to 3.49.0.
+- **Measured:** 0 of 36,752 corpus names change. 16,011 tests pass. Reverting
+  either mechanism fails 9 of the new tests.
+- Bumped to 3.50.0.

--- a/tests/test_ambiguous_species_inference.py
+++ b/tests/test_ambiguous_species_inference.py
@@ -161,21 +161,111 @@ def test_bare_gene_resolves_to_a_species_that_declares_it():
     Every candidate under a broad parent group can see that group's genes, so
     the winner must be one that actually uses the name rather than whichever
     inheritor happens to have the largest gene list.
+
+    Ranking the declarers is only allowed to settle it when they lie in one
+    lineage -- see test_bare_gene_shared_across_lineages_names_no_species,
+    which took DBB1, DAB1 and Ia1 out of this list.
     """
     for gene_name, expected in [
+        # a group node and its own descendant: one lineage
         ("BLB2", "Gallus gallus"),
         ("BLB1", "Gallus gallus"),
+        # chicken and guineafowl are not one lineage, but the guineafowl's
+        # BF2 is marked `context only`, leaving the chicken sole claimant
         ("BF2", "Gallus gallus"),
-        # quail's own class II beta genes stay with the quail
-        ("DBB1", "Coturnix japonica"),
-        # these were reassigned to an inheriting group when the ranking
-        # measured gene-list size instead of declaration
-        ("DAB1", "Crocodylus porosus"),
-        ("Ia1", "Paralichthys olivaceus"),
     ]:
         result = parse(gene_name)
         eq_(result.species.name, expected)
         assert result.species.declares_gene(gene_name), gene_name
+
+
+# ---------------------------------------------------------------------------
+# 3. A gene symbol shared across lineages names no species
+# https://github.com/pirl-unc/mhcgnomes/issues/130
+# ---------------------------------------------------------------------------
+
+# The report: every one of these resolved to Macaca fascicularis, which
+# declares the symbol and happened to have the longest gene list among the
+# 45 species that do.
+CLASS2_SYMBOLS_SHARED_ACROSS_SPECIES = [
+    "DRB1*01:01",
+    "DQA1*01:01",
+    "DQB1*05:01",
+    "DPA1*01:03",
+    "DPB1*04:01",
+]
+
+
+@pytest.mark.parametrize("name", CLASS2_SYMBOLS_SHARED_ACROSS_SPECIES)
+def test_shared_class2_symbol_names_no_species_on_its_own(name):
+    eq_(parse(name, default_species=None, raise_on_error=False), None)
+
+
+@pytest.mark.parametrize("name", CLASS2_SYMBOLS_SHARED_ACROSS_SPECIES)
+def test_shared_class2_symbol_still_uses_the_default_species(name):
+    # The fix must not touch the ordinary human case: a caller who left
+    # default_species alone is asking for the human reading.
+    result = parse(name)
+    eq_(result.species.name, "Homo sapiens")
+    eq_(result.species_source, "default")
+
+
+@pytest.mark.parametrize(
+    "gene_name,declarers",
+    [
+        # quail class II beta versus the ray-finned fish group node
+        ("DBB1", ["Coturnix japonica", "Actinopterygii sp."]),
+        # nine declarers across crocodiles, amphibians, birds, fish and
+        # marsupials; the saltwater crocodile used to win on gene count
+        ("DAB1", ["Crocodylus porosus", "Amphibia sp."]),
+        # flounder "Ia1" and golden pheasant "IA1" normalize to one key, and
+        # the tokenizer lower-cases before the parser ever sees the spelling,
+        # so nothing can tell these apart. See #160.
+        ("Ia1", ["Paralichthys olivaceus", "Chrysolophus pictus"]),
+    ],
+)
+def test_bare_gene_shared_across_lineages_names_no_species(gene_name, declarers):
+    for latin_name in declarers:
+        species = Species.get_by_latin_name(latin_name)
+        assert species.declares_gene(gene_name), f"{latin_name} no longer declares {gene_name}"
+    eq_(parse(gene_name, raise_on_error=False), None)
+    # naming the species still works, which is the whole point of refusing to
+    # guess one
+    eq_(
+        parse(f"{Species.get_by_latin_name(declarers[0]).prefix}-{gene_name}").species.name,
+        declarers[0],
+    )
+
+
+def test_guineafowl_bf2_is_real_but_does_not_claim_the_bare_name():
+    """
+    GenBank EU430728.1 and EF643463.1 are both "Numida meleagris MHC class I
+    antigen (BF2) mRNA", so the gene is not a curation error. What the
+    guineafowl does not have is the bare form: IEDB publishes chicken alleles
+    as BF2*2101, BF2*0401 and so on, and nothing is published as a guineafowl
+    BF2 allele.
+    """
+    guineafowl = Species.get_by_latin_name("Numida meleagris")
+    assert guineafowl.declares_gene("BF2")
+    assert guineafowl.gene_is_context_only("BF2")
+    eq_(parse("NumiMele-BF2").species.name, "Numida meleagris")
+    eq_(parse("NumiMele-BF2*01:01").species.name, "Numida meleagris")
+    eq_(parse("BF2*02:01").species.name, "Gallus gallus")
+
+
+def test_species_inferred_from_a_gene_name_is_not_reported_as_explicit():
+    """
+    `infer_species_from_prefix` falls back to a gene name unique to one
+    species and returns an empty matched string to say so. `species_named_in`
+    counted it anyway, so `require_explicit_species` -- whose entire job is
+    rejecting an inferred species -- accepted "A8*01:01", where nothing names
+    a species. 98 gene names took that route.
+    """
+    for name in ["A8*01:01", "BF2*02:01", "B12c*01:01"]:
+        eq_(parse(name).species_source, "inferred")
+        eq_(parse(name, require_explicit_species=True, raise_on_error=False), None)
+    # and a string that does name its species is unaffected
+    eq_(parse("Gaga-BLB2*02", require_explicit_species=True).species.name, "Gallus gallus")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #130.

`parse_gene_without_species` ranked every species declaring a digit-bearing
gene name and returned whichever had the longest gene list. That tie-break was
written for `BLB2`, whose two declarers are `Galliformes sp.` and its own
descendant `Gallus gallus`. Applied to `DRB1` it ranked **45 unrelated
declarers** — humans, cattle, dogs, horses — and returned *Macaca fascicularis*.

The ranking now runs only when the declarers lie in a single lineage.

| input | `main` | here |
|---|---|---|
| `parse("DRB1*01:01", default_species=None)` | `Mafa-DRB1*01:01` | `None` |
| `parse("DQA1*01:01", default_species=None)` | `Mafa-DQA1*01:01` | `None` |
| `parse("DRB1*01:01")` | `HLA-DRB1*01:01` | `HLA-DRB1*01:01` |
| `parse("BLB2*02")` | `Gaga-BLB2*02` | `Gaga-BLB2*02` |
| `parse("BF2*02:01")` | `Gaga-BF2*02:01` | `Gaga-BF2*02:01` |
| `parse("A8*01:01").species_source` | `"explicit"` | `"inferred"` |

### BF2, the case I flagged on the issue

I asked there whether `BF2` should keep resolving to chicken. It should, and
the evidence is in our own test data: IEDB publishes chicken alleles under the
bare form — `BF2*2101` (82 assay entries), `BF2*0401` (33), `BF2*1301` (30),
`BF2*0201`, `BF2*1201`. But the competing declarer is not a curation error
either: GenBank [EU430728.1](https://www.ncbi.nlm.nih.gov/nuccore/EU430728.1)
and [EF643463.1](https://www.ncbi.nlm.nih.gov/nuccore/EF643463.1) are both
*"Numida meleagris MHC class I antigen (BF2) mRNA"*.

So the guineafowl's `BF2` is marked `context only`, the gene property #113
added: `NumiMele-BF2` resolves, and the bare form stays with the chicken. The
attested side gets the bare name — the rule `AGENTS.md` already states for
prefixes, applied to a gene.

`DBB1`, `DAB1` and `Ia1` do become `None`, and no corpus contains them. Their
assertions in `test_ambiguous_species_inference.py` were added by #105 and
assert only that the winner declares the symbol, which is the same
over-confidence this issue reports.

### A provenance bug found on the way

`infer_species_from_prefix` falls back to a gene name unique to one species and
returns an **empty matched string** to signal that nothing in the input matched.
`species_named_in` counted it anyway, so `A8*01:01` reported
`species_source == "explicit"` and `require_explicit_species=True` — whose
entire job is rejecting an inferred species — accepted a string that names no
species at all. 98 gene names took that route on `main`.

### The corpus was lying to me

The 25,200-name set I have been measuring against did not include
`tests/iedb_allele_counts.csv` or the bundled netMHCpan lists. It reported **0
differences** for this change while 17 tests failed, nearly all BF2. Rebuilt to
36,752 unique names; the rebuilt corpus surfaced the 8 BF2 forms immediately.

### Measurement

- 0 of 36,752 corpus names change.
- 16,011 tests pass.
- Reverting either mechanism fails 9 of the new tests.

Filed #160 for why `Ia1` can no longer resolve: the tokenizer lower-cases
before `declares_gene_with_same_case` is consulted, so that ranking key has
never fired in the normal path.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH