### PR TITLE
Establish 11 more prefixes from GenBank (#131)

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -1289,6 +1289,11 @@ Oreochromis niloticus:
         - DDB
 Sparus aurata:
   parent: Actinopterygii sp.
+  # prefix source: designated -- GenBank DQ019411.1, "Sparus aurata MHC class
+  # II alpha antigen (Spau-DAA) mRNA, Spau-DAA-214 allele, complete cds", one
+  # of eleven records naming gilthead seabream class II alleles this way.
+  # https://www.ncbi.nlm.nih.gov/nuccore/DQ019411.1
+  prefix source: designated
   prefix: Spau
   other prefixes:
     - SparAura
@@ -1307,6 +1312,12 @@ Salarias fasciatus:
   name: Jewelled blenny
 Acipenser dabryanus:
   parent: Actinopterygii sp.
+  # prefix source: designated -- GenBank MN249667.1, "Acipenser dabryanus MHC
+  # class II beta antigen (Acda-DAB) mRNA, Acda-DAB*1102 allele", from
+  # "Molecular polymorphism and expression of MHC I alpha, II alpha, II beta
+  # and II invariant chain in the critically endangered Dabry's sturgeon".
+  # https://www.ncbi.nlm.nih.gov/nuccore/MN249667.1
+  prefix source: designated
   prefix: Acda
   other prefixes:
     - AcipDabr
@@ -1356,6 +1367,15 @@ Salmo trutta:
   name: Brown trout
 Salvelinus alpinus:
   parent: Salmonidae sp.
+  # prefix source: designated -- weaker in form than the others, so the form is
+  # stated rather than summarized. GenBank has 98 Salvelinus alpinus MHC class
+  # I records whose isolates are named Saal_UBA_101 through Saal_UBA_106 and
+  # onward (HQ620390.1-HQ620395.1): the species code and the salmonid class I
+  # locus, concatenated in an isolate label rather than written as an allele
+  # name. No "Saal-UBA*..." allele name is deposited. It is the same Saal used
+  # for this species alongside the IPD-designated Onmy and Sasa of its own
+  # family. https://www.ncbi.nlm.nih.gov/nuccore/HQ620395.1
+  prefix source: designated
   prefix: Saal
   name: Arctic char
   genes:
@@ -2094,6 +2114,11 @@ Conolophus subcristatus:
 ############################
 Crocodylus porosus:
   parent: Crocodylia sp.
+  # prefix source: designated -- GenBank KP118846.1, "Crocodylus porosus ...
+  # MHC class II beta chain (Crpo-DAB2) gene", from "Comparative genome
+  # analyses reveal distinct structure in the saltwater crocodile MHC".
+  # https://www.ncbi.nlm.nih.gov/nuccore/KP118846.1
+  prefix source: designated
   prefix: Crpo
   name: Saltwater crocodile
   genes:
@@ -2175,6 +2200,12 @@ Caiman latirostris:
   name: Broad-snouted caiman
 Crocodylus acutus:
   parent: Crocodylia sp.
+  # prefix source: designated -- GenBank GU126827.1 through GU126934.1 name
+  # the class II loci Crac-DB01 to Crac-DB06 and Crac-DA01, and HQ158325.1 to
+  # HQ158329.1 the class I genes Crac01 to Crac05, from "Evolution of MHC
+  # class I in the Order Crocodylia", Immunogenetics 2014;66:53.
+  # https://www.ncbi.nlm.nih.gov/nuccore/GU126827.1
+  prefix source: designated
   prefix: Crac
   name: American crocodile
 Crocodylus palustris:
@@ -3000,6 +3031,13 @@ Equus caballus:
   name: Horse
 Equus burchelli:
   parent: Equus sp.
+  # prefix source: designated -- GenBank MF997196.1 carries the allele name
+  # "DQB-Eqbu-DQB*0401", from "Genetic diversity, evolution and selection in
+  # the major histocompatibility complex DRB and DQB genes in the family
+  # Equidae". The record files it under Equus quagga burchellii, the accepted
+  # name for which Equus burchelli is the synonym used here.
+  # https://www.ncbi.nlm.nih.gov/nuccore/MF997196.1
+  prefix source: designated
   prefix: Eqbu
   name:
     - Plains zebra
@@ -3205,18 +3243,37 @@ Ctenomys sp.:
         - DRB
 Ctenomys talarum:
   parent: Ctenomys sp.
+  # prefix source: designated -- GenBank KY906266.1, "Ctenomys talarum MHC
+  # class II antigen (Ctta-DRB) gene, Ctta-DRB26 allele", same study as Ctau.
+  # https://www.ncbi.nlm.nih.gov/nuccore/KY906266.1
+  prefix source: designated
   prefix: Ctta
   name: Talas tuco-tuco
 Ctenomys australis:
   parent: Ctenomys sp.
+  # prefix source: designated -- GenBank KY906279.1, "Ctenomys australis MHC
+  # class II antigen (Ctau-DRB) gene, Ctau-DRB23 allele", from "Selection on
+  # MHC in a context of historical demographic change in two closely-
+  # distributed species of tuco-tucos".
+  # https://www.ncbi.nlm.nih.gov/nuccore/KY906279.1
+  prefix source: designated
   prefix: Ctau
   name: Southern tuco-tuco
 Ctenomys torquatus:
   parent: Ctenomys sp.
+  # prefix source: designated -- GenBank EU035230.1, "Ctenomys torquatus MHC
+  # class II antigen (Ctto-DQA02) gene", same study as Ctpe.
+  # https://www.ncbi.nlm.nih.gov/nuccore/EU035230.1
+  prefix source: designated
   prefix: Ctto
   name: Collared tuco-tuco
 Ctenomys pearsoni:
   parent: Ctenomys sp.
+  # prefix source: designated -- GenBank EU035225.1, "Ctenomys pearsoni MHC
+  # class II antigen (Ctpe-DQA03) gene", from "Trans-species polymorphism and
+  # evidence of selection on class II MHC loci in tuco-tucos (Rodentia:
+  # Ctenomyidae)". https://www.ncbi.nlm.nih.gov/nuccore/EU035225.1
+  prefix source: designated
   prefix: Ctpe
   name: Pearson's tuco-tuco
 Ctenomys haigi:
@@ -3453,6 +3510,11 @@ Oryctolagus sp.:
         - DOB
 Oryctolagus cuniculus:
   parent: Oryctolagus sp.
+  # prefix source: designated -- GenBank PV167019.1, "Oryctolagus cuniculus
+  # MHC class I antigen (Orcu-U2) gene, Orcu-U2*05:02:01:01 allele", one of a
+  # series naming rabbit class I alleles this way.
+  # https://www.ncbi.nlm.nih.gov/nuccore/PV167019.1
+  prefix source: designated
   prefix: Orcu
   name: European rabbit
 ################################################################################

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.55.1"
+__version__ = "3.56.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,35 +1,42 @@
-# Make deploy.sh tell the truth about whether the release shipped (#83)
+# Establish 11 more prefixes from GenBank (#131)
 
 ## Review
 
-- **The trusted-publisher configuration is still the user's to do** -- it needs
-  pypi.org access. What was fixable here is the second half of #83, quoted from
-  the issue itself: *"`./deploy.sh` looks like it succeeds (it pushes the tag)
-  but the package never lands on PyPI -- violates the 'done = merged AND
-  deployed' Golden Rule silently."*
+- **I stopped short of my own method.** The `Iibi` finding in #165 came from
+  searching GenBank nuccore, and it worked because deposited records name
+  species prefixes at allele level. I then reported the remaining 30 entries as
+  "could not establish" having searched only PubMed and the IPD group tables.
+  Running the same nuccore sweep across all of them establishes **eleven**.
 
-- **The script ended with a claim, not a check.**
+- **A query shape hid two more.** The first sweep asked for
+  `"<species>"[Organism] AND (<prefix> OR MHC OR histocompatibility)`, so for
+  species with many MHC records the prefix hits fell outside `retmax`. Re-run
+  with the prefix *required*, `Spau` and `Saal` appeared. A zero from a query
+  that could not have found the answer is not a negative result.
 
-      ok(f"Release tag pushed: {tag}")
-      note("GitHub Actions will build and publish this tag to PyPI.")
+- **Nine with allele-level names**: Acda (`Acda-DAB*1102`), Crac (`Crac-DB01`
+  through `-DB06`), Crpo (`Crpo-DAB2`), Ctau (`Ctau-DRB23`), Ctpe
+  (`Ctpe-DQA03`), Ctta (`Ctta-DRB26`), Ctto (`Ctto-DQA02`), Eqbu
+  (`DQB-Eqbu-DQB*0401`), Orcu (`Orcu-U2*05:02:01:01`). Plus Spau
+  (`Spau-DAA-214`).
 
-  That second line has been false for every release since #83 was filed. Golden
-  Rule 3 was being satisfied by a sentence.
+- **One weaker, and said so in the entry.** `Saal` appears in 98 records as the
+  *isolate* label `Saal_UBA_101`..`_106`, not as an allele name. That is the
+  species code and the salmonid class I locus concatenated, which is real
+  usage, but it is not `Saal-UBA*01:01` and the comment says so rather than
+  rounding it up.
 
-- **Three outcomes, not two.** A network failure is not evidence that a release
-  is missing, so `pypi_released_versions` returns `None` for "could not ask"
-  and a set for "asked". Conflating them with an empty set would fail every
-  offline deploy. Present -> exit 0, unknown -> exit 0 with no claim of
-  success, absent -> exit 3.
+- **Two negatives now have evidence rather than silence**, and are pinned in
+  the canary test: peafowl class II is deposited as `(B-LB) gene, B-LB-12
+  allele` -- the chicken nomenclature, no `Pacr` anywhere -- and `Xetr` does
+  occur in GenBank, as clone tags like `Xetr-T2R54` for bitter taste
+  receptors, not for MHC.
 
-- **Exit 3, not 1**, so a caller can tell "the release did not land" from "the
-  script could not run".
+- **#131 is now 157 designated / 19 unknown**, from 11/163 when filed and 30
+  before this. Ten of the nineteen are group nodes with no organism of their
+  own; the other nine are Boin, Chpi, EudyChrys, Mega, MesoCriAu, NeosScha,
+  Pacr, StriOccCaur and Xetr.
 
-- **The failure message cannot say "re-run deploy.sh".** The tag is pushed by
-  then, so a re-run stops on `ensure_tag_absent` -- the trap #152 was about. It
-  prints the `twine upload` line for the artifacts already in `dist/` instead.
-
-- **Verified:** 14 new tests; breaking either mechanism (returning an empty set
-  for an unreachable index, or exiting 0 on absent) fails 5 of them. 16,387
-  tests pass.
-- Bumped to 3.55.0.
+- **Measured:** 0 of 36,752 corpus names change -- provenance is metadata, not
+  parsing. 16,387 tests pass.
+- Bumped to 3.56.0.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -691,6 +691,15 @@ def test_unestablished_provenance_stays_none():
         # Felis sp. and Oryctolagus sp. used to be on this list and are not any
         # more: FLA and RLA are published (PMID 2492667, PMID 32522857) and are
         # now marked designated.
+        #
+        # Pavo cristatus is here for a different reason and is worth keeping:
+        # GenBank AY928104.1 names peafowl class II as "(B-LB) gene, B-LB-12
+        # allele", the chicken B-LB nomenclature, with no Pacr anywhere. And
+        # Xenopus tropicalis, whose Xetr does appear in GenBank -- as clone
+        # tags like "Xetr-T2R54" for bitter taste receptors, not for MHC.
+        # Neither absence is for want of looking.
+        "Pavo cristatus",
+        "Xenopus tropicalis",
         "Aotus sp.",
         "Callithrix sp.",
         "Gorilla sp.",


### PR DESCRIPTION
Advances #131: **157 designated / 19 unknown**, from 30 unknown before this.

### I stopped short of my own method

The `Iibi` finding in #165 came from searching GenBank nuccore, because
deposited records name species prefixes at allele level. I then reported the
remaining 30 entries as "could not establish" having searched only PubMed and
the IPD group tables. Running the same sweep across all of them establishes
**eleven**.

### A query shape hid two more

The first pass asked for
`"<species>"[Organism] AND (<prefix> OR MHC OR "histocompatibility")`. For a
species with hundreds of MHC records, the prefix hits fall outside `retmax`
and the sweep reports nothing. Re-run with the prefix **required**, `Spau` and
`Saal` appeared immediately. A zero from a query that could not have found the
answer is not a negative result.

### Ten with allele-level names

| prefix | species | GenBank |
|---|---|---|
| `Acda` | *Acipenser dabryanus* | `Acda-DAB*1102` (MN249667.1) |
| `Crac` | *Crocodylus acutus* | `Crac-DB01`…`-DB06` (GU126827.1) |
| `Crpo` | *Crocodylus porosus* | `Crpo-DAB2` (KP118846.1) |
| `Ctau` | *Ctenomys australis* | `Ctau-DRB23` (KY906279.1) |
| `Ctpe` | *Ctenomys pearsoni* | `Ctpe-DQA03` (EU035225.1) |
| `Ctta` | *Ctenomys talarum* | `Ctta-DRB26` (KY906266.1) |
| `Ctto` | *Ctenomys torquatus* | `Ctto-DQA02` (EU035230.1) |
| `Eqbu` | *Equus burchelli* | `DQB-Eqbu-DQB*0401` (MF997196.1) |
| `Orcu` | *Oryctolagus cuniculus* | `Orcu-U2*05:02:01:01` (PV167019.1) |
| `Spau` | *Sparus aurata* | `Spau-DAA-214` (DQ019411.1) |

### One weaker, and the entry says so rather than rounding it up

`Saal` appears in 98 records as the **isolate** label `Saal_UBA_101`…`_106` —
the species code and the salmonid class I locus concatenated — not as an allele
name. No `Saal-UBA*…` is deposited. The comment states the form so the next
reader can judge it, instead of summarising it as attestation.

### Two negatives now have evidence instead of silence

Both pinned in the canary test, so they cannot be quietly filled in later:

- **`Pacr`** — peafowl class II is deposited as `(B-LB) gene, B-LB-12 allele`,
  the *chicken* nomenclature. No `Pacr` anywhere.
- **`Xetr`** — does occur in GenBank, as clone tags like `Xetr-T2R54` for
  **bitter taste receptors**. Used as a species tag, never for MHC. Marking it
  on that would be the `Iibi` mistake pointed the other way.

### Measurement

- 0 of 36,752 corpus names change — provenance is metadata, not parsing.
- 16,387 tests pass.

Nineteen remain: ten are group nodes with no organism of their own, and the
other nine are `Boin`, `Chpi`, `EudyChrys`, `Mega`, `MesoCriAu`, `NeosScha`,
`Pacr`, `StriOccCaur`, `Xetr`.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH