### PR TITLE
Curate SLA (swine) haplotypes (#143)

### DIFF
--- a/mhcgnomes/data/haplotypes.yaml
+++ b/mhcgnomes/data/haplotypes.yaml
@@ -1,20 +1,88 @@
 #########################################
-# Swine MHC haplotypes copied from:
-#   https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5472656/
+# Swine (SLA) MHC haplotypes
+#
+# Naming. The ISAG/IUIS-VIC SLA Nomenclature Committee gives swine haplotypes
+# their own prefix, separate from the SLA- used for genes and alleles, and two
+# series of it: `Hp-` for high-resolution haplotypes, defined by sequenced
+# alleles, and `Lr-` for low-resolution ones, defined by PCR-SSP allele groups.
+# The number is <class I>.<class II>, so a class I haplotype ends in ".0" and a
+# class II one begins with "0." -- Hp-04.0 and Hp-0.03 are the two halves of
+# the NIH/MGH minipig's type, not variants of one thing.
+#
+# Both facts are stated in Reiner et al. 2024 (PMC10925748, Göttingen Minipig
+# SLA diversity): "SLA class I ... and class II ... genes were characterized by
+# PCR-based low-resolution (Lr) haplotyping. Criteria and nomenclature used for
+# SLA haplotyping were proposed by the ISAG/IUIS-VIC SLA Nomenclature
+# Committee", alongside class I types Lr-24.0 and Hp-55.0 and class II types
+# Lr-0.21 and Hp-0.03.
+#
+# The prefix lives in the haplotype names below rather than in a per-species
+# key: "Hp-1a.0" and "SLA-Hp-1a.0" both parse, and a `haplotype prefix` field
+# would only restate what the names already carry. That answers the open
+# question in #143; #139 removed the key that asserted it with nothing behind
+# it.
+#
+# Contents. The nine high-resolution class I haplotypes below are the ones
+# designated by the SLA Nomenclature Committee, as tabulated under "Known
+# haplotypes" in Table 2 of Bækbo et al. 2017
+# (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5472656/), whose columns run
+# Hp- | SLA-1 | SLA-3 | SLA-2. The same table's second half proposes
+# haplotypes A.0 through Z.0 from that study alone; those are the authors'
+# suggestions rather than committee designations, and several rest on
+# unnamed sequences (NS#5, HB01), so they are deliberately not listed here.
 ##########################################
 SLA:
-  # TODO:
-  #   no one writes "SLA-Hp-1a.0", pigs actually have a distinct prefix
-  #   "Hp" for haplotypes which is distinct from the prefix used for
-  #   gene names and alleles
+  # Large White. Table 2: SLA-1*0101, SLA-3*0101, SLA-2*0101.
   Hp-1a.0:
-    - SLA-1*01:01
-    - SLA-2*01:01
-    - SLA-3*01:01
+    - 1*01:01
+    - 3*01:01
+    - 2*01:01
+  # NIH, Sinclair and Hanford minipigs. Table 2 gives two SLA-1 alleles for
+  # this haplotype, "0201(a), 0701(b)", and *null* for SLA-3 -- the locus is
+  # absent, not unknown. The third allele here used to read SLA-3*02:01, which
+  # is the SLA-2 column misfiled under SLA-3.
   Hp-2.0:
-    - SLA-1*02:01
-    - SLA-1*07:01
-    - SLA-3*02:01
+    - 1*02:01
+    - 1*07:01
+    - 2*02:01
+  # Yucatan miniature pigs; the most prevalent class I haplotype in Danish
+  # commercial pigs by its low-resolution counterpart Lr-4.0.
+  Hp-4b.0:
+    - 1*04:01
+    - 3*04:01
+    - 2*04:02:01
+  # Yucatan and Microminipig.
+  Hp-6.0:
+    - 1*08:05
+    - 3*06:01
+    - 2*05:04
+  # Yucatan.
+  Hp-7.0:
+    - 1*08:01
+    - 3*07:01:01
+    - 2*05:02
+  # Clawn and Microminipig.
+  Hp-17.0:
+    - 1*08:04
+    - 3*03:05
+    - 2*06:03
+  # Landrace. Two SLA-1 alleles again, "0901(a), 1501(b)".
+  Hp-28.0:
+    - 1*09:01
+    - 1*15:01
+    - 3*07:01:02
+    - 2*05:03
+  # CMAH/Gal knockout pigs.
+  Hp-32.0:
+    - 1*07:02
+    - 3*04:02
+    - 2*02:02
+  # Landrace. Table 2 gives SLA-3 as "04hb06", a provisional designation rather
+  # than a committee-assigned allele name, so only the two named alleles are
+  # listed.
+  Hp-62.0:
+    - 1*14:01
+    - 2*06:02
 
 #########################################
 # Mouse MHC haplotypes copied from:

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -3047,11 +3047,12 @@ Sus scrofa:
   # SLA group: https://www.ebi.ac.uk/ipd/mhc/group/SLA/species
   prefix source: designated
   prefix: Susc
-  # Swine haplotypes are written with an "Hp" prefix. This was a
-  # `haplotype prefix: Hp` key, but nothing in the loader ever read it and no
-  # swine haplotype is curated for it to apply to -- haplotypes.yaml has no
-  # Sus scrofa entry, and Hp-1.1 does not parse. Kept as a note rather than a
-  # key that asserts support we do not have. See #143.
+  # Swine haplotypes carry their own prefix -- "Hp-" for high resolution,
+  # "Lr-" for low -- separate from the SLA- used for genes and alleles, and no
+  # `haplotype prefix` key is needed to express it: the names in
+  # haplotypes.yaml begin with it, so "Hp-17.0" and "SLA-Hp-17.0" both parse.
+  # The entries are keyed there by MHC prefix, so they hang off Sus sp. rather
+  # than this entry. See the header of haplotypes.yaml and #143.
   name: Feral Pig
 ######################################################
 # Rodentia — rodents

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.50.0"
+__version__ = "3.51.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,44 +1,42 @@
-# Do not assign a species to a gene symbol shared across lineages (#130)
+# Curate SLA (swine) haplotypes (#143)
 
 ## Review
 
-- **The rule.** `Parser.parse_gene_without_species` ranked every species that
-  declares a digit-bearing gene name and returned the one with the longest gene
-  list. That was written for `BLB2`, whose two declarers are `Galliformes sp.`
-  and its own descendant `Gallus gallus`. Applied to `DRB1` it ranked 45
-  unrelated declarers and returned *Macaca fascicularis*. The ranking now runs
-  only when the declarers lie in a single lineage; otherwise the name names no
-  species, per #108.
+- **The issue's premise was half wrong, and the half that was right hid a
+  live bug.** `haplotypes.yaml` did have swine entries -- keyed by MHC prefix
+  as `SLA:`, not by latin name, which is why a search for "Sus scrofa" found
+  nothing. But both entries wrote their member alleles *with* the species
+  prefix (`SLA-1*01:01`), and the loader hands the parser the string after the
+  species. So both haplotypes resolved carrying **zero alleles** and printed
+  six warnings to stdout on every parse. Nothing read those warnings.
 
-- **`BF2` was the one real casualty, and it is real.** IEDB publishes chicken
-  alleles under the bare form -- `BF2*2101` (82 assay entries), `BF2*0401`
-  (33), `BF2*1301` (30), and more. But GenBank EU430728.1 and EF643463.1 are
-  both "Numida meleagris MHC class I antigen (BF2) mRNA", so the guineafowl's
-  BF2 is not a curation error either and could not just be deleted.
+- **One of the two was also wrong on the data.** Table 2 of Baekbo et al. 2017
+  (PMC5472656) gives Hp-2.0 as SLA-1*0201/*0701, SLA-3 *null*, SLA-2*0201. The
+  entry read `SLA-3*02:01` -- the SLA-2 column filed one locus over. SLA-3*02:01
+  is a real allele, so nothing could have complained.
 
-  Resolved with the `context only` property #113 added: the guineafowl declares
-  BF2, `NumiMele-BF2` resolves, and the bare form stays with the chicken. The
-  attested side gets the bare name, the same rule AGENTS.md states for prefixes.
+- **The naming question the issue asks in step 3 has an answer in the
+  literature.** Reiner et al. 2024 (PMC10925748) states the ISAG/IUIS-VIC
+  scheme: swine haplotypes carry their own prefix, `Hp-` high resolution and
+  `Lr-` low resolution, numbered `<class I>.<class II>` -- so `Hp-04.0` and
+  `Hp-0.03` are the two halves of one animal's type, not variants. No
+  `haplotype prefix` field is needed: the prefix is part of the name, and
+  `Hp-17.0` and `SLA-Hp-17.0` both parse.
 
-- **My corpus was lying to me.** The 25,200-name set I had been measuring
-  against did not include `tests/iedb_allele_counts.csv` or the bundled
-  netMHCpan lists. It reported 0 differences for this change while 17 tests
-  failed, nearly all of them BF2. Rebuilt to 36,752 names; the rebuilt corpus
-  showed the 8 BF2 forms immediately.
+- **Curated all nine designated class I haplotypes**, not just the two:
+  Hp-1a.0, 2.0, 4b.0, 6.0, 7.0, 17.0, 28.0, 32.0, 62.0, from the "Known
+  haplotypes" half of Table 2. The same table's A.0-Z.0 rows are that study's
+  own proposals resting partly on unnamed sequences, so they are left out.
 
-- **A pre-existing provenance bug, found on the way.**
-  `infer_species_from_prefix` falls back to a gene name unique to one species
-  and returns an empty matched string to say nothing in the input matched.
-  `species_named_in` counted it anyway, so `species_source` reported
-  **"explicit"** for `A8*01:01`, and `require_explicit_species=True` -- whose
-  entire job is rejecting an inferred species -- accepted it. 98 gene names
-  took that route. Fixed by honouring the sentinel.
+- **Added the general guard.** Every one of the 71 curated haplotypes must keep
+  every allele it lists. That is the test that would have caught this: the
+  failure mode is a warning on stdout and a haplotype that claims a name and
+  carries nothing.
 
-- **Filed #160** for the reason `Ia1` can no longer resolve: the tokenizer
-  lower-cases before `declares_gene_with_same_case` is ever consulted, so the
-  case-aware ranking key the code comments describe has never fired in the
-  normal path.
+- **Filed #162** for what could not be sourced: `Lr-` haplotypes are defined by
+  allele *groups* (`SLA-1*15XX`, `Blank`), which the file format cannot express,
+  and the class II `Hp-0.y` compositions are in a paywalled table.
 
-- **Measured:** 0 of 36,752 corpus names change. 16,011 tests pass. Reverting
-  either mechanism fails 9 of the new tests.
-- Bumped to 3.50.0.
+- **Measured:** 0 of 36,752 corpus names change. 16,110 tests pass; restoring
+  either wrong spelling fails the guard.
+- Bumped to 3.51.0.

--- a/tests/test_swine_haplotypes.py
+++ b/tests/test_swine_haplotypes.py
@@ -1,0 +1,113 @@
+"""
+Swine (SLA) haplotypes, and the guard that every curated haplotype keeps its
+alleles.
+
+The two SLA entries that existed before this wrote their members with the
+species prefix -- "SLA-1*01:01" rather than "1*01:01" -- but the loader hands
+the parser the string *after* the species. So both haplotypes resolved with an
+empty allele list and printed a warning to stdout on every parse, and one of
+them had the SLA-2 column filed under SLA-3.
+
+Naming, from Reiner et al. 2024 (PMC10925748): the ISAG/IUIS-VIC committee
+gives swine haplotypes their own prefix -- `Hp-` high resolution, `Lr-` low
+resolution -- numbered <class I>.<class II>.
+
+Allele composition from Table 2 ("Known haplotypes") of Baekbo et al. 2017,
+https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5472656/
+
+https://github.com/pirl-unc/mhcgnomes/issues/143
+"""
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from mhcgnomes import Haplotype, parse
+from mhcgnomes.data import haplotypes as raw_haplotypes
+
+from .common import eq_, ok_
+
+# Every class I haplotype the SLA Nomenclature Committee has designated, with
+# the alleles Table 2 lists for it.
+SLA_HAPLOTYPES = {
+    "Hp-1a.0": ["SLA-1*01:01", "SLA-2*01:01", "SLA-3*01:01"],
+    "Hp-2.0": ["SLA-1*02:01", "SLA-1*07:01", "SLA-2*02:01"],
+    "Hp-4b.0": ["SLA-1*04:01", "SLA-2*04:02:01", "SLA-3*04:01"],
+    "Hp-6.0": ["SLA-1*08:05", "SLA-2*05:04", "SLA-3*06:01"],
+    "Hp-7.0": ["SLA-1*08:01", "SLA-2*05:02", "SLA-3*07:01:01"],
+    "Hp-17.0": ["SLA-1*08:04", "SLA-2*06:03", "SLA-3*03:05"],
+    "Hp-28.0": ["SLA-1*09:01", "SLA-1*15:01", "SLA-2*05:03", "SLA-3*07:01:02"],
+    "Hp-32.0": ["SLA-1*07:02", "SLA-2*02:02", "SLA-3*04:02"],
+    "Hp-62.0": ["SLA-1*14:01", "SLA-2*06:02"],
+}
+
+
+@pytest.mark.parametrize("name,allele_names", sorted(SLA_HAPLOTYPES.items()))
+def test_swine_haplotype_carries_its_alleles(name, allele_names):
+    result = parse(name, required_result_types=[Haplotype])
+    # haplotypes.yaml is keyed by MHC prefix, and SLA belongs to the genus
+    # node rather than to Sus scrofa -- which is why #143 reported "no Sus
+    # scrofa entry at all" when the entry was there under SLA.
+    eq_(result.species.prefix, "SLA")
+    eq_(result.species.name, "Sus sp.")
+    eq_(sorted(allele.to_string() for allele in result.alleles), sorted(allele_names))
+
+
+@pytest.mark.parametrize("name", sorted(SLA_HAPLOTYPES))
+def test_swine_haplotype_parses_with_and_without_the_species_prefix(name):
+    # The Hp- prefix is the haplotype's own; SLA- is the gene and allele
+    # prefix. Both spellings appear in print.
+    eq_(parse(name).to_string(), f"SLA-{name}")
+    eq_(parse(f"SLA-{name}").to_string(), f"SLA-{name}")
+
+
+def test_hp_2_0_has_no_class3_allele():
+    """
+    Table 2 gives Hp-2.0 as SLA-1*0201/*0701, SLA-3 *null*, SLA-2*0201. The
+    curated entry read SLA-3*02:01, which is the SLA-2 column misfiled a locus
+    over. SLA-3*02:01 is a real allele, so nothing complained.
+    """
+    genes = {allele.gene.name for allele in parse("Hp-2.0").alleles}
+    eq_(genes, {"1", "2"})
+    ok_(parse("SLA-3*02:01") is not None, "SLA-3*02:01 exists; it just is not in this haplotype")
+
+
+def test_undesignated_haplotype_spellings_do_not_resolve():
+    # Only the high-resolution class I series is curated. The class II series
+    # (Hp-0.03) and the low-resolution one (Lr-4.0) are defined by allele
+    # *groups* such as SLA-1*15XX, which this file has no way to express.
+    for name in ["Hp-4.0", "Hp-1.1", "Hp-0.03", "Lr-4.0", "SLA-1.1"]:
+        eq_(parse(name, raise_on_error=False), None)
+
+
+# ---------------------------------------------------------------------------
+# The general form of the bug: a haplotype that quietly loses its alleles
+# ---------------------------------------------------------------------------
+
+ALL_HAPLOTYPES = sorted(
+    (prefix, name, tuple(alleles))
+    for prefix, entries in raw_haplotypes.items()
+    for name, alleles in entries.items()
+)
+
+
+@pytest.mark.parametrize("prefix,name,allele_names", ALL_HAPLOTYPES)
+def test_every_curated_haplotype_keeps_every_allele(prefix, name, allele_names):
+    """
+    A member allele the parser cannot read is dropped with a warning printed to
+    stdout, which nothing reads and no test caught. The result is a Haplotype
+    that claims a name and carries nothing.
+    """
+    # Ask for the haplotype reading specifically: "H2-d" is also the mouse D
+    # gene and "RT1-b" also a rat class II locus, and those readings win.
+    captured = io.StringIO()
+    with redirect_stdout(captured):
+        result = parse(f"{prefix}-{name}", required_result_types=[Haplotype], raise_on_error=False)
+    ok_(result is not None, f"{prefix}-{name} has no haplotype reading")
+    eq_(
+        len(result.alleles),
+        len(allele_names),
+        f"{prefix}-{name} kept {len(result.alleles)} of {len(allele_names)} alleles"
+        + (f"; parser said: {captured.getvalue().strip()}" if captured.getvalue() else ""),
+    )


### PR DESCRIPTION
Closes #143.

### The issue's premise was half wrong, and the half that was right hid a live bug

`haplotypes.yaml` *did* have swine entries — keyed by MHC prefix as `SLA:`, not
by latin name, which is why a search for `Sus scrofa` found nothing. But both
wrote their member alleles **with** the species prefix (`SLA-1*01:01`) while
the loader hands the parser the string *after* the species. So each resolved
carrying **zero alleles** and printed a warning to stdout on every parse:

```
>>> mhcgnomes.parse("Hp-1a.0")
Warning: unable to parse allele name 'SLA-1*01:01' for 'Hp-1a.0'
Warning: unable to parse allele name 'SLA-2*01:01' for 'Hp-1a.0'
Warning: unable to parse allele name 'SLA-3*01:01' for 'Hp-1a.0'
Haplotype(..., name='Hp-1a.0', alleles=())
```

Those six were the only such warnings in the entire ontology.

`Hp-2.0` was also wrong on the data. [Table 2 of Bækbo et al.
2017](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5472656/) gives it as
`SLA-1*0201`/`*0701`, SLA-3 **null**, `SLA-2*0201`. The entry read
`SLA-3*02:01` — the SLA-2 column filed one locus over. `SLA-3*02:01` is a real
allele, so nothing could have complained.

### The `Hp` prefix question, answered from the literature

Step 3 of the issue asks whether a per-species haplotype prefix deserves a
field. It does not. Reiner et al. 2024
([PMC10925748](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10925748/)) states
the ISAG/IUIS-VIC scheme: swine haplotypes carry their own prefix — `Hp-` high
resolution, `Lr-` low resolution — numbered `<class I>.<class II>`, so `Hp-04.0`
and `Hp-0.03` are the two halves of one animal's type rather than variants of
one thing. The prefix is part of the name, so `Hp-17.0` and `SLA-Hp-17.0` both
parse and a `haplotype prefix` key would only restate it. #139 was right to
remove the key.

### What is curated

All nine class I haplotypes the SLA Nomenclature Committee has designated,
from the "Known haplotypes" half of Table 2: `Hp-1a.0`, `2.0`, `4b.0`, `6.0`,
`7.0`, `17.0`, `28.0`, `32.0`, `62.0`. The `A.0`–`Z.0` rows below it are that
study's own proposals, several resting on unnamed sequences (`NS#5`, `HB01`),
so they are left out.

### The general guard

Every one of the **71** curated haplotypes, all species, must keep every allele
it lists. That is the test that would have caught this six years ago: the
failure mode is a warning printed to stdout that nothing reads, and a haplotype
that claims a name and carries nothing. It needs `required_result_types=[Haplotype]`,
because `H2-d` is also the mouse D gene and `RT1-b` also a rat class II locus.

### Filed #162 for what could not be sourced

`Lr-` haplotypes are defined by allele *groups* (`SLA-1*15XX`, `Blank`), which
the file format cannot express, and the class II `Hp-0.y` compositions are in
Ho et al. 2009, which is paywalled.

### Measurement

- 0 of 36,752 corpus names change.
- 16,110 tests pass; 99 new.
- Restoring either wrong spelling fails the guard with the parser's own warning
  quoted in the assertion message.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH