### PR TITLE
Record the turkey negative, and that a search summary invented it (#131)

### DIFF
--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.59.1"
+__version__ = "3.59.2"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,30 +1,28 @@
-# Establish Chpi from UniProt (#131)
+# Record the turkey negative, and that a search summary invented it (#131)
 
 ## Review
 
-- **One source I had never queried.** The `underrepresented_taxa_source_registry`
-  is built from UniProt gene names -- `uniprot_gene_name: Tycu-IA` is what its
-  own entries record -- and I had gone through IPD, PubMed and GenBank without
-  once asking UniProt. Same gap as the GenBank one, one layer along.
+- **A web search produced a plausible-looking answer, and it was wrong.** For
+  `Mega` (*Meleagris gallopavo*) the summary asserted that turkey class I genes
+  use "Mega-Ia1" and "Mega-Ia2". Both primary papers say otherwise:
+  "Defining the turkey MHC: sequence and genes of the B locus" (PMID 19864609)
+  and its class I/IIB sequel (PMID 21710346) describe the turkey MHC as
+  **MHC-B** and **MHC-Y** -- the chicken system -- and neither writes `Mega-`.
 
-- **It settles Chrysolophus pictus.** UniProt curates the golden pheasant class
-  I sequences under prefixed gene names: A0A0U1ZFQ3 `Chpi-IA1`, A0A0U1ZFL7
-  `Chpi-IA2`, A0A0U1ZCW0 `Chpi-IA3`, all referencing PMID 26700854 -- the paper
-  already cited in this entry for IA3's pseudogene status, which writes the
-  loci as IA1/IA2/IA3 *without* the prefix. The prefix is in the database
-  curation rather than the paper text, which is why PubMed searching missed it.
+- **GenBank agrees.** Of 35 turkey MHC records, **zero** contain "Mega-". The
+  gene labels are `MHC-B` (10), `IIb1`, `IIb2`, `IIb3`, `DMB2`. Same pattern as
+  the peafowl, deposited under the chicken `B-LB` nomenclature.
 
-- **And it strengthens two negatives rather than leaving them silent.** A
-  `gene:Pacr*` search returns human PACRG and PACRGL; `gene:Xetr*` returns
-  nothing. Those are negatives from a source that demonstrably finds the
-  positives, which is worth more than an absence of hits, and the canary test
-  now says so.
+- **So `Mega` moves from silence to evidence against**, joining `Pacr` and
+  `Xetr` in the canary test. Three of the five remaining unknowns now have a
+  positive reason rather than an absence of hits.
 
-- **Queried twice, with different shapes**, after the GenBank retmax lesson:
-  `"<prefix>" AND organism_name:"<species>"` and `gene:<prefix>*`. Boin, Mega,
-  Pacr, StriOccCaur and Xetr are empty on both.
+- **Third time this issue.** A summary of the IPD group list once reported
+  "CLA = cat" and "CeLA = deer", both wrong. The mhcseqs registry cites the
+  de Groot report for six `_LA` codes it does not contain. And now this. The
+  protocol that caught all three is the same: use search to find candidate
+  sources, then read each one verbatim before believing it.
 
-- **#131 is 158 designated / 15 unknown**, from 11/163 when filed.
-
-- **Measured:** 0 of 36,752 corpus names change. 16,439 tests pass.
-- Bumped to 3.59.1.
+- **Verified:** 16,439 tests pass; no data changed, so no corpus measurement
+  applies.
+- Bumped to 3.59.2.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -702,6 +702,19 @@ def test_unestablished_provenance_stays_none():
         # returns nothing at all. It is the source that settled Chrysolophus
         # pictus, which UniProt curates as Chpi-IA1/IA2/IA3, so these two are
         # negatives from a source that demonstrably finds the positives.
+        #
+        # Meleagris gallopavo is here on the same footing, and is worth a
+        # sentence because a web search claims otherwise. Search summaries
+        # assert that turkey class I uses "Mega-Ia1"/"Mega-Ia2"; the primary
+        # sources do not. "Defining the turkey MHC: sequence and genes of the B
+        # locus" (PMID 19864609) and its class I/IIB sequel (PMID 21710346)
+        # both describe the turkey MHC as MHC-B and MHC-Y, the chicken system,
+        # and none of the 35 GenBank turkey MHC records contains "Mega-" --
+        # they are labelled MHC-B, IIb1, IIb2, IIb3. Same pattern as the
+        # peafowl's B-LB. This is the third time in this issue that a summary
+        # invented a plausible nomenclature: see also "CLA = cat" and the
+        # de Groot citation for the six _LA codes.
+        "Meleagris gallopavo",
         "Pavo cristatus",
         "Xenopus tropicalis",
         "Aotus sp.",


### PR DESCRIPTION
Doc/test-only, patch bump. Converts one of #131's five silences into a negative
with evidence, and records why the evidence was needed.

### A search summary invented a nomenclature

Chasing `Mega` (*Meleagris gallopavo*) with a general web search — the one
avenue I had not tried — returned a summary asserting that turkey class I genes
use `Mega-Ia1` and `Mega-Ia2`.

They do not. Both primary papers describe the turkey MHC as **MHC-B** and
**MHC-Y**, the chicken system:

- *"Defining the turkey MHC: sequence and genes of the B locus"* (PMID 19864609)
- *"Defining the turkey MHC: identification of expressed class I- and class IIB-like genes independent of the MHC-B"* (PMID 21710346)

Neither writes `Mega-`. And of **35** GenBank turkey MHC records, **zero**
contain it — the gene labels are `MHC-B` (10), `IIb1`, `IIb2`, `IIb3`, `DMB2`.
The same pattern as the peafowl, whose class II is deposited under the chicken
`B-LB` nomenclature.

### So `Mega` joins `Pacr` and `Xetr`

Three of #131's five remaining unknowns now carry a positive reason rather than
an absence of hits, all pinned in the canary test so none can be quietly filled
in later.

### Third time in this issue

- A summary of the IPD group list once reported *"CLA = cat"* and *"CeLA = deer"*. Both wrong — CLA is goat, CeLA is cetacean.
- The mhcseqs registry cites the de Groot report as evidence for six `_LA` codes it does not contain.
- And now this.

The protocol that caught all three is the same, and is worth the repetition in
the test comment: use search to find candidate *sources*, then read each one
verbatim before believing anything.

16,439 tests pass. No data changed, so no corpus measurement applies.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH