### PR TITLE
Make deploy.sh check that the release actually shipped (#83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,12 @@
    exist — `deploy.py` takes no positional version, and because `deploy.sh`
    runs lint and tests first, invoking it that way burns the full suite before
    failing on argument parsing (#152).
-3. **"Done" means merged AND deployed to PyPI** — never stop at merge. After a PR merges, run `./deploy.sh` from a clean main. Skipping deploy = task not done.
+3. **"Done" means merged AND deployed to PyPI** — never stop at merge. After a
+   PR merges, run `./deploy.sh` from a clean main. Skipping deploy = task not
+   done. `deploy.sh` now checks: it waits for PyPI to have the version and
+   **exits 3** if it does not, printing the `twine upload` command for the
+   artifacts already built. Do not re-run `deploy.sh` after that — the tag is
+   already pushed and it will stop on it (#152, #83).
 4. **File problems as issues, don't silently work around them.** If you hit a bug here or in a sibling openvax/pirl-unc repo, open a GitHub issue on the correct repo and link it from the PR.
 5. **After a PR ships, look for the next block of work.** Read open issues across the relevant openvax repos, group by dependency + urgency. Prefer *foundational* changes that unblock multiple downstream improvements; otherwise chain the smallest independent improvements.
 

--- a/deploy.py
+++ b/deploy.py
@@ -27,11 +27,15 @@ Dry-run:
 """
 
 import argparse
+import json
 import os
 import shlex
 import shutil
 import subprocess
 import sys
+import time
+import urllib.error
+import urllib.request
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -78,6 +82,11 @@ class Config:
     # None otherwise -- passing the venv's environment to a different
     # interpreter is the same drift, pointed the other way.
     build_env: Optional[dict[str, str]]
+    # How long to wait for the pushed tag to appear on PyPI, and whether to
+    # look at all. See await_pypi_publication and issue #83.
+    pypi_project: str
+    pypi_timeout: float
+    check_pypi: bool
 
 
 class CommandError(RuntimeError):
@@ -391,6 +400,107 @@ def tag_and_push(cfg: Config, tag: str, version: str, *, cwd: Path) -> None:
     ok("Tag pushed")
 
 
+# What a PyPI lookup can tell us. "absent" is the only one that means the
+# release failed; "unknown" means the question could not be asked.
+PYPI_PRESENT = "present"
+PYPI_ABSENT = "absent"
+PYPI_UNKNOWN = "unknown"
+
+
+def pypi_released_versions(project: str, *, timeout: float = 10.0) -> Optional[set[str]]:
+    """
+    Every version PyPI has for this project, or None if it could not be asked.
+
+    None and the empty set are different answers and the caller must not
+    conflate them: a network failure is not evidence that a release is missing.
+    """
+    url = f"https://pypi.org/pypi/{project}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.load(response)
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        return None
+    return set(releases)
+
+
+def await_pypi_publication(cfg: Config, version: str) -> str:
+    """
+    Wait for the pushed tag to become a PyPI release, and say what happened.
+
+    deploy.py used to end by printing "GitHub Actions will build and publish
+    this tag to PyPI", which has been false since #83: the trusted-publisher
+    exchange fails with `invalid-publisher`, the workflow stops, and the tag
+    sits on GitHub with nothing behind it. The script reported success anyway,
+    so "done means merged AND deployed" was being satisfied on paper by a
+    sentence rather than by a release.
+
+    Returns one of PYPI_PRESENT / PYPI_ABSENT / PYPI_UNKNOWN.
+    """
+    deadline = time.monotonic() + cfg.pypi_timeout
+    unreachable = False
+    attempt = 0
+    while True:
+        versions = pypi_released_versions(cfg.pypi_project)
+        attempt += 1
+        if versions is None:
+            unreachable = True
+        elif version in versions:
+            return PYPI_PRESENT
+        else:
+            unreachable = False
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        if attempt == 1:
+            note(
+                f"Waiting up to {cfg.pypi_timeout:.0f}s for {cfg.pypi_project} "
+                f"{version} to appear on PyPI..."
+            )
+        time.sleep(min(10.0, remaining))
+    return PYPI_UNKNOWN if unreachable else PYPI_ABSENT
+
+
+def report_pypi_outcome(cfg: Config, version: str, tag: str, *, cwd: Path) -> int:
+    """
+    Turn the lookup into an exit code and, when it failed, into instructions.
+
+    Exit 3 rather than 1 so a caller can tell "the release did not land" from
+    "the script could not run". The tag is already pushed at this point, so the
+    instructions must not be "run deploy.sh again" -- that fails on the
+    existing tag, which is the trap #152 was about.
+    """
+    if not cfg.check_pypi:
+        note("Skipping the PyPI check (--skip-pypi-check).")
+        note(f"Nothing has confirmed that {version} was published.")
+        return 0
+
+    outcome = await_pypi_publication(cfg, version)
+    if outcome == PYPI_PRESENT:
+        ok(f"{cfg.pypi_project} {version} is on PyPI")
+        return 0
+
+    artifacts = sorted(str(p) for p in (cwd / "dist").glob(f"*{version}*"))
+    if outcome == PYPI_UNKNOWN:
+        note(f"Could not reach PyPI to confirm {version}. The tag {tag} is pushed.")
+        note(f"Check https://pypi.org/project/{cfg.pypi_project}/ before calling this released.")
+        return 0
+
+    eprint(f"ERROR: {tag} is pushed but PyPI still has no {version}.")
+    eprint("This is issue #83: the release workflow's trusted-publisher exchange fails")
+    eprint("with `invalid-publisher`, so the tag lands on GitHub and nothing reaches PyPI.")
+    eprint("")
+    eprint("Do NOT re-run deploy.sh -- the tag exists now, and it will stop on that.")
+    if artifacts:
+        eprint("Upload what was already built:")
+        eprint(f"  python -m twine upload {' '.join(artifacts)}")
+    else:
+        eprint(f"No dist/ artifacts for {version} were found to upload.")
+    return 3
+
+
 def resolve_venv_bin(root: Path) -> Optional[Path]:
     for name in (".venv", "venv"):
         candidate = root / name / "bin"
@@ -494,6 +604,18 @@ def parse_args(argv: Sequence[str]) -> Config:
     p.add_argument("--version-file", default="mhcgnomes/version.py")
     p.add_argument("--required-branch", default="main")
     p.add_argument("--remote", default="origin")
+    p.add_argument("--pypi-project", default="mhcgnomes")
+    p.add_argument(
+        "--pypi-timeout",
+        type=float,
+        default=300.0,
+        help="Seconds to wait for the release to appear on PyPI (default 300).",
+    )
+    p.add_argument(
+        "--skip-pypi-check",
+        action="store_true",
+        help="Push the tag without checking whether PyPI received the release.",
+    )
 
     ns = p.parse_args(list(argv))
     require_nonempty("--required-branch", ns.required_branch)
@@ -510,6 +632,9 @@ def parse_args(argv: Sequence[str]) -> Config:
         # once the repo root and venv are known.
         python="",
         build_env=None,
+        pypi_project=ns.pypi_project,
+        pypi_timeout=float(ns.pypi_timeout),
+        check_pypi=not bool(ns.skip_pypi_check),
     )
 
 
@@ -578,14 +703,15 @@ def main(argv: Sequence[str]) -> int:
         note(f"  would run: {cfg.python} -m build --no-isolation")
         note(f"  would run: git tag -a {tag} -m 'Release {tag} ({version})'")
         note(f"  would run: git push {cfg.remote} refs/tags/{tag}")
+        if cfg.check_pypi:
+            note(f"  would then wait up to {cfg.pypi_timeout:.0f}s for PyPI to have {version}")
         ok("Dry run complete")
         return 0
 
     build_distributions(cfg, cwd=root)
     tag_and_push(cfg, tag, version, cwd=root)
     ok(f"Release tag pushed: {tag}")
-    note("GitHub Actions will build and publish this tag to PyPI.")
-    return 0
+    return report_pypi_outcome(cfg, version, tag, cwd=root)
 
 
 if __name__ == "__main__":

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,9 +47,44 @@ These are one-time repository setup tasks outside the codebase:
 3. Run `./deploy.sh --fetch` from a clean local checkout of `main`.
 4. Confirm the pushed `v<version>` tag starts the
    `.github/workflows/release.yml` workflow.
-5. Verify the workflow succeeds and the new version appears on PyPI.
+5. `deploy.sh` now does step 5 for you: it waits for the version to appear on
+   PyPI and says which of three things happened. See below.
 6. If needed, run `.github/workflows/release_testpypi.yml` manually against an
    existing tag before a production release.
+
+### Did it actually ship?
+
+`deploy.sh` used to end by printing "GitHub Actions will build and publish this
+tag to PyPI" and exiting 0. That sentence has been false since
+[#83](https://github.com/pirl-unc/mhcgnomes/issues/83): the workflow's
+trusted-publisher exchange fails with `invalid-publisher`, so the tag lands on
+GitHub and nothing reaches PyPI, while the script reports success. Golden Rule
+3 says done means deployed, and it was being satisfied by a sentence.
+
+After pushing the tag, `deploy.py` polls PyPI for up to `--pypi-timeout`
+seconds (default 300) and reports one of:
+
+| outcome | exit | meaning |
+|---|---|---|
+| `OK: mhcgnomes <version> is on PyPI` | 0 | released |
+| `Could not reach PyPI to confirm ...` | 0 | the question could not be asked; check by hand |
+| `ERROR: v<version> is pushed but PyPI still has no <version>` | 3 | **not released** |
+
+Exit 3 rather than 1 so a caller can tell "the release did not land" from "the
+script could not run". A network failure is deliberately not the same answer as
+a missing release; treating them alike would fail deploys on flaky wifi.
+
+When it exits 3, **do not re-run `deploy.sh`** — the tag exists by then, so the
+run stops on `ensure_tag_absent`, which is the trap described in
+[#152](https://github.com/pirl-unc/mhcgnomes/issues/152). The error message
+prints the upload command for the artifacts already in `dist/`:
+
+```bash
+python -m twine upload dist/mhcgnomes-<version>-py3-none-any.whl dist/mhcgnomes-<version>.tar.gz
+```
+
+`--skip-pypi-check` turns the whole thing off, and says plainly that nothing
+has confirmed the release.
 
 ## What `deploy.sh` Enforces
 

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.54.0"
+__version__ = "3.55.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,45 +1,35 @@
-# HLA-Cw16 (#153)
+# Make deploy.sh tell the truth about whether the release shipped (#83)
 
 ## Review
 
-- **I had the premise backwards, and the source I could not reach settles it.**
-  My earlier comment on this issue said the shipped `hla_dictionary.xlsx`
-  reports `WHO Assigned Type = "-"` for every `C*16` allele and tops out at
-  Cw10, and inferred that HLA-C serology might stop there -- which would have
-  put `Cw12`, `Cw14`, `Cw15`, `Cw17` and `Cw18` in doubt too. The dictionary
-  reading was right; the inference was wrong.
+- **The trusted-publisher configuration is still the user's to do** -- it needs
+  pypi.org access. What was fixable here is the second half of #83, quoted from
+  the issue itself: *"`./deploy.sh` looks like it succeeds (it pushes the tag)
+  but the package never lands on PyPI -- violates the 'done = merged AND
+  deployed' Golden Rule silently."*
 
-- **The WHO file was reachable after all.** `hla.alleles.org/wmda/` is a 404,
-  but ANHIG/IMGTHLA mirrors the same files:
-  `wmda/hla_nom.txt` (3.65.0, 2026-07-14, "author: WHO, Steven G. E. Marsh")
-  reads
+- **The script ended with a claim, not a check.**
 
-      Cw;12;20260128;;;      Cw;16;20260128;;;
-      Cw;14;20260128;;;      Cw;17;20260128;;;
-      Cw;15;20260128;;;      Cw;18;20260128;;;
+      ok(f"Release tag pushed: {tag}")
+      note("GitHub Actions will build and publish this tag to PyPI.")
 
-  All six were assigned on 2026-01-28 by the 2026 HLA Nomenclature Report. The
-  dictionary is simply a snapshot from before that date -- it does not
-  disagree, it predates.
+  That second line has been false for every release since #83 was filed. Golden
+  Rule 3 was being satisfied by a sentence.
 
-- **That also explains #156.** Five of the fifteen rows the generator cannot
-  reproduce are exactly these C specificities, for the same reason.
+- **Three outcomes, not two.** A network failure is not evidence that a release
+  is missing, so `pypi_released_versions` returns `None` for "could not ask"
+  and a set for "asked". Conflating them with an empty set would fail every
+  offline deploy. Present -> exit 0, unknown -> exit 0 with no claim of
+  success, absent -> exit 3.
 
-- **Two more absences are correct, and now cited.** The same file records
-  `Cw;11;19871121;19911114;1;Sequence error` -- assigned then withdrawn -- and
-  has no `Cw13` line at all. Both now have a test.
+- **Exit 3, not 1**, so a caller can tell "the release did not land" from "the
+  script could not run".
 
-- **Members from the authority, not from the shape of the neighbours.**
-  `wmda/rel_ser_ser.txt` reads `Cw;16;;1601/1602`, and `rel_dna_ser.txt` maps
-  `C*16:01 -> 1601` and `C*16:02 -> 1602`. The same file associates ~240
-  further `C*16` alleles with the broad specificity; those are left out for the
-  same reason the neighbouring rows leave out their own hundreds.
+- **The failure message cannot say "re-run deploy.sh".** The tag is pushed by
+  then, so a re-run stops on `ensure_tag_absent` -- the trap #152 was about. It
+  prints the `twine upload` line for the artifacts already in `dist/` instead.
 
-- **Regenerated `serotypes_generated.yaml`** so the two files still match: the
-  generator carries forward rows the dictionary does not support, so `Cw16`
-  survives a re-run exactly as `Cw15` does.
-
-- **Measured:** 0 of 36,752 corpus names change -- `HLA-Cw16` is not in any
-  bundled corpus, which is why the hitlist scan found it and these did not.
-  16,373 tests pass.
-- Bumped to 3.54.0.
+- **Verified:** 14 new tests; breaking either mechanism (returning an empty set
+  for an unreachable index, or exiting 0 on absent) fails 5 of them. 16,387
+  tests pass.
+- Bumped to 3.55.0.

--- a/tests/test_deploy_pypi_check.py
+++ b/tests/test_deploy_pypi_check.py
@@ -1,0 +1,199 @@
+"""
+Whether `deploy.py` checks that the release it just tagged actually shipped.
+
+The script used to end with
+
+    ok(f"Release tag pushed: {tag}")
+    note("GitHub Actions will build and publish this tag to PyPI.")
+
+and that second line has been false since #83: the workflow's
+trusted-publisher exchange fails with `invalid-publisher`, so the tag lands on
+GitHub and nothing reaches PyPI. The script reported success either way, which
+is how "done means merged AND deployed" ends up satisfied by a sentence.
+
+The check has to distinguish three outcomes, not two. A network failure is not
+evidence that a release is missing, and treating it as one would make deploys
+fail on flaky wifi.
+
+https://github.com/pirl-unc/mhcgnomes/issues/83
+"""
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+deploy = pytest.importorskip("deploy")
+
+
+def _config(tmp_path, **overrides):
+    values = {
+        "version_file": Path("mhcgnomes/version.py"),
+        "required_branch": "main",
+        "remote": "origin",
+        "dry_run": False,
+        "fetch": False,
+        "env": None,
+        "python": "python3",
+        "build_env": None,
+        "pypi_project": "mhcgnomes",
+        "pypi_timeout": 0.0,
+        "check_pypi": True,
+    }
+    values.update(overrides)
+    return deploy.Config(**values)
+
+
+def _fake_urlopen(payload=None, error=None):
+    def opener(url, timeout=None):
+        if error is not None:
+            raise error
+        return io.BytesIO(json.dumps(payload).encode())
+
+    class _Ctx:
+        def __init__(self, url, timeout=None):
+            self.stream = opener(url, timeout)
+
+        def __enter__(self):
+            return self.stream
+
+        def __exit__(self, *exc):
+            return False
+
+    return _Ctx
+
+
+# ---------------------------------------------------------------------------
+# The lookup itself
+# ---------------------------------------------------------------------------
+
+
+def test_versions_are_read_from_the_releases_map(monkeypatch):
+    monkeypatch.setattr(
+        deploy.urllib.request,
+        "urlopen",
+        _fake_urlopen({"releases": {"1.0.0": [], "1.1.0": []}}),
+    )
+    assert deploy.pypi_released_versions("mhcgnomes") == {"1.0.0", "1.1.0"}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        urllib.error.URLError("no route to host"),
+        TimeoutError("timed out"),
+        OSError("connection reset"),
+    ],
+)
+def test_an_unreachable_index_is_none_not_empty(monkeypatch, error):
+    """
+    The distinction the whole check rests on. Returning an empty set here would
+    make every offline deploy report the release as missing.
+    """
+    monkeypatch.setattr(deploy.urllib.request, "urlopen", _fake_urlopen(error=error))
+    assert deploy.pypi_released_versions("mhcgnomes") is None
+
+
+def test_a_payload_without_releases_is_none(monkeypatch):
+    monkeypatch.setattr(deploy.urllib.request, "urlopen", _fake_urlopen({"info": {}}))
+    assert deploy.pypi_released_versions("mhcgnomes") is None
+
+
+# ---------------------------------------------------------------------------
+# The three outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_a_published_version_is_present(monkeypatch, tmp_path):
+    monkeypatch.setattr(deploy, "pypi_released_versions", lambda project, **kw: {"3.54.0"})
+    assert deploy.await_pypi_publication(_config(tmp_path), "3.54.0") == deploy.PYPI_PRESENT
+
+
+def test_a_reachable_index_without_the_version_is_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(deploy, "pypi_released_versions", lambda project, **kw: {"3.53.0"})
+    assert deploy.await_pypi_publication(_config(tmp_path), "3.54.0") == deploy.PYPI_ABSENT
+
+
+def test_an_unreachable_index_is_unknown(monkeypatch, tmp_path):
+    monkeypatch.setattr(deploy, "pypi_released_versions", lambda project, **kw: None)
+    assert deploy.await_pypi_publication(_config(tmp_path), "3.54.0") == deploy.PYPI_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# What the operator is told, and what the shell sees
+# ---------------------------------------------------------------------------
+
+
+def test_present_exits_zero(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(deploy, "await_pypi_publication", lambda cfg, v: deploy.PYPI_PRESENT)
+    code = deploy.report_pypi_outcome(_config(tmp_path), "3.54.0", "v3.54.0", cwd=tmp_path)
+    assert code == 0
+    # note()/ok() write to stderr, which is what makes them survive a caller
+    # that is capturing stdout.
+    assert "is on PyPI" in capsys.readouterr().err
+
+
+def test_unknown_exits_zero_but_does_not_claim_success(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(deploy, "await_pypi_publication", lambda cfg, v: deploy.PYPI_UNKNOWN)
+    code = deploy.report_pypi_outcome(_config(tmp_path), "3.54.0", "v3.54.0", cwd=tmp_path)
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "Could not reach PyPI" in err
+    assert "is on PyPI" not in err
+
+
+def test_absent_exits_three_and_says_what_to_do(monkeypatch, tmp_path, capsys):
+    """
+    Exit 3 rather than 1 so a caller can tell "the release did not land" from
+    "the script could not run", and the message must not say to re-run
+    deploy.sh: the tag exists by now, so that stops on the existing tag (#152).
+    """
+    monkeypatch.setattr(deploy, "await_pypi_publication", lambda cfg, v: deploy.PYPI_ABSENT)
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    wheel = dist / "mhcgnomes-3.54.0-py3-none-any.whl"
+    sdist = dist / "mhcgnomes-3.54.0.tar.gz"
+    wheel.write_text("")
+    sdist.write_text("")
+
+    code = deploy.report_pypi_outcome(_config(tmp_path), "3.54.0", "v3.54.0", cwd=tmp_path)
+    assert code == 3
+    err = capsys.readouterr().err
+    assert "no 3.54.0" in err
+    assert "#83" in err
+    assert "Do NOT re-run deploy.sh" in err
+    assert "twine upload" in err
+    assert str(wheel) in err and str(sdist) in err
+
+
+def test_absent_with_no_artifacts_says_so(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(deploy, "await_pypi_publication", lambda cfg, v: deploy.PYPI_ABSENT)
+    code = deploy.report_pypi_outcome(_config(tmp_path), "3.54.0", "v3.54.0", cwd=tmp_path)
+    assert code == 3
+    assert "No dist/ artifacts" in capsys.readouterr().err
+
+
+def test_the_check_can_be_skipped_without_touching_the_network(monkeypatch, tmp_path, capsys):
+    def explode(*args, **kwargs):
+        raise AssertionError("--skip-pypi-check must not look anything up")
+
+    monkeypatch.setattr(deploy, "await_pypi_publication", explode)
+    code = deploy.report_pypi_outcome(
+        _config(tmp_path, check_pypi=False), "3.54.0", "v3.54.0", cwd=tmp_path
+    )
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "Skipping the PyPI check" in err
+    assert "Nothing has confirmed" in err
+
+
+def test_the_flags_are_wired_through():
+    cfg = deploy.parse_args(
+        ["--skip-pypi-check", "--pypi-timeout", "12", "--pypi-project", "other"]
+    )
+    assert cfg.check_pypi is False
+    assert cfg.pypi_timeout == 12.0
+    assert cfg.pypi_project == "other"
+    assert deploy.parse_args([]).check_pypi is True


### PR DESCRIPTION
Advances #83. **The trusted-publisher configuration still needs your pypi.org
access** — that half cannot be done from here. This is the other half, which
the issue states plainly:

> Until this is fixed, `./deploy.sh` looks like it succeeds (it pushes the tag)
> but the package never lands on PyPI — violates the "done = merged AND
> deployed" Golden Rule **silently**.

### The script ended with a claim, not a check

```python
ok(f"Release tag pushed: {tag}")
note("GitHub Actions will build and publish this tag to PyPI.")
```

That second line has been false for every release since the workflow's
trusted-publisher exchange started failing with `invalid-publisher`. Golden
Rule 3 was being satisfied by a sentence.

### Three outcomes, not two

A network failure is **not** evidence that a release is missing, so
`pypi_released_versions` returns `None` for "could not ask" and a set for
"asked". Conflating them with an empty set would fail every offline deploy —
that distinction is the one thing this change rests on, and it has its own
test.

| outcome | exit | printed |
|---|---:|---|
| present | 0 | `OK: mhcgnomes 3.55.0 is on PyPI` |
| unknown | 0 | `Could not reach PyPI to confirm 3.55.0` — and no claim of success |
| absent | **3** | `ERROR: v3.55.0 is pushed but PyPI still has no 3.55.0` + instructions |

Exit 3 rather than 1 so a caller can tell "the release did not land" from "the
script could not run".

### The failure message cannot say "re-run deploy.sh"

The tag is pushed by then, so a re-run stops on `ensure_tag_absent` — the trap
#152 was about. It prints the upload line for the artifacts already in `dist/`:

```
Do NOT re-run deploy.sh -- the tag exists now, and it will stop on that.
Upload what was already built:
  python -m twine upload dist/mhcgnomes-3.55.0-py3-none-any.whl dist/mhcgnomes-3.55.0.tar.gz
```

`--skip-pypi-check` turns it off, and says plainly that nothing has confirmed
the release.

### Verification

- 14 new tests. Breaking either mechanism — returning an empty set for an
  unreachable index, or exiting 0 on absent — fails 5 of them.
- 16,387 tests pass.
- `docs/releasing.md` and Golden Rule 3 in `AGENTS.md` updated to match.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH