### PR TITLE
Add an opt-in policy for printing only attested prefixes (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,29 @@ Provenance is not part of a result's identity: two alleles that differ only in
 how their species was determined still compare equal and hash the same. It is
 also computed only when asked, so it costs nothing if you never look.
 
+### Printing only the prefixes a source attests
+
+`HLA-A*02:01` and `CyanCaer-DAB1` look alike, but only the first is published
+nomenclature — the second was minted here so the blue tit would have a unique
+prefix. `prefix_provenance` tells them apart, and an opt-in display policy acts
+on it:
+
+```python
+>>> from mhcgnomes.prefix_display_policy import prefix_display_policy, ATTESTED
+>>> parse("CyanCaer-DAB1").to_string()
+'CyanCaer-DAB1'
+>>> with prefix_display_policy(ATTESTED):
+...     parse("CyanCaer-DAB1").to_string()
+'CyanistesCaeruleus-DAB1'
+>>> with prefix_display_policy(ATTESTED):
+...     parse("HLA-A*02:01").to_string()   # designated, so untouched
+'HLA-A*02:01'
+```
+
+The default is unchanged, both spellings parse under either policy, and group
+labels such as `SLA` and `BoLA` keep their labels. `set_prefix_display_policy`
+is the process-wide form; the policy is thread-local.
+
 A gene symbol only carries a species when it belongs to one lineage. `DRB1` is
 declared by 45 species across humans, cattle, dogs and horses, so on its own it
 names none of them:

--- a/mhcgnomes/prefix_display_policy.py
+++ b/mhcgnomes/prefix_display_policy.py
@@ -1,0 +1,109 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Which prefix normalized output uses.
+
+Issue #129 asks for a display policy: print a short prefix only where an
+external database or the literature attests it, and otherwise the concatenated
+binomial, so that ``CyanistesCaeruleus-DAB1`` cannot be mistaken for
+established nomenclature the way ``CyanCaer-DAB1`` can. It proposes shipping
+that "as an explicit formatting policy first, then become the default in a
+documented minor release".
+
+This is the first half. The default is unchanged, so nothing anyone parses
+today prints differently; asking for ATTESTED opts in.
+
+The question the policy asks is ``Species.prefix_provenance``, which #131 spent
+its length populating: "designated" means a source is cited beside the entry in
+species.yaml, and every other value means the prefix is one this package
+minted. So the policy is not a fresh judgement -- it reads a curated one.
+
+    >>> parse("CyanCaer-DAB1").to_string()
+    'CyanCaer-DAB1'
+    >>> with prefix_display_policy(ATTESTED):
+    ...     parse("CyanCaer-DAB1").to_string()
+    'CyanistesCaeruleus-DAB1'
+    >>> with prefix_display_policy(ATTESTED):
+    ...     parse("HLA-A*02:01").to_string()   # designated, so unchanged
+    'HLA-A*02:01'
+
+Both spellings keep parsing under either policy. The compatibility change #129
+describes is display only.
+"""
+
+from contextlib import contextmanager
+from threading import local
+
+# Print the prefix curated in species.yaml, whatever its provenance. What
+# mhcgnomes has always done, and still the default.
+CURATED = "curated"
+
+# Print a short prefix only where prefix_provenance says a source attests it,
+# and the concatenated binomial otherwise.
+ATTESTED = "attested"
+
+POLICIES = (CURATED, ATTESTED)
+
+# Thread-local rather than a plain module global: a policy set in one thread
+# must not change what another thread is midway through formatting.
+_state = local()
+
+
+def get_prefix_display_policy() -> str:
+    """The policy in force on this thread."""
+    return getattr(_state, "policy", CURATED)
+
+
+def set_prefix_display_policy(policy: str) -> None:
+    """
+    Set the policy for this thread until it is set again.
+
+    Prefer `prefix_display_policy`, the context manager; this exists for
+    callers configuring a process once at startup.
+    """
+    if policy not in POLICIES:
+        raise ValueError(f"Unknown prefix display policy {policy!r}; expected one of {POLICIES}")
+    _state.policy = policy
+
+
+@contextmanager
+def prefix_display_policy(policy: str):
+    """Use `policy` for the duration of the block, then restore the previous one."""
+    previous = get_prefix_display_policy()
+    set_prefix_display_policy(policy)
+    try:
+        yield
+    finally:
+        set_prefix_display_policy(previous)
+
+
+def display_prefix_for(species) -> str:
+    """
+    The prefix to print for this species under the current policy.
+
+    Falls back to the curated prefix wherever a binomial cannot produce one --
+    group nodes such as `Bos sp.`, and trinomials, which the emitter declines.
+    Those keep their labels under either policy, which is #129's own point 6.
+    """
+    # `canonical_mhc_prefix`, not `.prefix`: on a Species those are the same
+    # value, but `.prefix` now routes back through this function, so reading it
+    # here recurses until the stack gives out.
+    curated = species.canonical_mhc_prefix
+    if get_prefix_display_policy() == CURATED:
+        return curated
+    if species.prefix_provenance == "designated":
+        return curated
+
+    from .species import unambiguous_prefix_for
+
+    return unambiguous_prefix_for(species)

--- a/mhcgnomes/result_with_species.py
+++ b/mhcgnomes/result_with_species.py
@@ -13,6 +13,7 @@
 from dataclasses import dataclass
 from typing import Any
 
+from .prefix_display_policy import display_prefix_for
 from .result import Result
 
 
@@ -36,7 +37,10 @@ class ResultWithSpecies(Result):
 
     @property
     def species_prefix(self):
-        return self.species.prefix
+        # Every to_string in the package reads this one property, which is why
+        # the display policy lives here rather than as a parameter on ten
+        # signatures. The default is unchanged. See prefix_display_policy, #129.
+        return display_prefix_for(self.species)
 
     @property
     def species_common_name(self):

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -538,7 +538,12 @@ class Species(Result):
 
     @property
     def species_prefix(self):
-        return self.canonical_mhc_prefix
+        # A bare Species prints under the same policy as everything carrying
+        # one. Imported inside the property because prefix_display_policy asks
+        # this module for unambiguous_prefix_for. See #129.
+        from .prefix_display_policy import display_prefix_for
+
+        return display_prefix_for(self)
 
     @property
     def prefix(self):
@@ -1212,7 +1217,9 @@ def unambiguous_prefix_for(species):
     full = _make_full_scientific_prefix(species.name)
     if full and len(_scientific_name_parts(species.name)) == 2:
         return full
-    return species.prefix
+    # The curated field rather than `.prefix`, which routes through
+    # prefix_display_policy and would call straight back here.
+    return species.canonical_mhc_prefix
 
 
 def _derive_prefix_provenance(prefix, latin_name):

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.59.2"
+__version__ = "3.60.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,28 +1,39 @@
-# Record the turkey negative, and that a search summary invented it (#131)
+# An opt-in policy for printing only attested prefixes (#129)
 
 ## Review
 
-- **A web search produced a plausible-looking answer, and it was wrong.** For
-  `Mega` (*Meleagris gallopavo*) the summary asserted that turkey class I genes
-  use "Mega-Ia1" and "Mega-Ia2". Both primary papers say otherwise:
-  "Defining the turkey MHC: sequence and genes of the B locus" (PMID 19864609)
-  and its class I/IIB sequel (PMID 21710346) describe the turkey MHC as
-  **MHC-B** and **MHC-Y** -- the chicken system -- and neither writes `Mega-`.
+- **The issue proposes this, and I had not read it closely enough.** #129's
+  "API/compatibility shape" section says the change "could ship as an explicit
+  formatting policy first, then become the default in a documented minor
+  release". The 467-species migration was declined; the opt-in policy had never
+  been on the table. I had been reporting the whole issue as blocked on a
+  decision that only covered half of it.
 
-- **GenBank agrees.** Of 35 turkey MHC records, **zero** contain "Mega-". The
-  gene labels are `MHC-B` (10), `IIb1`, `IIb2`, `IIb3`, `DMB2`. Same pattern as
-  the peafowl, deposited under the chicken `B-LB` nomenclature.
+- **It reads a curated judgement rather than making a new one.**
+  `Species.prefix_provenance` is what #131 spent its length populating:
+  "designated" means a URL or PMID sits beside the entry. So the policy is one
+  branch -- designated keeps its short prefix, everything else prints the
+  concatenated binomial.
 
-- **So `Mega` moves from silence to evidence against**, joining `Pacr` and
-  `Xetr` in the canary test. Three of the five remaining unknowns now have a
-  positive reason rather than an absence of hits.
+- **One property, not ten signatures.** Every `to_string` in the package reads
+  `species_prefix`, so the policy lives there. No call-site churn, and
+  `MhcClass`, `Haplotype`, `Serotype` and a bare `Species` all inherit it.
 
-- **Third time this issue.** A summary of the IPD group list once reported
-  "CLA = cat" and "CeLA = deer", both wrong. The mhcseqs registry cites the
-  de Groot report for six `_LA` codes it does not contain. And now this. The
-  protocol that caught all three is the same: use search to find candidate
-  sources, then read each one verbatim before believing it.
+- **Two recursions, both caught immediately.** `Species.prefix` delegates to
+  `species_prefix`, so reading `.prefix` inside the policy recursed until the
+  stack gave out; the same for `unambiguous_prefix_for`'s fallback. Both now
+  read `canonical_mhc_prefix`, the underlying curated field.
 
-- **Verified:** 16,439 tests pass; no data changed, so no corpus measurement
-  applies.
-- Bumped to 3.59.2.
+- **Thread-local, not a module global**, so a policy set by one caller cannot
+  change what another thread is midway through formatting. There is a test.
+
+- **Found a pre-existing bug while measuring.** Requiring that every printed
+  form parse back showed **148** corpus names that do not -- all CD1, where
+  `Gene.to_string` renders class `Id` genes with the *common species name*:
+  "gray-bellied night monkey-CD1a". Identical count on main, so this change
+  neither caused nor worsened it. Filed separately.
+
+- **Measured:** 0 of 36,752 corpus names change under the default policy. Under
+  ATTESTED, 25,389 printed forms differ and every one parses back. 16,473 tests
+  pass.
+- Bumped to 3.60.0.

--- a/tests/test_prefix_display_policy.py
+++ b/tests/test_prefix_display_policy.py
@@ -1,0 +1,146 @@
+"""
+Printing a short prefix only where a source attests it.
+
+Issue #129: `HLA-A*02:01` and `CyanCaer-DAB1` occupy the same canonical-output
+role, though only the first is established nomenclature and the second was
+minted here for runtime uniqueness. A caller cannot tell them apart from the
+string. The issue proposes shipping the fix "as an explicit formatting policy
+first, then become the default in a documented minor release" -- this is the
+first half, so the default is unchanged and ATTESTED opts in.
+
+The policy asks `Species.prefix_provenance`, which #131 populated: "designated"
+means a URL or PMID sits beside the entry in species.yaml. So it reads a
+curated judgement rather than making a new one.
+
+https://github.com/pirl-unc/mhcgnomes/issues/129
+"""
+
+import pytest
+
+from mhcgnomes import Species, parse
+from mhcgnomes.prefix_display_policy import (
+    ATTESTED,
+    CURATED,
+    display_prefix_for,
+    get_prefix_display_policy,
+    prefix_display_policy,
+    set_prefix_display_policy,
+)
+
+from .common import eq_, ok_
+
+# (input, default output, output under ATTESTED)
+CASES = [
+    # generated prefixes expand to the binomial nobody can mistake for a
+    # published code
+    ("CyanCaer-DAB1", "CyanCaer-DAB1", "CyanistesCaeruleus-DAB1"),
+    ("EudyChry-DMA", "EudyChry-DMA", "EudyptesChrysocome-DMA"),
+    # designated ones are left alone, which is the whole point
+    ("HLA-A*02:01", "HLA-A*02:01", "HLA-A*02:01"),
+    ("Mamu-A*01:01", "Mamu-A*01:01", "Mamu-A*01:01"),
+    ("BoLA-DRB3*01:01", "BoLA-DRB3*01:01", "BoLA-DRB3*01:01"),
+    ("Tycu-BLB*28", "Tycu-BLB*28", "Tycu-BLB*28"),
+    ("H2-Kb", "H2-K*b", "H2-K*b"),
+    # #129 point 6: group and non-binomial nodes keep their labels
+    ("Hp-17.0", "SLA-Hp-17.0", "SLA-Hp-17.0"),
+    ("HLA", "HLA", "HLA"),
+]
+
+
+@pytest.mark.parametrize("text,default_output,attested_output", CASES)
+def test_the_default_is_unchanged(text, default_output, attested_output):
+    eq_(parse(text).to_string(), default_output)
+
+
+@pytest.mark.parametrize("text,default_output,attested_output", CASES)
+def test_attested_expands_only_the_prefixes_we_minted(text, default_output, attested_output):
+    with prefix_display_policy(ATTESTED):
+        eq_(parse(text).to_string(), attested_output)
+
+
+@pytest.mark.parametrize("text,default_output,attested_output", CASES)
+def test_both_spellings_parse_under_either_policy(text, default_output, attested_output):
+    """
+    #129's compatibility requirement: "the intentional compatibility change is
+    normalized/display output rather than loss of accepted inputs."
+    """
+    for policy in (CURATED, ATTESTED):
+        with prefix_display_policy(policy):
+            for spelling in (default_output, attested_output):
+                ok_(
+                    parse(spelling, raise_on_error=False) is not None, f"{spelling} stopped parsing"
+                )
+
+
+def test_the_expanded_form_round_trips():
+    with prefix_display_policy(ATTESTED):
+        expanded = parse("CyanCaer-DAB1").to_string()
+        eq_(expanded, "CyanistesCaeruleus-DAB1")
+        eq_(parse(expanded).to_string(), expanded)
+
+
+# ---------------------------------------------------------------------------
+# The policy itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_policy_restores_itself_even_when_the_block_raises():
+    eq_(get_prefix_display_policy(), CURATED)
+    with pytest.raises(RuntimeError), prefix_display_policy(ATTESTED):
+        raise RuntimeError("boom")
+    eq_(get_prefix_display_policy(), CURATED)
+
+
+def test_nesting_restores_the_outer_policy():
+    with prefix_display_policy(ATTESTED):
+        with prefix_display_policy(CURATED):
+            eq_(parse("CyanCaer-DAB1").to_string(), "CyanCaer-DAB1")
+        eq_(parse("CyanCaer-DAB1").to_string(), "CyanistesCaeruleus-DAB1")
+    eq_(get_prefix_display_policy(), CURATED)
+
+
+def test_an_unknown_policy_is_refused():
+    with pytest.raises(ValueError, match="Unknown prefix display policy"):
+        set_prefix_display_policy("binomial-always")
+    eq_(get_prefix_display_policy(), CURATED)
+
+
+def test_another_thread_is_unaffected():
+    """
+    Thread-local, so a policy set for one caller cannot change what another is
+    midway through formatting.
+    """
+    import threading
+
+    seen = []
+
+    def read_in_thread():
+        seen.append(parse("CyanCaer-DAB1").to_string())
+
+    with prefix_display_policy(ATTESTED):
+        eq_(parse("CyanCaer-DAB1").to_string(), "CyanistesCaeruleus-DAB1")
+        thread = threading.Thread(target=read_in_thread)
+        thread.start()
+        thread.join()
+
+    eq_(seen, ["CyanCaer-DAB1"])
+
+
+def test_the_policy_reads_provenance_rather_than_guessing():
+    human = Species.get_by_latin_name("Homo sapiens")
+    tit = Species.get_by_latin_name("Cyanistes caeruleus")
+    eq_(human.prefix_provenance, "designated")
+    ok_(tit.prefix_provenance != "designated")
+    with prefix_display_policy(ATTESTED):
+        eq_(display_prefix_for(human), "HLA")
+        eq_(display_prefix_for(tit), "CyanistesCaeruleus")
+
+
+def test_a_trinomial_keeps_its_curated_prefix():
+    """
+    The emitter declines trinomials, so there is no binomial to expand to and
+    the curated label stands under either policy.
+    """
+    owl = Species.get_by_latin_name("Strix occidentalis caurina")
+    with prefix_display_policy(ATTESTED):
+        eq_(display_prefix_for(owl), owl.canonical_mhc_prefix)


### PR DESCRIPTION
Ships the half of #129 that was never actually asked about.

### I had been reading this issue as more blocked than it is

Its "API/compatibility shape" section says:

> This could ship as **an explicit formatting policy first**, then become the
> default in a documented minor release.

The 467-species migration was declined. The **opt-in policy** had never been on
the table, and I had been reporting the whole issue as waiting on a decision
that covered only half of it.

### It reads a curated judgement rather than making a new one

`Species.prefix_provenance` is what #131 spent its length populating —
`"designated"` means a URL or PMID sits beside the entry in `species.yaml`. So
the policy is a single branch:

```python
>>> parse("CyanCaer-DAB1").to_string()
'CyanCaer-DAB1'
>>> with prefix_display_policy(ATTESTED):
...     parse("CyanCaer-DAB1").to_string()
'CyanistesCaeruleus-DAB1'
>>> with prefix_display_policy(ATTESTED):
...     parse("HLA-A*02:01").to_string()   # designated, so untouched
'HLA-A*02:01'
```

`HLA`, `Mamu`, `BoLA`, `Tycu`, `H2` are untouched. Group and non-binomial nodes
keep their labels — #129's own point 6.

### One property, not ten signatures

Every `to_string` in the package reads `species_prefix`, so the policy lives
there. No call-site churn, and `MhcClass`, `Haplotype`, `Serotype` and a bare
`Species` all inherit it. It is **thread-local**, so a policy set by one caller
cannot change what another thread is midway through formatting.

Two recursions turned up and are fixed: `Species.prefix` delegates to
`species_prefix`, so reading `.prefix` inside the policy recursed until the
stack gave out — and `unambiguous_prefix_for`'s fallback did the same. Both now
read `canonical_mhc_prefix`, the underlying curated field.

### A pre-existing bug found while measuring

Requiring that every printed form parse back surfaced **148** corpus names that
do not — all CD1, where `Gene.to_string` renders class `Id` genes with the
*common species name*: `gray-bellied night monkey-CD1a`. The count is
**identical on main**, so this change neither caused nor worsened it. Filed
separately.

### Measurement

- **0 of 36,752** corpus names change under the default policy.
- Under `ATTESTED`, 25,389 printed forms differ — and **every one parses back**,
  which is the compatibility guarantee #129 asks for.
- 16,473 tests pass; 34 new.

Points 2 and 3 — making this the default — remain your call, and are now a flag
flip rather than a rewrite.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH