### PR TITLE
Carry the caller's spelling to the gene lookup (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,22 @@ A species that uses a shared symbol but does not own its bare form says so in
 the ontology with `context only`, which is why `BF2*02:01` still resolves to
 the chicken although the guineafowl also has a BF2.
 
+Gene lookup is case- and separator-normalizing, so some symbols differ only in
+spelling. Where they do, your spelling decides:
+
+```python
+>>> parse("Ia1").species.name   # Paralichthys olivaceus spells it this way
+'Paralichthys olivaceus'
+>>> parse("IA1").species.name   # Chrysolophus pictus spells it this way
+'Chrysolophus pictus'
+>>> parse("ia1", raise_on_error=False) is None  # neither, so neither is named
+True
+```
+
+A species you name outright still wins over a spelling that points elsewhere —
+`OS=Mus musculus GN=Mr1` is a mouse gene even though *Rattus sp.* is the entry
+that spells `MR1` as `Mr1`.
+
 ## How many digits per field?
 
 Originally alleles for many genes were numbered with two digits:

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -65,6 +65,22 @@ _MHC_REGION_RE = re.compile(
 )
 
 
+def _spelling_as_written(normalized_name, raw_name):
+    """
+    The caller's own spelling of a name the tokenizer has lower-cased.
+
+    Gene lookup is case-normalizing, so "Ia1" (Paralichthys olivaceus) and
+    "IA1" (Chrysolophus pictus) share one key and only the spelling tells them
+    apart -- but the tokenizer lower-cases before the parser sees anything, so
+    the case-aware ranking in parse_gene_without_species had nothing to rank
+    on. Token.raw_string keeps the original, and this hands it back when it is
+    the same name, falling back to the normalized form otherwise. See #160.
+    """
+    if raw_name and raw_name.lower() == normalized_name.lower():
+        return raw_name
+    return normalized_name
+
+
 def _lie_in_one_lineage(species_objects):
     """
     Is every one of these species an ancestor or descendant of every other?
@@ -1356,6 +1372,7 @@ class Parser:
         gene_name: str,
         default_species: Union[Sequence, str, None] = None,
         strict_default_species: bool = False,
+        raw_gene_name: Union[str, None] = None,
     ):
         """
         Parse the gene name without any associated species based on being
@@ -1369,12 +1386,14 @@ class Parser:
 
         species = None
         species_candidates = Species.get_species_with_gene_name(gene_name)
-        if (
-            len(species_candidates) > 1
-            and default_species is not None
-            and default_species in species_candidates
-        ):
-            species = default_species
+        # Species.get first: callers pass default_species as a latin name, a
+        # prefix or an object, and a bare string never matches a list of
+        # Species, so this preference used to fire only for object callers.
+        # A UniProt line naming "OS=Mus musculus GN=Mr1" then lost its own
+        # species to whichever one spells the gene that way. See #160.
+        default_species_object = Species.get(default_species) if default_species else None
+        if len(species_candidates) > 1 and default_species_object in species_candidates:
+            species = default_species_object
         if len(species_candidates) == 1:
             species = species_candidates[0]
         # When a distinctive gene name (contains a digit, e.g. BF2, DPB1)
@@ -1408,7 +1427,10 @@ class Parser:
         # nothing. A species which does use the name but does not own its bare
         # form says so with `context only` in the ontology. See issue #130.
         if species is None and len(species_candidates) > 1 and any(c.isdigit() for c in gene_name):
-            declarers = [s for s in species_candidates if s.declares_gene_with_same_case(gene_name)]
+            cased_gene_name = _spelling_as_written(gene_name, raw_gene_name)
+            declarers = [
+                s for s in species_candidates if s.declares_gene_with_same_case(cased_gene_name)
+            ]
             if not declarers:
                 declarers = [s for s in species_candidates if s.declares_gene(gene_name)]
             if len(declarers) == 1:
@@ -1432,6 +1454,7 @@ class Parser:
         allele_name: str,
         default_species: Union[str, Species, None] = None,
         strict_default_species: bool = False,
+        raw_allele_name: Union[str, None] = None,
     ):
         """
         Parse the allele name without any associated species based on being
@@ -1448,10 +1471,19 @@ class Parser:
             gene_name, allele_string = split_digits_at_end(allele_name)
 
         if gene_name and allele_string:
+            # Split the original spelling the same way, so "Ia1*01:01" reaches
+            # the gene lookup as "Ia1" and not just "ia1". See issue #160.
+            raw_gene_name = None
+            if raw_allele_name and _spelling_as_written(allele_name, raw_allele_name):
+                if raw_allele_name.count("*") == 1:
+                    raw_gene_name = raw_allele_name.split("*")[0]
+                else:
+                    raw_gene_name = split_digits_at_end(raw_allele_name)[0]
             gene = self.parse_gene_without_species(
                 gene_name=gene_name,
                 default_species=default_species,
                 strict_default_species=strict_default_species,
+                raw_gene_name=raw_gene_name,
             )
             if gene:
                 return self.parse_allele_or_gene_candidates(
@@ -1594,18 +1626,22 @@ class Parser:
         # all of these functions are expected to take the sequence
         # without any additional knowledge of which species it is associated
         # with.
+        # The gene and allele lookups also get the token as the caller spelled
+        # it, since gene names collide only in case. parse_haplotype has no use
+        # for it. See _spelling_as_written and issue #160.
         fns_without_species = [
-            self.parse_haplotype,
-            self.parse_gene_without_species,
-            self.parse_allele_without_species,
+            (self.parse_haplotype, {}),
+            (self.parse_gene_without_species, {"raw_gene_name": raw_string}),
+            (self.parse_allele_without_species, {"raw_allele_name": raw_string}),
         ]
         if self.verbose:
             print("=== Functions without required species argument ===")
-        for fn in fns_without_species:
+        for fn, extra_kwargs in fns_without_species:
             result = fn(
                 seq,
                 default_species=default_species,
                 strict_default_species=strict_default_species,
+                **extra_kwargs,
             )
 
             if self.verbose:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.51.0"
+__version__ = "3.52.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,42 +1,34 @@
-# Curate SLA (swine) haplotypes (#143)
+# Carry the caller's spelling to the gene lookup (#160)
 
 ## Review
 
-- **The issue's premise was half wrong, and the half that was right hid a
-  live bug.** `haplotypes.yaml` did have swine entries -- keyed by MHC prefix
-  as `SLA:`, not by latin name, which is why a search for "Sus scrofa" found
-  nothing. But both entries wrote their member alleles *with* the species
-  prefix (`SLA-1*01:01`), and the loader hands the parser the string after the
-  species. So both haplotypes resolved carrying **zero alleles** and printed
-  six warnings to stdout on every parse. Nothing read those warnings.
+- **The ranking key had never fired.** `parse_gene_without_species` ranks
+  candidate species by `declares_gene_with_same_case(gene_name)` first, and the
+  comment above it explains that "Ia1" is *Paralichthys olivaceus* and "IA1" is
+  *Chrysolophus pictus*. But the tokenizer lower-cases every token, so the
+  function only ever saw `ia1`, which nobody spells that way. The key was dead
+  code the comment described as working.
 
-- **One of the two was also wrong on the data.** Table 2 of Baekbo et al. 2017
-  (PMC5472656) gives Hp-2.0 as SLA-1*0201/*0701, SLA-3 *null*, SLA-2*0201. The
-  entry read `SLA-3*02:01` -- the SLA-2 column filed one locus over. SLA-3*02:01
-  is a real allele, so nothing could have complained.
+- **`Token.raw_string` had the spelling the whole time.** Threaded it to the
+  gene and allele lookups; `parse_haplotype` has no use for it, so the call
+  loop pairs each function with its own kwargs rather than growing a
+  parameter nobody wants.
 
-- **The naming question the issue asks in step 3 has an answer in the
-  literature.** Reiner et al. 2024 (PMC10925748) states the ISAG/IUIS-VIC
-  scheme: swine haplotypes carry their own prefix, `Hp-` high resolution and
-  `Lr-` low resolution, numbered `<class I>.<class II>` -- so `Hp-04.0` and
-  `Hp-0.03` are the two halves of one animal's type, not variants. No
-  `haplotype prefix` field is needed: the prefix is part of the name, and
-  `Hp-17.0` and `SLA-Hp-17.0` both parse.
+- **19 gene forms that returned None now resolve**, and nothing stops
+  resolving: `Ia1`/`IA1`, `Ia2`/`IA2`, `AB1` (mouse) vs `Ab1` (Roborovski
+  hamster), `DAA-1`, `DAA-2`, `DAA2`, `DMB-1`. Each has exactly one same-case
+  declarer, so each is precise rather than a guess.
 
-- **Curated all nine designated class I haplotypes**, not just the two:
-  Hp-1a.0, 2.0, 4b.0, 6.0, 7.0, 17.0, 28.0, 32.0, 62.0, from the "Known
-  haplotypes" half of Table 2. The same table's A.0-Z.0 rows are that study's
-  own proposals resting partly on unnamed sequences, so they are left out.
+- **A second bug fell out of the first.** The preference for a species the
+  caller named compared `default_species` -- often a latin-name *string* --
+  against a list of `Species` objects, so it fired only for callers passing an
+  object. Nothing noticed while the case-aware key was dead. Once spellings
+  worked, a UniProt line reading `OS=Mus musculus ... GN=Mr1` lost its own
+  species to *Rattus sp.*, the only entry spelling MR1 that way. Fixed by
+  resolving `default_species` before the membership test; a named species now
+  outranks a spelling, which is the right order.
 
-- **Added the general guard.** Every one of the 71 curated haplotypes must keep
-  every allele it lists. That is the test that would have caught this: the
-  failure mode is a warning on stdout and a haplotype that claims a name and
-  carries nothing.
-
-- **Filed #162** for what could not be sourced: `Lr-` haplotypes are defined by
-  allele *groups* (`SLA-1*15XX`, `Blank`), which the file format cannot express,
-  and the class II `Hp-0.y` compositions are in a paywalled table.
-
-- **Measured:** 0 of 36,752 corpus names change. 16,110 tests pass; restoring
-  either wrong spelling fails the guard.
-- Bumped to 3.51.0.
+- **Measured:** 0 of 36,752 corpus names change; 19 of 1,066 gene forms change,
+  all None -> a resolution. 16,129 tests pass. Reverting the spelling
+  pass-through fails 18 tests, reverting the default-species fix fails 2.
+- Bumped to 3.52.0.

--- a/tests/test_ambiguous_species_inference.py
+++ b/tests/test_ambiguous_species_inference.py
@@ -218,10 +218,11 @@ def test_shared_class2_symbol_still_uses_the_default_species(name):
         # nine declarers across crocodiles, amphibians, birds, fish and
         # marsupials; the saltwater crocodile used to win on gene count
         ("DAB1", ["Crocodylus porosus", "Amphibia sp."]),
-        # flounder "Ia1" and golden pheasant "IA1" normalize to one key, and
-        # the tokenizer lower-cases before the parser ever sees the spelling,
-        # so nothing can tell these apart. See #160.
-        ("Ia1", ["Paralichthys olivaceus", "Chrysolophus pictus"]),
+        # flounder "Ia1" and golden pheasant "IA1" normalize to one key, so
+        # a caller who spells it neither way has named neither species. The
+        # cased spellings do resolve -- see
+        # test_gene_name_spelling_picks_the_species_that_uses_it.
+        ("ia1", ["Paralichthys olivaceus", "Chrysolophus pictus"]),
     ],
 )
 def test_bare_gene_shared_across_lineages_names_no_species(gene_name, declarers):
@@ -235,6 +236,73 @@ def test_bare_gene_shared_across_lineages_names_no_species(gene_name, declarers)
         parse(f"{Species.get_by_latin_name(declarers[0]).prefix}-{gene_name}").species.name,
         declarers[0],
     )
+
+
+# The spellings that do tell two species apart. Gene lookup normalizes case and
+# separators, so these pairs share one key; only the caller's own spelling says
+# which species is meant. https://github.com/pirl-unc/mhcgnomes/issues/160
+SPELLING_TO_SPECIES = [
+    ("Ia1", "Paralichthys olivaceus"),
+    ("Ia2", "Paralichthys olivaceus"),
+    ("IA1", "Chrysolophus pictus"),
+    ("IA2", "Chrysolophus pictus"),
+    ("AB1", "Mus musculus"),
+    ("Ab1", "Phodopus roborovskii"),
+    ("DAA-1", "Reptilia sp."),
+    ("DAA2", "Nipponia nippon"),
+    ("DMB-1", "Spheniscus mendiculus"),
+]
+
+
+@pytest.mark.parametrize("spelling,expected", SPELLING_TO_SPECIES)
+def test_gene_name_spelling_picks_the_species_that_uses_it(spelling, expected):
+    """
+    The tokenizer lower-cases every token, so the case-aware ranking key in
+    parse_gene_without_species had nothing to rank on and these all returned
+    None. Token.raw_string kept the spelling the whole time.
+    """
+    species = Species.get_by_latin_name(expected)
+    assert species.declares_gene_with_same_case(spelling), (
+        f"{expected} no longer spells it that way"
+    )
+    eq_(parse(spelling).species.name, expected)
+
+
+@pytest.mark.parametrize(
+    "spelling,expected",
+    # "AB1*01:01" is left out: a bare mouse gene with numeric allele fields
+    # does not parse at all, with or without this change, because mouse
+    # alleles are haplotype letters ("AB1*b" works). That is a separate
+    # question from which species a spelling names.
+    [(s, e) for s, e in SPELLING_TO_SPECIES if e != "Mus musculus"],
+)
+def test_gene_name_spelling_also_decides_for_an_allele(spelling, expected):
+    eq_(parse(f"{spelling}*01:01").species.name, expected)
+
+
+def test_a_spelling_nobody_uses_still_names_no_species():
+    # Lower-casing it yourself puts you back where the tokenizer was.
+    eq_(parse("ia1", raise_on_error=False), None)
+    eq_(parse("ia1*01:01", raise_on_error=False), None)
+
+
+def test_a_named_species_outranks_a_spelling_that_points_elsewhere():
+    """
+    Rattus sp. is the only entry spelling MR1 as "Mr1", but a UniProt line
+    carrying "OS=Mus musculus GN=Mr1" has named its species outright and must
+    keep it. The preference for a named species was there, and compared a
+    latin-name string against a list of Species objects, so it only ever fired
+    for callers passing an object.
+    """
+    uniprot = (
+        "Major histocompatibility complex class I-related gene protein "
+        "OS=Mus musculus OX=10090 GN=Mr1 PE=1 SV=2"
+    )
+    eq_(parse(uniprot).species.name, "Mus musculus")
+    eq_(parse("Mr1", species="Mus musculus").species.name, "Mus musculus")
+    eq_(parse("Mr1", default_species="Mus musculus").species.name, "Mus musculus")
+    # and with no species named at all, the spelling still decides
+    eq_(parse("Mr1", default_species=None).species.name, "Rattus sp.")
 
 
 def test_guineafowl_bf2_is_real_but_does_not_claim_the_bare_name():


### PR DESCRIPTION
Closes #160.

`parse_gene_without_species` ranks candidate species by
`declares_gene_with_same_case` first, and the comment above it says why:

> Gene lookup is case-normalizing, so distinct genes can collide: `Ia1` belongs
> to *Paralichthys olivaceus* and `IA1` to *Chrysolophus pictus*. Prefer the
> species that spells the gene the way the caller did.

**That key had never fired.** The tokenizer lower-cases every token, so the
function only ever saw `ia1`, which neither species spells that way. It was
dead code that a comment described as working, and the names it was written for
returned `None`.

`Token.raw_string` had the spelling the whole time.

| input | `main` | here |
|---|---|---|
| `Ia1` | `None` | `ParaOliv-Ia1` |
| `IA1` | `None` | `Chpi-IA1` |
| `ia1` | `None` | `None` — neither spelling, so neither species |
| `AB1` | `None` | `H2-AB1` (mouse) |
| `Ab1` | `None` | `PhodRobo-Ab1` (Roborovski hamster) |
| `DMB-1` | `None` | `SpheMend-DMB-1` |

19 gene forms resolve that did not, and **none stop resolving**. Each has
exactly one same-case declarer, so each is precise rather than a guess.

### A second bug fell out of the first

The preference for a species the caller named compared `default_species` —
usually a latin-name *string* — against a list of `Species` objects:

```python
if len(species_candidates) > 1 and default_species in species_candidates:
```

so it only ever fired for callers passing an object. Nothing noticed while the
case-aware key was dead. Once spellings worked, this UniProt line lost its own
species:

```
Major histocompatibility complex class I-related gene protein OS=Mus musculus OX=10090 GN=Mr1 PE=1 SV=2
```

*Rattus sp.* is the only entry spelling `MR1` as `Mr1`, so the spelling beat the
`OS=`. Resolving `default_species` before the membership test puts a named
species back above a spelling, which is the right order — and `tests/test_mouse.py`
had covered that line since long before this, so it caught the regression.

### Left alone

`AB1*01:01` still does not parse without a prefix, because a bare mouse gene
with numeric allele fields never did — mouse alleles are haplotype letters, and
`AB1*b` works. Separate question from which species a spelling names, so it is
noted in the test rather than changed here.

### Measurement

- 0 of 36,752 corpus names change.
- 19 of 1,066 gene forms change, every one `None` → a resolution.
- 16,129 tests pass.
- Reverting the spelling pass-through fails 18 tests; reverting the
  default-species fix fails 2.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH