### PR TITLE
Finish the IPD-MHC namespace sweep; establish 15 more prefixes (#131)

### DIFF
--- a/mhcgnomes/data/ipd_designations.yaml
+++ b/mhcgnomes/data/ipd_designations.yaml
@@ -17,9 +17,14 @@
 #      another species holds it in published use -- the Caau and Hyam cases.
 # Anything else is a disagreement nobody has looked at.
 #
-# Groups not yet transcribed: NHP, FISH, CHICKEN. Their tables are large enough
-# that a fetch summary cannot be trusted for them, which is why they are the
-# tail of #131 rather than part of this file.
+# All eleven IPD-MHC groups are transcribed here -- BoLA, CeLA, CHICKEN, CLA,
+# DLA, ELA, FISH, NHP, OLA, RT1, SLA -- read from the group species tables
+# rather than a fetch summary. 125 rows. The eight groups that were here before
+# were re-read at the same time and every row still agreed, code for code.
+#
+# Where a row's parentheses carry two codes the first is the species
+# designation and the second is usually the group label ("Canis lupus
+# (Calu,DLA)"); only the species code is recorded.
 
 
 BoLA:
@@ -28,7 +33,17 @@ BoLA:
   species:
     Bos frontalis: Bofr
     Bos grunniens: Bogr
+    # The group node itself: IPD files cattle under "Bos sp. (BoLA)" and has no
+    # separate row for Bos taurus or Bos indicus, so their two-plus-two codes
+    # are ours rather than designations. See #131.
+    Bos sp.: BoLA
     Bubalus bubalis: Bubu
+
+CHICKEN:
+  name: Chicken
+  url: https://www.ebi.ac.uk/ipd/mhc/group/CHICKEN/species
+  species:
+    Gallus gallus: Gaga
 
 CLA:
   name: Caprids
@@ -94,6 +109,84 @@ ELA:
   url: https://www.ebi.ac.uk/ipd/mhc/group/ELA/species
   species:
     Equus caballus: Eqca
+
+FISH:
+  name: Fish
+  url: https://www.ebi.ac.uk/ipd/mhc/group/FISH/species
+  species:
+    Oncorhynchus mykiss: Onmy
+    Salmo salar: Sasa
+
+NHP:
+  name: Non-human primates
+  url: https://www.ebi.ac.uk/ipd/mhc/group/NHP/species
+  species:
+    Alouatta pigra: Alpi
+    Aotus azarai: Aoaz
+    Aotus lemurinus: Aole
+    Aotus nancymaae: Aona
+    Aotus nigriceps: Aoni
+    Aotus trivirgatus: Aotr
+    Aotus vociferans: Aovo
+    Ateles belzebuth: Atbe
+    Ateles fusciceps: Atfu
+    Callicebus moloch: Camo
+    Callithrix jacchus: Caja
+    Callithrix pygmaea: Capy
+    Cebus albifrons: Ceal
+    Cebus apella: Ceap
+    Cebus capucinus: Ceca
+    Cebus imitator: Ceim
+    Cebus kaapori: Ceka
+    Cebus olivaceus: Ceol
+    Cercocebus atys: Ceat
+    Cercopithecus mitis: Cemi
+    Cercopithecus neglectus: Cene
+    Chlorocebus aethiops: Chae
+    Chlorocebus pygerythrus: Chpy
+    Chlorocebus sabaeus: Chsa
+    Colobus guereza: Cogu
+    Gorilla beringei: Gobe
+    Gorilla gorilla: Gogo
+    Hylobates lar: Hyla
+    Hylobates moloch: Hymo
+    Leontopithecus rosalia: Lero
+    Lophocebus aterrimus: Loat
+    Macaca arctoides: Maar
+    Macaca assamensis: Maas
+    Macaca fascicularis: Mafa
+    Macaca fuscata: Mafu
+    Macaca leonina: Malo
+    Macaca mulatta: Mamu
+    Macaca nemestrina: Mane
+    Macaca silenus: Masi
+    Macaca thibetana: Math
+    Mandrillus leucophaeus: Male
+    Mandrillus sphinx: Masp
+    Pan paniscus: Papa
+    Pan troglodytes: Patr
+    Papio anubis: Paan
+    Papio cynocephalus: Pacy
+    Papio hamadryas: Paha
+    Papio papio: Papp
+    Papio ursinus: Paur
+    Pithecia pithecia: Pipi
+    Pongo abelii: Poab
+    Pongo pygmaeus: Popy
+    Rhinopithecus roxellana: Rhro
+    Saguinus fuscicollis: Safu
+    Saguinus geoffroyi: Sage
+    Saguinus labiatus: Sala
+    Saguinus mystax: Samy
+    Saguinus oedipus: Saoe
+    Saimiri sciureus: Sasc
+    Sapajus apella macrocephalus: Sama
+    Sapajus cay: Saca
+    Sapajus libidinosus: Sali
+    Sapajus nigritus: Sani
+    Sapajus xanthosternos: Saxa
+    Semnopithecus entellus: Seen
+    Theropithecus gelada: Thge
 
 OLA:
   name: Ovids

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -622,6 +622,13 @@ Mus sp.:
         - DMB2
 Mus musculus:
   parent: Mus sp.
+  # prefix source: designated -- Klein J, Benoist C, David CS, Demant P,
+  # Lindahl KF, Flaherty L, Flavell RA, Hammerling U, Hood LE, Hunt SW et al.,
+  # "Revised nomenclature of mouse H-2 genes", Immunogenetics 1990;32:147-9
+  # (PMID 2228044), the committee report naming the mouse system. The report
+  # writes it hyphenated, "H-2"; the unhyphenated form is what allele strings
+  # use and what "old prefix" carries here.
+  prefix source: designated
   prefix: H2
   name: [Mouse, Murine]
   genes:
@@ -1124,6 +1131,10 @@ Felis sp.:
         - DMB
 Felis catus:
   parent: Felis sp.
+  # prefix source: designated -- PMID 9058818 (Yuhki & O'Brien, J Immunol
+  # 1997;158:2822) reports "limited variation in the domestic cat Feca-DRA
+  # gene ... but abundant variation in the Feca-DRB gene".
+  prefix source: designated
   prefix: Feca
   name: Domestic cat
 ############################
@@ -1146,12 +1157,20 @@ Ctenopharyngodon idella:
       - B2M-2
 Oncorhynchus mykiss:
   parent: Salmonidae sp.
+  # prefix source: designated -- one of the two species in the IPD-MHC FISH
+  # group, listed as "Oncorhynchus mykiss (Onmy)":
+  # https://www.ebi.ac.uk/ipd/mhc/group/FISH/species
+  prefix source: designated
   prefix: Onmy
   name:
     - Rainbow Trout
     - Trout
 Salmo salar:
   parent: Salmonidae sp.
+  # prefix source: designated -- the other species in the IPD-MHC FISH group,
+  # listed as "Salmo salar (Sasa)":
+  # https://www.ebi.ac.uk/ipd/mhc/group/FISH/species
+  prefix source: designated
   prefix: Sasa
   genes:
     Ia:
@@ -1205,6 +1224,9 @@ Salmonidae sp.:
   name: Salmonid
 Danio rerio:
   parent: Actinopterygii sp.
+  # prefix source: designated -- PMID 10799891 (Michalova et al., J Immunol
+  # 2000;164:5296) lists the zebrafish class I loci as "Dare-UDA, -UEA, -UFA".
+  prefix source: designated
   prefix: Dare
   other prefixes:
     # Old genus: Brachydanio rerio → Danio rerio
@@ -1243,6 +1265,10 @@ Oryzias latipes:
       - UHA
 Cyprinus carpio:
   parent: Cyprinidae sp.
+  # prefix source: designated -- PMID 9877432 (Rodrigues et al., Dev Comp
+  # Immunol 1998;22:493), titled "Expression of MhcCyca class I and class II
+  # molecules ... common carp", names Cyca-UA, Cyca-B2m, Cyca-DXA and Cyca-DAB.
+  prefix source: designated
   prefix: Cyca
   name: Common carp
   genes:
@@ -1322,6 +1348,10 @@ Epinephelus coioides:
   name: Orange-spotted grouper
 Salmo trutta:
   parent: Salmonidae sp.
+  # prefix source: designated -- PMID 22957875 (O'Farrell et al., J Fish Biol
+  # 2012;81:1357) describes "an MHC class I (satr-uba)-linked microsatellite
+  # locus" in wild brown trout.
+  prefix source: designated
   prefix: Satr
   name: Brown trout
 Salvelinus alpinus:
@@ -2511,6 +2541,12 @@ Bos sp.:
         - DIB
 Bos taurus:
   parent: Bos sp.
+  # prefix source: designated -- PMID 1559718 (Ammer et al., Immunogenetics
+  # 1992;35:332) writes "we identified different Bota-DRB alleles" of a study
+  # "focused on cattle (Bos taurus)". Note IPD-MHC does not designate it: the
+  # BoLA group files cattle under "Bos sp. (BoLA)" with no Bos taurus row, so
+  # this is literature usage rather than a committee assignment.
+  prefix source: designated
   prefix: Bota
   name: Cow
 Bos indicus:
@@ -3359,6 +3395,10 @@ Heliophobius argenteocinereus:
 ################################################################################
 Pteropus alecto:
   parent: Chiroptera sp.
+  # prefix source: designated -- PMID 31076531 (Qu et al., J Immunol
+  # 2019;202:3493) determined the structures of "peptide-MHC I complexes of
+  # Pteropus alecto, Ptal-N*01:01/HEV-1".
+  prefix source: designated
   prefix: Ptal
   name:
     - Black fruit bat
@@ -4193,14 +4233,34 @@ Phasianus colchicus:
   name: Common pheasant
 Tympanuchus cupido:
   parent: Galliformes sp.
-  # mhcseqs uses Iibi — unusual but attested
-  prefix: Iibi
+  # prefix source: designated -- GenBank names greater prairie chicken alleles
+  # with Tycu: 80 records, e.g. HM011586.1 "Tympanuchus cupido MHC class II
+  # antigen B (Tycu-BLB) gene, Tycu-BLB*26 allele", at
+  # https://www.ncbi.nlm.nih.gov/nuccore/HM011586.1 -- and it is the Klein 2+2
+  # code for the binomial, so it can be derived as well as cited.
+  prefix source: designated
+  prefix: Tycu
   other prefixes:
-    # Attested in UniProt gene_names; see registry entry Tycu.
-    - Tycu
+    # Iibi was the runtime prefix here until #131 traced it. It is not a
+    # species code at all: it is a *gene* symbol, read off GenBank JX971120.1
+    # (Immunogenetics 2013;65:133), which annotates the prairie chicken MHC-B
+    # locus with
+    #     gene   complement(5622..6980)
+    #            /gene="IIBI"
+    #            /product="MHC class II antigen beta chain 2"
+    # and that is its only occurrence in the nucleotide database. PubMed has
+    # none. It cannot be derived from Tympanuchus cupido either, and a prefix
+    # that cannot be derived from a binomial does not belong to it. Kept here
+    # so strings already emitted under it still parse, but nothing is written
+    # with it any more.
+    - Iibi
   name: Greater prairie chicken
 Gallus gallus:
   parent: Galliformes sp.
+  # prefix source: designated -- the only species in the IPD-MHC CHICKEN group,
+  # listed as "Gallus gallus (Gaga)":
+  # https://www.ebi.ac.uk/ipd/mhc/group/CHICKEN/species
+  prefix source: designated
   prefix: Gaga
   name: Chicken
   genes:
@@ -4278,6 +4338,11 @@ Chrysolophus pictus:
       - IA3
 Coturnix japonica:
   parent: Galliformes sp.
+  # prefix source: designated -- PMID 10199914 (Shiina et al., Immunogenetics
+  # 1999;49:384) is titled "Gene organization of the quail major
+  # histocompatibility complex (MhcCoja) class I gene region" and names
+  # Coja-A, Coja-B, Coja-C and Coja-D.
+  prefix source: designated
   prefix: Coja
   name: Japanese quail
   genes:
@@ -5915,6 +5980,10 @@ Chiroptera sp.:
 ##########################
 Xenopus laevis:
   parent: Xenopus sp.
+  # prefix source: designated -- PMID 31776204 (Ma et al., J Immunol
+  # 2020;204:147) reports "the single classical MHC class I (MHC-I) molecule
+  # Xela-UAA" for Xenopus laevis.
+  prefix source: designated
   prefix: Xela
   name: African clawed frog
   genes:
@@ -5998,6 +6067,10 @@ Ambystoma tigrinum:
   name: Tiger salamander
 Andrias davidianus:
   parent: Caudata sp.
+  # prefix source: designated -- PMID 24135718 is titled "Extensive
+  # diversification of MHC in Chinese giant salamanders Andrias davidianus
+  # (Anda-MHC) reveals novel splice variants".
+  prefix source: designated
   prefix: Anda
   other prefixes:
     - AndrDavi
@@ -6207,6 +6280,9 @@ Tiliqua adelaidensis:
 ##########################
 Monodelphis domestica:
   parent: Marsupialia sp.
+  # prefix source: designated -- PMID 16738937 (Gouin et al., Immunogenetics
+  # 2006) is titled "Modo-UG, a marsupial nonclassical MHC class I locus".
+  prefix source: designated
   prefix: Modo
   name: Gray short-tailed opossum
   genes:
@@ -6228,6 +6304,10 @@ Monodelphis domestica:
       - UT8
 Sarcophilus harrisii:
   parent: Marsupialia sp.
+  # prefix source: designated -- PMID 35335675 (Hussey et al., Pathogens
+  # 2022;11:351) is titled "Expression of the Nonclassical MHC Class I,
+  # Saha-UD in the Transmissible Cancer Devil Facial Tumour Disease".
+  prefix source: designated
   prefix: Saha
   name: Tasmanian devil
   genes:

--- a/mhcgnomes/data/underrepresented_taxa_source_registry.yaml
+++ b/mhcgnomes/data/underrepresented_taxa_source_registry.yaml
@@ -1010,11 +1010,17 @@ taxa:
       - https://www.uniprot.org/uniprotkb/A0A024B555/entry
     observed_structure:
       - uniprot_gene_name: Tycu-IA
-      - runtime_alias_addition: short alias Tycu added alongside canonical prefix Iibi
+      - genbank_allele_names: Tycu-BLB*20 through Tycu-BLB*28, 80 records
+      - runtime_prefix: Tycu, since #131
     notes: >
-      Greater prairie chicken already used the unusual but attested Iibi
-      prefix in runtime. The short Tycu alias is now accepted because
-      UniProt-derived source records use exact Tycu-IA labels.
+      Tycu is the prefix. The note here used to say the greater prairie chicken
+      "already used the unusual but attested Iibi prefix in runtime", and that
+      was wrong twice over: nothing attested it, and it is not a species code.
+      IIBI is a gene symbol, annotated on GenBank JX971120.1 as
+      /gene="IIBI" /product="MHC class II antigen beta chain 2", and that is
+      its only occurrence anywhere in the nucleotide database. Tycu meanwhile
+      names 80 GenBank records at allele level (Tycu-BLB*26 and siblings) and
+      is the Klein two-plus-two code for the binomial. See #131.
 
   Euma:
     scientific_name: Eublepharis macularius

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.52.0"
+__version__ = "3.53.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,34 +1,52 @@
-# Carry the caller's spelling to the gene lookup (#160)
+# Finish the IPD-MHC namespace sweep; 15 more prefixes established (#131, #112)
 
 ## Review
 
-- **The ranking key had never fired.** `parse_gene_without_species` ranks
-  candidate species by `declares_gene_with_same_case(gene_name)` first, and the
-  comment above it explains that "Ia1" is *Paralichthys olivaceus* and "IA1" is
-  *Chrysolophus pictus*. But the tokenizer lower-cases every token, so the
-  function only ever saw `ia1`, which nobody spells that way. The key was dead
-  code the comment described as working.
+- **All eleven IPD-MHC groups are now transcribed**, not eight.
+  `ipd_designations.yaml` goes from 55 rows to 125 with CHICKEN, FISH, NHP and
+  the `Bos sp.` group row. The eight groups already there were re-read at the
+  same time and every row still agreed, code for code.
 
-- **`Token.raw_string` had the spelling the whole time.** Threaded it to the
-  gene and allele lookups; `parse_haplotype` has no use for it, so the call
-  loop pairs each function with its own kwargs rather than growing a
-  parameter nobody wants.
+- **The completed sweep found zero disagreements.** All 125 IPD designations
+  match our prefix, and every species IPD lists is in our ontology. That is now
+  a CI check rather than a thing someone did by hand once.
 
-- **19 gene forms that returned None now resolve**, and nothing stops
-  resolving: `Ia1`/`IA1`, `Ia2`/`IA2`, `AB1` (mouse) vs `Ab1` (Roborovski
-  hamster), `DAA-1`, `DAA-2`, `DAA2`, `DMB-1`. Each has exactly one same-case
-  declarer, so each is precise rather than a guess.
+- **Three groups are far smaller than they look**, which is itself the finding:
+  FISH is two species and CHICKEN is one. Every other fish and bird in this
+  ontology has a generated prefix or a literature citation, never a
+  designation. IPD also has no `Bos taurus` row -- cattle are filed as
+  `Bos sp. (BoLA)` -- so `Bota` is literature usage, not a committee
+  assignment, and `Boin` has nothing behind it at all.
 
-- **A second bug fell out of the first.** The preference for a species the
-  caller named compared `default_species` -- often a latin-name *string* --
-  against a list of `Species` objects, so it fired only for callers passing an
-  object. Nothing noticed while the case-aware key was dead. Once spellings
-  worked, a UniProt line reading `OS=Mus musculus ... GN=Mr1` lost its own
-  species to *Rattus sp.*, the only entry spelling MR1 that way. Fixed by
-  resolving `default_species` before the membership test; a named species now
-  outranks a spelling, which is the right order.
+- **Fifteen prefixes established, 130 -> 146 designated, 46 -> 30 unknown.**
+  Three from IPD (Gaga, Onmy, Sasa) and twelve read verbatim from the papers:
+  Bota, Feca, Cyca, Coja, Saha, Xela, Modo, Anda, Dare, Ptal, Satr, and H2 from
+  the committee report that named the mouse system.
 
-- **Measured:** 0 of 36,752 corpus names change; 19 of 1,066 gene forms change,
-  all None -> a resolution. 16,129 tests pass. Reverting the spelling
-  pass-through fails 18 tests, reverting the default-species fix fails 2.
-- Bumped to 3.52.0.
+- **`Iibi` is not a species prefix.** Greater prairie chicken carried it with
+  the note "mhcseqs uses Iibi -- unusual but attested". Nothing attested it.
+  PubMed has no occurrence; the nucleotide database has exactly one, GenBank
+  JX971120.1, where it is a *gene* symbol:
+
+      gene   complement(5622..6980)
+             /gene="IIBI"
+             /product="MHC class II antigen beta chain 2"
+
+  Meanwhile `Tycu` names 80 GenBank records at allele level (`Tycu-BLB*26` and
+  siblings) and is the Klein 2+2 code for the binomial. So `Tycu` is the
+  prefix; `Iibi` stays as an `other prefix` so strings already emitted under it
+  parse, but nothing is written with it. The same failure shape as `Caau`: a
+  code that cannot be derived from the binomial did not belong to it.
+
+- **A second authority on the six primate `_LA` codes.** The IPD-MHC NHP group
+  lists 66 primates, every one with a 2+2 code, and none of ChLA/GoLA/MaLA/
+  OmLA/OrLA/RhLA is among them -- agreeing with the de Groot report, which does
+  not contain them either. Recorded next to the canary list.
+
+- **Could not establish, and said so**: 30 entries remain, including Acda,
+  Boin, Chpi, Crac, Crpo, Eqbu, Mega, Orcu, Pacr, Spau, Xetr and four
+  *Ctenomys*. Each was searched and none returned a usable citation.
+
+- **Measured:** 40 of 36,752 corpus names change, every one of them the
+  Iibi -> Tycu rename. 16,352 tests pass.
+- Bumped to 3.53.0.

--- a/tests/test_batch_species_v3_10.py
+++ b/tests/test_batch_species_v3_10.py
@@ -45,7 +45,9 @@ BATCH_SPECIES = [
     ("LaceAgil", "Lacerta agilis"),
     # Birds
     ("PhasColc", "Phasianus colchicus"),
-    ("Iibi", "Tympanuchus cupido"),
+    # Tycu since #131: Iibi turned out to be GenBank's gene symbol for the
+    # class II beta chain (JX971120.1 /gene="IIBI"), not a species code.
+    ("Tycu", "Tympanuchus cupido"),
     ("CicoBoyc", "Ciconia boyciana"),
     ("AgelPhoe", "Agelaius phoeniceus"),
     ("OceaLeuc", "Oceanodroma leucorhoa"),
@@ -102,7 +104,7 @@ def test_pheasant_inherits_bf_from_galliformes():
 
 
 def test_prairie_chicken_inherits_blb_from_galliformes():
-    result = parse("Iibi-BLB", raise_on_error=True)
+    result = parse("Tycu-BLB", raise_on_error=True)
     eq_(result.species.name, "Tympanuchus cupido")
 
 
@@ -169,8 +171,18 @@ def test_pctn_prefix_for_softnose():
     eq_(Species.get("Pctn").name, "Parachondrostoma toxostoma")
 
 
-def test_iibi_prefix_for_prairie_chicken():
+def test_tycu_prefix_for_prairie_chicken():
+    """
+    Tycu is what GenBank writes prairie chicken alleles with -- 80 records,
+    Tycu-BLB*20 through *28. Iibi, which used to be the prefix here, still
+    resolves so that strings already emitted under it keep working, but it is
+    not written any more. See #131.
+    """
+    eq_(Species.get("Tycu").name, "Tympanuchus cupido")
+    eq_(Species.get("Tycu").prefix, "Tycu")
     eq_(Species.get("Iibi").name, "Tympanuchus cupido")
+    eq_(parse("Iibi-BLB*01").to_string(), "Tycu-BLB*01")
+    eq_(parse("Tycu-BLB*28").to_string(), "Tycu-BLB*28")
 
 
 def test_lasc_prefix_for_gull():

--- a/tests/test_ipd_designations.py
+++ b/tests/test_ipd_designations.py
@@ -6,9 +6,9 @@ only by uniqueness within this repo, so it has no knowledge of the IPD-MHC
 namespace. That is how `Caau` and `Hyam` were found pointing at a goldfish and
 a minnow -- by a manual sweep, months after the fact.
 
-`mhcgnomes/data/ipd_designations.yaml` is that namespace for the groups checked
-so far, transcribed verbatim from the group species tables. These tests turn
-the sweep into something CI does.
+`mhcgnomes/data/ipd_designations.yaml` is that namespace -- all eleven groups,
+125 species, transcribed verbatim from the group species tables. These tests
+turn the sweep into something CI does.
 
 https://github.com/pirl-unc/mhcgnomes/issues/112
 """
@@ -43,8 +43,25 @@ DELIBERATE_DISAGREEMENTS = {
 
 
 def test_the_file_covers_the_groups_it_claims():
-    eq_(sorted(GROUPS), ["BoLA", "CLA", "CeLA", "DLA", "ELA", "OLA", "RT1", "SLA"])
-    eq_(len(ROWS), 55)
+    # All eleven IPD-MHC groups, so the whole published namespace is checked
+    # against ours in CI rather than the two thirds of it that were here first.
+    eq_(
+        sorted(GROUPS),
+        [
+            "BoLA",
+            "CHICKEN",
+            "CLA",
+            "CeLA",
+            "DLA",
+            "ELA",
+            "FISH",
+            "NHP",
+            "OLA",
+            "RT1",
+            "SLA",
+        ],
+    )
+    eq_(len(ROWS), 125)
 
 
 @pytest.mark.parametrize("group,latin_name,code", ROWS)
@@ -110,3 +127,56 @@ def test_the_documented_disagreements_are_still_the_only_ones():
         if species is not None and species.prefix.lower() != code.lower():
             actual.add((latin_name, code))
     eq_(sorted(actual), sorted(DELIBERATE_DISAGREEMENTS))
+
+
+# ---------------------------------------------------------------------------
+# What the completed sweep established
+# https://github.com/pirl-unc/mhcgnomes/issues/131
+# ---------------------------------------------------------------------------
+
+# Every group table read in full, and every row agreed with our prefix. Pinned
+# so a later curation change that breaks the agreement has to come here.
+GROUP_SIZES = {
+    "BoLA": 4,
+    "CHICKEN": 1,
+    "CLA": 1,
+    "CeLA": 33,
+    "DLA": 10,
+    "ELA": 1,
+    "FISH": 2,
+    "NHP": 66,
+    "OLA": 2,
+    "RT1": 2,
+    "SLA": 3,
+}
+
+
+@pytest.mark.parametrize("group,size", sorted(GROUP_SIZES.items()))
+def test_each_group_has_the_number_of_species_the_page_listed(group, size):
+    eq_(len(GROUPS[group]["species"]), size)
+
+
+def test_the_fish_and_chicken_groups_are_smaller_than_they_look():
+    """
+    A guard against a plausible-looking bulk import. IPD-MHC's FISH group is
+    two species and CHICKEN is one -- not the hundreds of fish and dozens of
+    birds this ontology carries. Everything else in those clades has a prefix
+    we generated or a literature citation, never an IPD designation.
+    """
+    eq_(sorted(GROUPS["FISH"]["species"]), ["Oncorhynchus mykiss", "Salmo salar"])
+    eq_(sorted(GROUPS["CHICKEN"]["species"]), ["Gallus gallus"])
+
+
+def test_cattle_are_designated_at_the_genus_node_not_the_species():
+    """
+    IPD files cattle as "Bos sp. (BoLA)" and has no row for Bos taurus or Bos
+    indicus, so their two-plus-two codes are not designations. Bota is marked
+    designated from the literature instead (PMID 1559718); Boin is not marked
+    at all, because nothing was found for it.
+    """
+    species = GROUPS["BoLA"]["species"]
+    eq_(species["Bos sp."], "BoLA")
+    ok_("Bos taurus" not in species, "IPD now lists Bos taurus; mark it from the page")
+    ok_("Bos indicus" not in species, "IPD now lists Bos indicus; mark it from the page")
+    eq_(Species.get_by_latin_name("Bos taurus").prefix_provenance, "designated")
+    eq_(Species.get_by_latin_name("Bos indicus").prefix_provenance, None)

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -683,6 +683,11 @@ def test_unestablished_provenance_stays_none():
         # RhLA zero times, case-insensitively. So the citation is wrong and
         # these stay unestablished until someone finds the actual source.
         #
+        # A second authority now agrees: the IPD-MHC NHP group species table
+        # lists 66 primates, every one with a two-plus-two code, and none of
+        # the six appears there either.
+        # https://www.ebi.ac.uk/ipd/mhc/group/NHP/species
+        #
         # Felis sp. and Oryctolagus sp. used to be on this list and are not any
         # more: FLA and RLA are published (PMID 2492667, PMID 32522857) and are
         # now marked designated.


### PR DESCRIPTION
Advances #131 and completes the file #112 started.

### The sweep is now complete

`ipd_designations.yaml` covered eight of the eleven IPD-MHC groups; its own
header called NHP, FISH and CHICKEN "the tail of #131". All three are
transcribed now, plus the `Bos sp.` group row — **55 rows → 125**. The eight
groups already there were re-read at the same time and every row still agreed,
code for code.

**Zero disagreements across the whole namespace.** All 125 designations match
our prefix and every species IPD lists is in the ontology. CI checks the whole
published namespace instead of two thirds of it.

### Three groups are much smaller than they look

That is the useful part. IPD-MHC's **FISH group is two species** and **CHICKEN
is one** — not the hundreds of fish and dozens of birds this ontology carries.
And there is no `Bos taurus` row at all: cattle are filed as `Bos sp. (BoLA)`.
So `Bota` is literature usage rather than a committee assignment, and `Boin`
has nothing behind it. Pinned in tests, because a plausible-looking bulk import
is exactly how `Caau` happened.

### Fifteen prefixes established — 130 → 146 designated, 46 → 30 unknown

Three from IPD (`Gaga`, `Onmy`, `Sasa`); twelve read verbatim from the papers
rather than from a search summary:

| prefix | source | the words |
|---|---|---|
| `Bota` | PMID 1559718 | "we identified different **Bota-DRB** alleles" |
| `Feca` | PMID 9058818 | "abundant variation in the **Feca-DRB** gene" |
| `Cyca` | PMID 9877432 | "class I alpha chain (**Cyca-UA**) … (**Cyca-DAB**)" |
| `Coja` | PMID 10199914 | "quail MHC (**MhcCoja**) class I gene region" |
| `Saha` | PMID 35335675 | "the Nonclassical MHC Class I, **Saha-UD**" |
| `Xela` | PMID 31776204 | "the single classical MHC-I molecule **Xela-UAA**" |
| `Modo` | PMID 16738937 | "**Modo-UG**, a marsupial nonclassical MHC class I locus" |
| `Anda` | PMID 24135718 | "Andrias davidianus (**Anda**-MHC)" |
| `Dare` | PMID 10799891 | "three class I (**Dare-UDA**, -UEA, -UFA)" |
| `Ptal` | PMID 31076531 | "Pteropus alecto, **Ptal-N\*01:01**/HEV-1" |
| `Satr` | PMID 22957875 | "an MHC class I (**satr-uba**)-linked microsatellite locus" |
| `H2` | PMID 2228044 | Klein et al., *Revised nomenclature of mouse H-2 genes* |

### `Iibi` is not a species prefix

Greater prairie chicken carried it, with the note *"mhcseqs uses Iibi —
unusual but attested"*. Nothing attested it. PubMed has no occurrence, and the
nucleotide database has exactly one — GenBank
[JX971120.1](https://www.ncbi.nlm.nih.gov/nuccore/JX971120.1), where it is a
**gene** symbol:

```
gene   complement(5622..6980)
       /gene="IIBI"
       /product="MHC class II antigen beta chain 2"
```

`Tycu` meanwhile names **80** GenBank records at allele level (`Tycu-BLB*20`
through `*28`) and is the Klein 2+2 code for the binomial, so it can be derived
as well as cited. `Tycu` is now the prefix; `Iibi` stays as an `other prefix`
so strings already emitted under it still parse, but nothing is written with
it. Same shape as `Caau`: a code that cannot be derived from a binomial does
not belong to it.

### A second authority on the six primate `_LA` codes

The IPD-MHC NHP group lists **66** primates, every one with a 2+2 code, and
none of `ChLA`/`GoLA`/`MaLA`/`OmLA`/`OrLA`/`RhLA` is among them — agreeing
with the de Groot report, which does not contain them either. Recorded next to
the canary list.

### Could not establish

Thirty entries remain, including `Acda`, `Boin`, `Chpi`, `Crac`, `Crpo`,
`Eqbu`, `Mega`, `Orcu`, `Pacr`, `Spau`, `Xetr` and four *Ctenomys*. Each was
searched; none returned a usable citation, so they are left alone.

### Measurement

- 40 of 36,752 corpus names change, **every one** the `Iibi` → `Tycu` rename.
- 16,352 tests pass.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH