### PR TITLE
Record a haplotype locus that is positively absent (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,26 @@ lookup, so the shorthand keeps its meaning.
 'HLA-N'
 ```
 
+### A locus a haplotype does not have
+
+Some haplotypes are defined partly by what is *missing*. The swine haplotype
+`Hp-2.0` has no SLA-3 at all, which its source states as `null`, and
+low-resolution swine types are written `SLA-1*15XX or Blank`. That is a
+different claim from a locus nobody typed, so it is recorded rather than left
+out:
+
+```python
+>>> hap = mhcgnomes.parse("Hp-2.0")
+>>> [allele.to_string() for allele in hap.alleles]
+['SLA-1*02:01', 'SLA-1*07:01', 'SLA-2*02:01']
+>>> [gene.to_string() for gene in hap.absent_genes]
+['SLA-3']
+```
+
+`absent_genes` is empty for every haplotype that does not say otherwise, and it
+narrows with the alleles beside it: `parse("Hp-2.0 class II").absent_genes` is
+empty, because an absent class I locus says nothing about a class II reading.
+
 ### Mutations
 
 MHC proteins are sometimes described in terms of mutations to a known allele.

--- a/mhcgnomes/data/haplotypes.yaml
+++ b/mhcgnomes/data/haplotypes.yaml
@@ -41,10 +41,15 @@ SLA:
   # this haplotype, "0201(a), 0701(b)", and *null* for SLA-3 -- the locus is
   # absent, not unknown. The third allele here used to read SLA-3*02:01, which
   # is the SLA-2 column misfiled under SLA-3.
+  #
+  # "3*Blank" is how that null is written. Omitting SLA-3 would record it as a
+  # locus nobody typed, which is a different claim from one the source says is
+  # not there. Reachable as Haplotype.absent_genes. See #162.
   Hp-2.0:
     - 1*02:01
     - 1*07:01
     - 2*02:01
+    - 3*Blank
   # Yucatan miniature pigs; the most prevalent class I haplotype in Danish
   # commercial pigs by its low-resolution counterpart Lr-4.0.
   Hp-4b.0:

--- a/mhcgnomes/haplotype.py
+++ b/mhcgnomes/haplotype.py
@@ -16,9 +16,11 @@ from typing import Union
 
 from .allele import Allele
 from .class2_locus import Class2Locus
+from .gene import Gene
 from .mhc_class_helpers import (
     is_valid_restriction,
     restrict_alleles,
+    restrict_genes,
 )
 from .pair import Pair
 from .result_with_multiple_alleles import ResultWithMultipleAlleles
@@ -80,6 +82,11 @@ class Haplotype(ResultWithMultipleAlleles):
     class_restriction: Union[str, None] = None
     locus_restriction: Union[Class2Locus, None] = None
     parent_haplotypes: Union[tuple["Haplotype", ...], None] = None
+    # Loci this haplotype positively lacks, as against loci nobody typed. See
+    # Parser._blank_locus_gene_name and issue #162. Deliberately not in
+    # eq_field_names: a haplotype's identity is its species and name, which is
+    # why `alleles` is not there either.
+    absent_genes: tuple["Gene", ...] = ()
 
     def __init__(
         self,
@@ -90,6 +97,7 @@ class Haplotype(ResultWithMultipleAlleles):
         locus_restriction: Union[Class2Locus, None] = None,
         parent_haplotypes: Union[Sequence["Haplotype"], None] = None,
         raw_string: Union[str, None] = None,
+        absent_genes: Union[Sequence["Gene"], None] = None,
     ):
         ResultWithMultipleAlleles.__init__(
             self, species=species, name=name, alleles=alleles, raw_string=raw_string
@@ -101,6 +109,7 @@ class Haplotype(ResultWithMultipleAlleles):
             "parent_haplotypes",
             tuple(parent_haplotypes) if parent_haplotypes is not None else None,
         )
+        self._set_field(self, "absent_genes", tuple(absent_genes or ()))
 
     @classmethod
     def str_field_names(cls):
@@ -138,6 +147,13 @@ class Haplotype(ResultWithMultipleAlleles):
             class_restriction=class_restriction,
             locus_restriction=self.locus_restriction,
             raw_string=self.raw_string,
+            # Restricted by the same rule as the alleles beside them --
+            # restrict_alleles, not is_valid_restriction, which answers a
+            # different question and would have dropped SLA-3 ("Ia") from a
+            # class I reading. Dropping the field here instead would be the
+            # #137 failure: a rebuilt object quietly losing what its source
+            # said.
+            absent_genes=restrict_genes(self.absent_genes, class_restriction),
         )
 
     def restrict_class2_locus(self, class2_locus: Class2Locus, raise_on_error=True):
@@ -162,6 +178,9 @@ class Haplotype(ResultWithMultipleAlleles):
             class_restriction=self.class_restriction,
             locus_restriction=class2_locus,
             raw_string=self.raw_string,
+            # Same rule as the alleles beside them: keep only the loci this
+            # restriction is about.
+            absent_genes=[gene for gene in self.absent_genes if gene in valid_genes],
         )
 
     def collapse_if_possible(self):

--- a/mhcgnomes/mhc_class_helpers.py
+++ b/mhcgnomes/mhc_class_helpers.py
@@ -68,6 +68,26 @@ def restrict_alleles(alleles, mhc_class):
     return [allele for allele in alleles if allele.mhc_class in valid_subtypes]
 
 
+def restrict_genes(genes, mhc_class):
+    """
+    The gene-level twin of restrict_alleles, sharing its subtype table.
+
+    Written because Haplotype.absent_genes has to survive a class restriction
+    on the same terms as the alleles beside it. is_valid_restriction answers a
+    different question -- may this restriction be applied at all -- and returns
+    False for ("Ia", "I"), so using it here silently dropped a class I locus
+    from a class I reading.
+    """
+    if mhc_class == "I":
+        valid_subtypes = class1_restrictions
+    elif mhc_class == "II":
+        valid_subtypes = class2_restrictions
+    else:
+        valid_subtypes = {mhc_class}
+
+    return [gene for gene in genes if gene.mhc_class in valid_subtypes]
+
+
 def normalize_mhc_class_string(mhc_class, raise_on_error=True):
     original_string = mhc_class
     mhc_class = mhc_class.lower()

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -81,6 +81,25 @@ def _spelling_as_written(normalized_name, raw_name):
     return normalized_name
 
 
+def _blank_locus_gene_name(member: str):
+    """
+    The gene name in a "<gene>*Blank" haplotype member, or None.
+
+    A blank locus is a positive finding -- the haplotype carries no allele
+    there -- as against a locus nobody typed. Published swine haplotypes state
+    it: Table 2 of PMC5472656 gives Hp-2.0's SLA-3 as *null*, and low-resolution
+    types are written "SLA-1*15XX or Blank". Leaving the locus out of the list
+    records it as untyped instead, which is a different claim. See issue #162.
+    """
+    if member.count("*") != 1:
+        return None
+    gene_name, allele_field = member.split("*")
+    if allele_field.strip().lower() not in ("blank", "null"):
+        return None
+    gene_name = gene_name.strip()
+    return gene_name or None
+
+
 def _lie_in_one_lineage(species_objects):
     """
     Is every one of these species an ancestor or descendant of every other?
@@ -337,7 +356,20 @@ class Parser:
             return None
 
         alleles = []
+        absent_genes = []
         for allele_name in allele_names:
+            blank_gene_name = _blank_locus_gene_name(allele_name)
+            if blank_gene_name is not None:
+                gene = Gene.get(species, blank_gene_name)
+                if gene is None:
+                    print(
+                        f"Warning: unknown gene '{blank_gene_name}' marked blank "
+                        f"for '{normalized_name}'"
+                    )
+                else:
+                    absent_genes.append(gene)
+                continue
+
             candidates = self.parse_allele_or_gene_candidates(
                 species, str_after_species=allele_name
             )
@@ -349,7 +381,7 @@ class Parser:
                 )
             else:
                 alleles.append(allele)
-        return (normalized_name, alleles)
+        return (normalized_name, alleles, absent_genes)
 
     def get_serotype(self, species: Union[Species, str], serotype_name: str):
         """
@@ -371,7 +403,15 @@ class Parser:
         if name_and_alleles is None:
             return None
 
-        normalized_name, alleles = name_and_alleles
+        normalized_name, alleles, absent_genes = name_and_alleles
+        if absent_genes:
+            # A serotype is a set of alleles that cross-react, not a locus map,
+            # so "blank" says nothing there. Loudly, because a silent drop is
+            # how the swine haplotypes lost their alleles for years (#143).
+            raise ParseError(
+                f"Serotype '{normalized_name}' marks "
+                f"{[gene.name for gene in absent_genes]} blank; only haplotypes may."
+            )
 
         return Serotype(
             species=species, name=normalized_name, alleles=alleles, raw_string=serotype_name
@@ -540,10 +580,14 @@ class Parser:
         if name_and_alleles is None:
             return None
 
-        normalized_name, alleles = name_and_alleles
+        normalized_name, alleles, absent_genes = name_and_alleles
 
         return Haplotype(
-            species=species, name=normalized_name, alleles=alleles, raw_string=haplotype_name
+            species=species,
+            name=normalized_name,
+            alleles=alleles,
+            absent_genes=absent_genes,
+            raw_string=haplotype_name,
         )
 
     def create_crossed_haplotype(

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.58.0"
+__version__ = "3.59.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,37 +1,38 @@
-# Re-spell three prefixes to the form the emitter produces (#129, #131)
+# A haplotype locus that is positively absent (#162)
 
 ## Review
 
-- **Asked, and got an answer.** These three had been sitting in #131's
-  "unestablished" list and #129's "you declined the rename" bucket at once,
-  which is not a place a decision can be made from. The call was to re-spell
-  them to 4+4, keeping the old spellings as aliases.
+- **Built on the decision, not on my recommendation.** I had argued for waiting
+  until the `Lr-` data is available, because the only consumer today is one
+  row. The call was to build it now, so `Hp-2.0` says what its source says
+  rather than recording it in a YAML comment.
 
-- **What was wrong with them.** Each followed no rule this library implements:
+- **Syntax follows the published notation.** Swine types are written
+  "SLA-1*15XX or Blank", so a member is `<gene>*Blank` -- `null` accepted too,
+  since Table 2 of PMC5472656 words it that way. Allele fields are numeric, so
+  it cannot be confused with one.
 
-      EudyChrys   4+5, a shape no tier has produced since 3.42.0 removed 5+5,
-                  while its own siblings are EudyFilh and EudyScla
-      MesoCriAu   not 2+2 (Meau), not 4+4 (MesoAura), not the binomial, next
-                  to a hamster spelled CricGris
-      NeosScha    not even a truncation of the genus -- Neomonachus gives
-                  "Neom", not "Neos"
+- **The bug I predicted appeared, in the place I predicted.**
+  `restrict_mhc_class` rebuilds a `Haplotype` from scratch, so a new field is
+  what such a method forgets -- the #137 shape. It did not forget it; it
+  filtered it with the wrong predicate. `is_valid_restriction` answers "may
+  this restriction be applied at all" and returns **False** for `("Ia", "I")`,
+  so `Hp-2.0 class I` kept its three class I alleles and lost its class I
+  absent locus. The alleles beside them go through `restrict_alleles`, which
+  uses a subtype table. Fixed with a `restrict_genes` twin sharing that table.
 
-  None was attested in the registry, the literature or IPD.
+- **The serotype path needed a guard, not a pass-through.** The loader is
+  shared with `Serotype`, and a serotype is a set of cross-reacting alleles
+  rather than a locus map, so `Blank` says nothing there. It raises. A silent
+  drop is how the swine haplotypes lost their alleles for years (#143).
 
-- **All three new forms were already aliases**, so promoting them collided with
-  nothing: `Species.get("EudyChry")` resolved to the right penguin before this.
+- **The #143 guard was extended rather than relaxed.** "Every curated haplotype
+  keeps every allele" now also requires every blank member to survive, so a
+  blank cannot be quietly dropped either.
 
-- **`EudyChry` carries a note.** It is also what the 4+4 rule would give
-  *Eudyptes chrysolophus*, the macaroni penguin, which this ontology does not
-  carry -- which may well be why the odd 4+5 form was chosen. A test fails if
-  that species is ever added, so the tie has to be broken deliberately.
+- **Not added to equality.** A haplotype's identity is its species and name --
+  which is why `alleles` is not in `eq_field_names` either.
 
-- **#131 drops 19 -> 16.** Not by finding a source but by removing a false
-  question: a prefix the emitter would produce is one we minted, and now says
-  so instead of reporting `None` and looking like an unchecked claim about the
-  outside world.
-
-- **Measured:** 113 of 36,752 corpus names change, every one of them one of the
-  three renames and nothing else. Old spellings still parse and normalize to
-  the new form. 16,423 tests pass.
-- Bumped to 3.58.0.
+- **Verified:** reverting the `restrict_genes` call fails 2 tests. 16,439 tests
+  pass. 0 corpus differences, since no bundled corpus name is a swine haplotype.
+- Bumped to 3.59.0.

--- a/tests/test_blank_haplotype_locus.py
+++ b/tests/test_blank_haplotype_locus.py
@@ -1,0 +1,142 @@
+"""
+A haplotype locus that is positively absent, as against one nobody typed.
+
+Published swine haplotypes state it. Table 2 of PMC5472656 gives Hp-2.0's
+SLA-3 as *null*, and low-resolution types are written "SLA-1*15XX or Blank".
+Leaving the locus out of the member list records it as untyped, which is a
+different claim, so #143 could only put the fact in a YAML comment.
+
+`<gene>*Blank` in haplotypes.yaml now says it, and it comes back as
+`Haplotype.absent_genes`.
+
+https://github.com/pirl-unc/mhcgnomes/issues/162
+"""
+
+import pytest
+
+from mhcgnomes import Haplotype, Serotype, parse
+from mhcgnomes.errors import ParseError
+from mhcgnomes.parser import Parser, _blank_locus_gene_name
+
+from .common import eq_, ok_
+
+
+def _absent(haplotype):
+    return sorted(gene.to_string() for gene in haplotype.absent_genes)
+
+
+def test_the_swine_haplotype_records_its_null_locus():
+    haplotype = parse("Hp-2.0", required_result_types=[Haplotype])
+    eq_(
+        sorted(a.to_string() for a in haplotype.alleles),
+        ["SLA-1*02:01", "SLA-1*07:01", "SLA-2*02:01"],
+    )
+    eq_(_absent(haplotype), ["SLA-3"])
+
+
+def test_a_haplotype_with_no_blank_has_an_empty_tuple_not_none():
+    haplotype = parse("Hp-17.0", required_result_types=[Haplotype])
+    eq_(haplotype.absent_genes, ())
+
+
+@pytest.mark.parametrize(
+    "member,expected",
+    [
+        ("3*Blank", "3"),
+        ("3*blank", "3"),
+        ("3*null", "3"),
+        ("DRB1*BLANK", "DRB1"),
+        ("3*02:01", None),  # a real allele
+        ("3", None),  # a bare gene
+        ("*Blank", None),  # no gene named
+        ("3*01*Blank", None),  # not a single field
+    ],
+)
+def test_the_member_syntax_is_recognized_exactly(member, expected):
+    eq_(_blank_locus_gene_name(member), expected)
+
+
+# ---------------------------------------------------------------------------
+# The bug this was always going to have
+# ---------------------------------------------------------------------------
+
+
+def test_a_class_restriction_keeps_the_absent_locus_it_is_about():
+    """
+    restrict_mhc_class rebuilds the Haplotype from scratch, so a new field is
+    exactly what such a method forgets -- the #137 failure shape.
+
+    The first version of this used is_valid_restriction, which answers "may
+    this restriction be applied at all" and returns False for ("Ia", "I"). That
+    dropped SLA-3 from a class I reading while the class I alleles beside it
+    survived, because they go through restrict_alleles.
+    """
+    unrestricted = parse("Hp-2.0", required_result_types=[Haplotype])
+    eq_(_absent(unrestricted), ["SLA-3"])
+
+    class1 = unrestricted.restrict_mhc_class("I")
+    eq_(_absent(class1), ["SLA-3"], "a class I locus vanished from a class I reading")
+    eq_(len(class1.alleles), 3)
+
+    class2 = unrestricted.restrict_mhc_class("II")
+    eq_(_absent(class2), [])
+    eq_(len(class2.alleles), 0)
+
+
+def test_the_parsed_class_restricted_form_agrees():
+    eq_(_absent(parse("Hp-2.0 class I")), ["SLA-3"])
+    eq_(_absent(parse("Hp-2.0 class II")), [])
+
+
+def test_a_class2_locus_restriction_also_carries_the_field():
+    # The other rebuilder. SLA-3 is class I, so no class II locus keeps it --
+    # what matters is that the code path runs rather than raising or dropping
+    # the attribute.
+    haplotype = parse("Hp-2.0", required_result_types=[Haplotype])
+    for locus in ["DR", "DQ"]:
+        restricted = haplotype.restrict_class2_locus(parse(f"SLA-{locus}"))
+        if restricted is not None:
+            eq_(restricted.absent_genes, ())
+
+
+# ---------------------------------------------------------------------------
+# Serotypes share the loader and must not silently accept it
+# ---------------------------------------------------------------------------
+
+
+def test_a_serotype_that_marks_a_locus_blank_is_an_error():
+    """
+    _find_matching_name_and_parse_alleles is shared with Serotype. A serotype
+    is a set of cross-reacting alleles, not a locus map, so "blank" says
+    nothing there -- and a silent drop is how the swine haplotypes lost their
+    alleles for years (#143).
+    """
+    from mhcgnomes.normalizing_dictionary import NormalizingDictionary
+    from mhcgnomes.species import Species
+
+    human = Species.get("HLA")
+    table = NormalizingDictionary()
+    table["FakeSero"] = ["A*02:01", "B*Blank"]
+
+    parser = Parser()
+    normalized, alleles, absent = parser._find_matching_name_and_parse_alleles(
+        query_name="FakeSero", name_to_alleles_dict=table, species=human
+    )
+    # The helper reports it rather than dropping it...
+    eq_(normalized, "FakeSero")
+    eq_([gene.to_string() for gene in absent], ["HLA-B"])
+    eq_([allele.to_string() for allele in alleles], ["HLA-A*02:01"])
+
+    # ...and get_serotype refuses it out loud.
+    original = human.serotypes
+    try:
+        object.__setattr__(human, "serotypes", table)
+        with pytest.raises(ParseError, match="blank"):
+            parser.get_serotype(human, "FakeSero")
+    finally:
+        object.__setattr__(human, "serotypes", original)
+
+
+def test_ordinary_serotypes_still_parse():
+    result = parse("HLA-A2", required_result_types=[Serotype])
+    ok_(len(result.alleles) > 0)

--- a/tests/test_swine_haplotypes.py
+++ b/tests/test_swine_haplotypes.py
@@ -25,6 +25,7 @@ import pytest
 
 from mhcgnomes import Haplotype, parse
 from mhcgnomes.data import haplotypes as raw_haplotypes
+from mhcgnomes.parser import _blank_locus_gene_name
 
 from .common import eq_, ok_
 
@@ -32,7 +33,7 @@ from .common import eq_, ok_
 # the alleles Table 2 lists for it.
 SLA_HAPLOTYPES = {
     "Hp-1a.0": ["SLA-1*01:01", "SLA-2*01:01", "SLA-3*01:01"],
-    "Hp-2.0": ["SLA-1*02:01", "SLA-1*07:01", "SLA-2*02:01"],
+    "Hp-2.0": ["SLA-1*02:01", "SLA-1*07:01", "SLA-2*02:01"],  # plus SLA-3 blank
     "Hp-4b.0": ["SLA-1*04:01", "SLA-2*04:02:01", "SLA-3*04:01"],
     "Hp-6.0": ["SLA-1*08:05", "SLA-2*05:04", "SLA-3*06:01"],
     "Hp-7.0": ["SLA-1*08:01", "SLA-2*05:02", "SLA-3*07:01:01"],
@@ -60,6 +61,14 @@ def test_swine_haplotype_parses_with_and_without_the_species_prefix(name):
     # prefix. Both spellings appear in print.
     eq_(parse(name).to_string(), f"SLA-{name}")
     eq_(parse(f"SLA-{name}").to_string(), f"SLA-{name}")
+
+
+def test_hp_2_0_records_its_null_sla3_rather_than_omitting_it():
+    """
+    Table 2 gives SLA-3 as *null* for this haplotype. Since #162 that is data
+    rather than a comment.
+    """
+    eq_([gene.to_string() for gene in parse("Hp-2.0").absent_genes], ["SLA-3"])
 
 
 def test_hp_2_0_has_no_class3_allele():
@@ -105,9 +114,19 @@ def test_every_curated_haplotype_keeps_every_allele(prefix, name, allele_names):
     with redirect_stdout(captured):
         result = parse(f"{prefix}-{name}", required_result_types=[Haplotype], raise_on_error=False)
     ok_(result is not None, f"{prefix}-{name} has no haplotype reading")
+    # A "<gene>*Blank" member is a locus the haplotype positively lacks, so it
+    # lands in absent_genes rather than alleles (#162). It is still a member,
+    # and still must not be dropped.
+    blank_members = [m for m in allele_names if _blank_locus_gene_name(m) is not None]
+    expected_alleles = len(allele_names) - len(blank_members)
     eq_(
         len(result.alleles),
-        len(allele_names),
-        f"{prefix}-{name} kept {len(result.alleles)} of {len(allele_names)} alleles"
+        expected_alleles,
+        f"{prefix}-{name} kept {len(result.alleles)} of {expected_alleles} alleles"
         + (f"; parser said: {captured.getvalue().strip()}" if captured.getvalue() else ""),
+    )
+    eq_(
+        len(result.absent_genes),
+        len(blank_members),
+        f"{prefix}-{name} kept {len(result.absent_genes)} of {len(blank_members)} blank loci",
     )


### PR DESCRIPTION
Builds the half of #162 you asked for. The `Lr-` curation still waits on
Ho et al. 2009 or Hammer et al. 2020, both paywalled.

### What it records

Some haplotypes are defined partly by what is *missing*. Table 2 of PMC5472656
gives `Hp-2.0`'s SLA-3 as **null**, and low-resolution swine types are written
`SLA-1*15XX or Blank`. Leaving the locus out of the member list records it as
*untyped*, which is a different claim — so #143 could only put the fact in a
YAML comment.

```python
>>> hap = mhcgnomes.parse("Hp-2.0")
>>> [a.to_string() for a in hap.alleles]
['SLA-1*02:01', 'SLA-1*07:01', 'SLA-2*02:01']
>>> [g.to_string() for g in hap.absent_genes]
['SLA-3']
```

The member syntax follows the published notation: `<gene>*Blank`, with `null`
accepted too since the source words it that way. Allele fields are numeric, so
neither can be mistaken for one.

### The bug I expected showed up in the place I expected

I argued against building this partly because `restrict_mhc_class` rebuilds a
`Haplotype` from scratch, so a new field is exactly what such a method forgets
— the #137 shape. It did not forget it. It filtered it with the **wrong
predicate**:

```python
>>> is_valid_restriction("Ia", "I")
False
```

`is_valid_restriction` answers *"may this restriction be applied at all"*, not
*"does this belong to this class"*. So `Hp-2.0 class I` kept its three class I
alleles and lost its class I absent locus. The alleles beside them go through
`restrict_alleles`, which uses a subtype table; `absent_genes` now goes through
a `restrict_genes` twin sharing that table. **Reverting it fails 2 tests.**

### The serotype path guards rather than passes through

The loader is shared with `Serotype`, where a blank says nothing — a serotype
is a set of cross-reacting alleles, not a locus map. It raises. A silent drop
is how the swine haplotypes lost their alleles for years.

### The #143 guard was extended, not relaxed

"Every curated haplotype keeps every allele" now also requires every blank
member to survive, across all 71 haplotypes — so a blank cannot be quietly
dropped either.

### Deliberately not in equality

A haplotype's identity is its species and name, which is why `alleles` is not
in `eq_field_names` either.

### Measurement

- 0 corpus differences — no bundled corpus name is a swine haplotype, which is
  why #143's broken entries survived so long.
- 16,439 tests pass; 15 new.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH