### PR TITLE
Add the rabbit class I locus series Orcu-U1..U9 (#170)

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -3517,6 +3517,35 @@ Oryctolagus cuniculus:
   prefix source: designated
   prefix: Orcu
   name: European rabbit
+  genes:
+    # The rabbit class I locus series, deposited in GenBank as Orcu-U1 through
+    # Orcu-U9 across 104 records -- e.g. PV167019.1, "Oryctolagus cuniculus MHC
+    # class I antigen (Orcu-U2) gene, Orcu-U2*05:02:01:01 allele". The
+    # submissions accompany Zhang et al., "MHC-I diversity enables rapid
+    # adaptation during a viral pandemic in wild rabbit populations", PNAS
+    # 2026;123:e2532064123 (PMID 42113988).
+    #
+    # Filed as class I with no subclass: the records say "MHC class I antigen"
+    # and nothing establishes which of the nine are classical. Kept on the
+    # species rather than on Oryctolagus sp., because that is what the records
+    # name; the A/A1/A2/A3/D series on the parent node is the older RLA-A
+    # nomenclature (PMID 32522857) and is left alone. How the two relate is
+    # open -- see #170.
+    #
+    # An older set of 21 records labels the gene with the bare species code and
+    # writes alleles as "Orcu*19" (KU848263.1). That is deliberately not added:
+    # making a species prefix its own gene name is the shape that put a class
+    # II beta chain symbol in the prefix column for the prairie chicken (#165).
+    I:
+      - U1
+      - U2
+      - U3
+      - U4
+      - U5
+      - U6
+      - U7
+      - U8
+      - U9
 ################################################################################
 #
 # Passerine birds

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.56.0"
+__version__ = "3.57.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,42 +1,46 @@
-# Establish 11 more prefixes from GenBank (#131)
+# Add the rabbit class I locus series Orcu-U1..U9 (#170)
 
 ## Review
 
-- **I stopped short of my own method.** The `Iibi` finding in #165 came from
-  searching GenBank nuccore, and it worked because deposited records name
-  species prefixes at allele level. I then reported the remaining 30 entries as
-  "could not establish" having searched only PubMed and the IPD group tables.
-  Running the same nuccore sweep across all of them establishes **eleven**.
+- **Filed this issue and then answered it.** I found `Orcu-U2*05:02:01:01`
+  failing to parse while establishing the `Orcu` prefix from GenBank (#169),
+  filed #170, and handed it back on the grounds that `U` is the teleost class I
+  convention and so deserved the literature rather than an accession title.
+  Reading further settles it in the other direction.
 
-- **A query shape hid two more.** The first sweep asked for
-  `"<species>"[Organism] AND (<prefix> OR MHC OR histocompatibility)`, so for
-  species with many MHC records the prefix hits fell outside `retmax`. Re-run
-  with the prefix *required*, `Spau` and `Saal` appeared. A zero from a query
-  that could not have found the answer is not a negative result.
+- **It is a system, not a submitter's label.** GenBank has 104
+  *Oryctolagus cuniculus* MHC class I records spread over nine loci:
 
-- **Nine with allele-level names**: Acda (`Acda-DAB*1102`), Crac (`Crac-DB01`
-  through `-DB06`), Crpo (`Crpo-DAB2`), Ctau (`Ctau-DRB23`), Ctpe
-  (`Ctpe-DQA03`), Ctta (`Ctta-DRB26`), Ctto (`Ctto-DQA02`), Eqbu
-  (`DQB-Eqbu-DQB*0401`), Orcu (`Orcu-U2*05:02:01:01`). Plus Spau
-  (`Spau-DAA-214`).
+      Orcu-U1  29    Orcu-U4  10    Orcu-U7   9
+      Orcu-U2  17    Orcu-U5   5    Orcu-U8   9
+      Orcu-U3  13    Orcu-U6   5    Orcu-U9   7
 
-- **One weaker, and said so in the entry.** `Saal` appears in 98 records as the
-  *isolate* label `Saal_UBA_101`..`_106`, not as an allele name. That is the
-  species code and the salmonid class I locus concatenated, which is real
-  usage, but it is not `Saal-UBA*01:01` and the comment says so rather than
-  rounding it up.
+  The submissions accompany Zhang et al., "MHC-I diversity enables rapid
+  adaptation during a viral pandemic in wild rabbit populations", PNAS
+  2026;123:e2532064123 (PMID 42113988), whose authors include Jim Kaufman. The
+  `U` prefix being a non-mammalian convention is what made it worth checking,
+  and is not evidence against it.
 
-- **Two negatives now have evidence rather than silence**, and are pinned in
-  the canary test: peafowl class II is deposited as `(B-LB) gene, B-LB-12
-  allele` -- the chicken nomenclature, no `Pacr` anywhere -- and `Xetr` does
-  occur in GenBank, as clone tags like `Xetr-T2R54` for bitter taste
-  receptors, not for MHC.
+- **Filed as class I with no subclass.** The records say "MHC class I antigen"
+  and nothing establishes which of the nine are classical.
 
-- **#131 is now 157 designated / 19 unknown**, from 11/163 when filed and 30
-  before this. Ten of the nineteen are group nodes with no organism of their
-  own; the other nine are Boin, Chpi, EudyChrys, Mega, MesoCriAu, NeosScha,
-  Pacr, StriOccCaur and Xetr.
+- **On the species, not the genus node**, because that is what the records
+  name. The A/A1/A2/A3/D series stays where it is on `Oryctolagus sp.` under
+  the RLA prefix (PMID 32522857); how the two nomenclatures relate is still
+  open and is the remaining half of #170.
 
-- **Measured:** 0 of 36,752 corpus names change -- provenance is metadata, not
-  parsing. 16,387 tests pass.
-- Bumped to 3.56.0.
+- **The bare `Orcu*19` form is deliberately not added.** Twenty-one older
+  records label the gene with the species code itself. Making a prefix its own
+  gene name is the shape that put a class II beta chain symbol in the prefix
+  column for the greater prairie chicken (#165).
+
+- **Bare `U1` and `U2` stop resolving, and that is the honest answer.** Rattus
+  sp. declares both, so they are now genuinely ambiguous between rat and
+  rabbit; nothing attests the bare form for either, and the rat won them only
+  by being the sole declarer. `RT1-U1` and `Orcu-U1` both work. U3-U9 have one
+  declarer and resolve bare.
+
+- **Measured:** 0 of 36,752 corpus names change. Of 1,080 gene forms, 4 stop
+  resolving (`U1`, `U2` and their allele forms) and 14 start. 16,409 tests
+  pass.
+- Bumped to 3.57.0.

--- a/tests/test_rabbit_class1_loci.py
+++ b/tests/test_rabbit_class1_loci.py
@@ -1,0 +1,93 @@
+"""
+The rabbit class I locus series, and the ambiguity adding it creates.
+
+`Orcu-U2*05:02:01:01` is deposited in GenBank and did not parse: Oryctolagus
+cuniculus declared no genes of its own, inheriting A/A1/A2/A3/D from
+Oryctolagus sp. -- the older RLA-A nomenclature. GenBank carries a second,
+systematic series across 104 records, Orcu-U1 through Orcu-U9, submitted
+alongside Zhang et al., PNAS 2026;123:e2532064123 (PMID 42113988).
+
+Adding it makes bare "U1" and "U2" genuinely ambiguous, because Rattus sp.
+declares those two as well. Under the #130 rule they stop resolving, which is
+the honest answer: nothing attests the bare form for either species, and the
+rat only won them by being the sole declarer.
+
+https://github.com/pirl-unc/mhcgnomes/issues/170
+https://www.ncbi.nlm.nih.gov/nuccore/PV167019.1
+"""
+
+import pytest
+
+from mhcgnomes import Allele, Gene, Species, parse
+
+from .common import eq_, ok_
+
+RABBIT_LOCI = ["U1", "U2", "U3", "U4", "U5", "U6", "U7", "U8", "U9"]
+
+# The two the rat also declares, as RT1-U1 and RT1-U2.
+SHARED_WITH_RAT = ["U1", "U2"]
+
+
+@pytest.mark.parametrize("gene_name", RABBIT_LOCI)
+def test_each_rabbit_locus_resolves_under_its_prefix(gene_name):
+    gene = parse(f"Orcu-{gene_name}", required_result_types=[Gene])
+    eq_(gene.name, gene_name)
+    eq_(gene.species.name, "Oryctolagus cuniculus")
+
+
+def test_the_deposited_allele_name_parses():
+    allele = parse("Orcu-U2*05:02:01:01", required_result_types=[Allele])
+    eq_(allele.to_string(), "Orcu-U2*05:02:01:01")
+    eq_(allele.gene.name, "U2")
+
+
+@pytest.mark.parametrize("gene_name", SHARED_WITH_RAT)
+def test_a_locus_both_species_declare_names_neither_on_its_own(gene_name):
+    rat = Species.get_by_latin_name("Rattus sp.")
+    rabbit = Species.get_by_latin_name("Oryctolagus cuniculus")
+    ok_(rat.declares_gene(gene_name), f"Rattus sp. no longer declares {gene_name}")
+    ok_(rabbit.declares_gene(gene_name), f"the rabbit no longer declares {gene_name}")
+    # Bare resolved to the rat before this, only because the rat was the sole
+    # declarer. Both prefixed forms still work, which is the point.
+    eq_(parse(gene_name, raise_on_error=False), None)
+    eq_(parse(f"{gene_name}*01:01", raise_on_error=False), None)
+    eq_(parse(f"RT1-{gene_name}").species.name, "Rattus sp.")
+    eq_(parse(f"Orcu-{gene_name}").species.name, "Oryctolagus cuniculus")
+
+
+@pytest.mark.parametrize("gene_name", [g for g in RABBIT_LOCI if g not in SHARED_WITH_RAT])
+def test_a_locus_only_the_rabbit_declares_still_resolves_bare(gene_name):
+    eq_(parse(gene_name).species.name, "Oryctolagus cuniculus")
+
+
+def test_the_older_rla_nomenclature_is_untouched():
+    """
+    A/A1/A2/A3/D sit on Oryctolagus sp. under the RLA prefix (PMID 32522857).
+    How that series relates to Orcu-U1..U9 is the open half of #170, so nothing
+    here merges or replaces them.
+    """
+    eq_(parse("RLA-A1*01:01").to_string(), "RLA-A1*01:01")
+    eq_(parse("Orcu-A1").species.name, "Oryctolagus cuniculus")
+    eq_(parse("RLA-A1").species.name, "Oryctolagus sp.")
+
+
+def test_the_bare_species_code_is_not_a_gene_name():
+    """
+    21 older GenBank records label the gene with the species code itself and
+    write alleles as "Orcu*19" (KU848263.1). Adding that would make a prefix
+    its own gene name -- the shape that put a class II beta chain symbol in the
+    prefix column for the greater prairie chicken (#165).
+    """
+    eq_(parse("Orcu*19", raise_on_error=False), None)
+    ok_(not Species.get_by_latin_name("Oryctolagus cuniculus").declares_gene("Orcu"))
+
+
+def test_the_loci_sit_on_the_species_not_the_genus_node():
+    # The records name Oryctolagus cuniculus, so that is where they go. RLA-U2
+    # is not a deposited spelling and does not resolve.
+    eq_(parse("RLA-U2", raise_on_error=False), None)
+    rabbit = Species.get_by_latin_name("Oryctolagus cuniculus")
+    genus = Species.get_by_latin_name("Oryctolagus sp.")
+    for gene_name in RABBIT_LOCI:
+        ok_(rabbit.declares_gene(gene_name), f"{gene_name} left the species entry")
+        ok_(not genus.declares_gene(gene_name), f"{gene_name} moved up to the genus node")


### PR DESCRIPTION
Answers the first half of #170, which I filed a few hours ago and then handed
back on the grounds that `U` is the *teleost* class I convention (`UBA`, `UDA`)
and so deserved the literature rather than an accession title. Reading further
settles it the other way.

### It is a system, not a submitter's label

GenBank has **104** *Oryctolagus cuniculus* MHC class I records across nine
loci:

```
Orcu-U1  29    Orcu-U4  10    Orcu-U7   9
Orcu-U2  17    Orcu-U5   5    Orcu-U8   9
Orcu-U3  13    Orcu-U6   5    Orcu-U9   7
```

The submissions accompany Zhang et al., *"MHC-I diversity enables rapid
adaptation during a viral pandemic in wild rabbit populations"*, PNAS
2026;123:e2532064123 (PMID 42113988), whose authors include Jim Kaufman. The
`U` prefix being a non-mammalian convention is what made it worth checking, and
is not evidence against it.

| input | `main` | here |
|---|---|---|
| `Orcu-U2*05:02:01:01` | `None` | `Orcu-U2*05:02:01:01` |
| `Orcu-U1` … `Orcu-U9` | `None` | resolve |
| `RT1-U1`, `RT1-U2` | resolve | resolve |
| `U1`, `U2` | `RT1-U1`, `RT1-U2` | **`None`** |
| `U3` … `U9` | `None` | `Orcu-U3` … |
| `Orcu*19` | `None` | `None` |

### Bare `U1` and `U2` stop resolving, and that is the honest answer

*Rattus sp.* declares both, so they are now genuinely ambiguous between rat and
rabbit. Nothing attests the bare form for either species — the rat won them
only by being the sole declarer, which is the accident #130 exists to stop.
Both prefixed forms still work.

### Three deliberate restraints

- **Class I with no subclass.** The records say "MHC class I antigen"; nothing
  establishes which of the nine are classical.
- **On the species, not the genus node.** That is what the records name. The
  A/A1/A2/A3/D series stays on `Oryctolagus sp.` under the RLA prefix
  (PMID 32522857), and how the two nomenclatures relate is the remaining half
  of #170. `RLA-U2` is not a deposited spelling and does not resolve.
- **`Orcu*19` is not added.** 21 older records label the gene with the species
  code itself. Making a prefix its own gene name is exactly the shape that put
  a class II beta chain symbol in the prefix column for the greater prairie
  chicken (#165).

### Measurement

- 0 of 36,752 corpus names change.
- Of 1,080 gene forms, 4 stop resolving (`U1`, `U2` and their allele forms) and
  14 start.
- 16,409 tests pass; 22 new.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH