### PR TITLE
Establish Chpi from UniProt (#131)

### DIFF
--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -4425,6 +4425,13 @@ Gallus gallus:
 ################################################################################
 Chrysolophus pictus:
   parent: Galliformes sp.
+  # prefix source: designated -- UniProt curates the golden pheasant class I
+  # sequences under gene names that carry the prefix: A0A0U1ZFQ3 "Chpi-IA1",
+  # A0A0U1ZFL7 "Chpi-IA2", A0A0U1ZCW0 "Chpi-IA3", all on Chrysolophus pictus
+  # and all referencing PMID 26700854 -- the same paper cited for IA3's
+  # pseudogene status below, which writes the loci as IA1/IA2/IA3 without the
+  # prefix. https://rest.uniprot.org/uniprotkb/A0A0U1ZFQ3
+  prefix source: designated
   prefix: Chpi
   # ChryPict is derivable by the 4+4 rule from this species and from
   # Chrysemys picta (painted turtle) so it names neither; see "contested

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.59.0"
+__version__ = "3.59.1"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,38 +1,30 @@
-# A haplotype locus that is positively absent (#162)
+# Establish Chpi from UniProt (#131)
 
 ## Review
 
-- **Built on the decision, not on my recommendation.** I had argued for waiting
-  until the `Lr-` data is available, because the only consumer today is one
-  row. The call was to build it now, so `Hp-2.0` says what its source says
-  rather than recording it in a YAML comment.
+- **One source I had never queried.** The `underrepresented_taxa_source_registry`
+  is built from UniProt gene names -- `uniprot_gene_name: Tycu-IA` is what its
+  own entries record -- and I had gone through IPD, PubMed and GenBank without
+  once asking UniProt. Same gap as the GenBank one, one layer along.
 
-- **Syntax follows the published notation.** Swine types are written
-  "SLA-1*15XX or Blank", so a member is `<gene>*Blank` -- `null` accepted too,
-  since Table 2 of PMC5472656 words it that way. Allele fields are numeric, so
-  it cannot be confused with one.
+- **It settles Chrysolophus pictus.** UniProt curates the golden pheasant class
+  I sequences under prefixed gene names: A0A0U1ZFQ3 `Chpi-IA1`, A0A0U1ZFL7
+  `Chpi-IA2`, A0A0U1ZCW0 `Chpi-IA3`, all referencing PMID 26700854 -- the paper
+  already cited in this entry for IA3's pseudogene status, which writes the
+  loci as IA1/IA2/IA3 *without* the prefix. The prefix is in the database
+  curation rather than the paper text, which is why PubMed searching missed it.
 
-- **The bug I predicted appeared, in the place I predicted.**
-  `restrict_mhc_class` rebuilds a `Haplotype` from scratch, so a new field is
-  what such a method forgets -- the #137 shape. It did not forget it; it
-  filtered it with the wrong predicate. `is_valid_restriction` answers "may
-  this restriction be applied at all" and returns **False** for `("Ia", "I")`,
-  so `Hp-2.0 class I` kept its three class I alleles and lost its class I
-  absent locus. The alleles beside them go through `restrict_alleles`, which
-  uses a subtype table. Fixed with a `restrict_genes` twin sharing that table.
+- **And it strengthens two negatives rather than leaving them silent.** A
+  `gene:Pacr*` search returns human PACRG and PACRGL; `gene:Xetr*` returns
+  nothing. Those are negatives from a source that demonstrably finds the
+  positives, which is worth more than an absence of hits, and the canary test
+  now says so.
 
-- **The serotype path needed a guard, not a pass-through.** The loader is
-  shared with `Serotype`, and a serotype is a set of cross-reacting alleles
-  rather than a locus map, so `Blank` says nothing there. It raises. A silent
-  drop is how the swine haplotypes lost their alleles for years (#143).
+- **Queried twice, with different shapes**, after the GenBank retmax lesson:
+  `"<prefix>" AND organism_name:"<species>"` and `gene:<prefix>*`. Boin, Mega,
+  Pacr, StriOccCaur and Xetr are empty on both.
 
-- **The #143 guard was extended rather than relaxed.** "Every curated haplotype
-  keeps every allele" now also requires every blank member to survive, so a
-  blank cannot be quietly dropped either.
+- **#131 is 158 designated / 15 unknown**, from 11/163 when filed.
 
-- **Not added to equality.** A haplotype's identity is its species and name --
-  which is why `alleles` is not in `eq_field_names` either.
-
-- **Verified:** reverting the `restrict_genes` call fails 2 tests. 16,439 tests
-  pass. 0 corpus differences, since no bundled corpus name is a swine haplotype.
-- Bumped to 3.59.0.
+- **Measured:** 0 of 36,752 corpus names change. 16,439 tests pass.
+- Bumped to 3.59.1.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -697,7 +697,11 @@ def test_unestablished_provenance_stays_none():
         # allele", the chicken B-LB nomenclature, with no Pacr anywhere. And
         # Xenopus tropicalis, whose Xetr does appear in GenBank -- as clone
         # tags like "Xetr-T2R54" for bitter taste receptors, not for MHC.
-        # Neither absence is for want of looking.
+        # Neither absence is for want of looking. UniProt says the same: a
+        # gene:Pacr* search returns human PACRG and PACRGL, and gene:Xetr*
+        # returns nothing at all. It is the source that settled Chrysolophus
+        # pictus, which UniProt curates as Chpi-IA1/IA2/IA3, so these two are
+        # negatives from a source that demonstrably finds the positives.
         "Pavo cristatus",
         "Xenopus tropicalis",
         "Aotus sp.",


### PR DESCRIPTION
Advances #131: **158 designated / 15 unknown**.

### A source I had never queried

The `underrepresented_taxa_source_registry` is built from UniProt gene names —
its own entries record things like `uniprot_gene_name: Tycu-IA` — and I had
worked through IPD's eleven group tables, PubMed and GenBank without once
asking UniProt directly. Same shape as the GenBank gap caught two PRs ago, one
layer along.

### It settles *Chrysolophus pictus*

UniProt curates the golden pheasant class I sequences under **prefixed** gene
names:

| accession | gene | organism |
|---|---|---|
| [A0A0U1ZFQ3](https://rest.uniprot.org/uniprotkb/A0A0U1ZFQ3) | `Chpi-IA1` | *Chrysolophus pictus* |
| A0A0U1ZFL7 | `Chpi-IA2` | *Chrysolophus pictus* |
| A0A0U1ZCW0 | `Chpi-IA3` | *Chrysolophus pictus* |

All three reference **PMID 26700854** — the paper *already cited in this entry*
for IA3's pseudogene status, and which writes the loci as `IA1`/`IA2`/`IA3`
**without** the prefix. The prefix lives in the database curation rather than
the paper text, which is exactly why searching PubMed for it found nothing.

### It also strengthens two negatives

`gene:Pacr*` returns human `PACRG` and `PACRGL`; `gene:Xetr*` returns nothing
at all. Those are negatives from a source that demonstrably finds the
positives, which is worth more than an absence of hits — the canary test now
records that reasoning rather than just the names.

### Queried twice, deliberately

After the GenBank `retmax` lesson, each prefix went through two query shapes:
`"<prefix>" AND organism_name:"<species>"` and `gene:<prefix>*`. `Boin`,
`Mega`, `Pacr`, `StriOccCaur` and `Xetr` are empty on both.

### Measurement

- 0 of 36,752 corpus names change — provenance is metadata, not parsing.
- 16,439 tests pass.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH