### PR TITLE
Let a species be named by more than three words (#177)

### DIFF
--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -47,6 +47,7 @@ from .result_sorting import pick_best_result
 from .result_with_species import ResultWithSpecies
 from .serotype import Serotype
 from .species import (
+    MAX_SPECIES_NAME_TOKENS_RANGE,
     Species,
     classify_species_source,
     find_matching_species_objects,
@@ -2316,7 +2317,7 @@ class Parser:
 
         species_candidates = []
         found_species_prefix = False
-        for num_species_tokens in [3, 2, 1]:
+        for num_species_tokens in MAX_SPECIES_NAME_TOKENS_RANGE:
             if len(tokens) >= (num_species_tokens + 1):
                 # try peeling off species names such as
                 # "homo sapiens" at the beginning of a token sequence

--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -1647,6 +1647,18 @@ def create_species_lookup_dictionaries():
 ) = create_species_lookup_dictionaries()
 
 
+# How many leading tokens may be a species name. The longest common name in the
+# ontology is five tokens once hyphens are split -- "rio grande silvery minnow"
+# is four, "thirteen-lined ground squirrel" four, and two reach five -- and the
+# window used to stop at three, so none of the 41 names longer than that could
+# be read back. Gene.to_string prints CD1 genes with the common name, so it was
+# emitting 148 strings the parser then refused (#177).
+#
+# tests/test_long_species_names.py fails if a longer name is ever curated.
+MAX_SPECIES_NAME_TOKENS = 5
+MAX_SPECIES_NAME_TOKENS_RANGE = list(range(MAX_SPECIES_NAME_TOKENS, 0, -1))
+
+
 def species_named_in(name):
     """
     Which species, if any, the string names outright.
@@ -1679,7 +1691,7 @@ def species_named_in(name):
 
     tokenization_result = tokenize(name)
     tokens = tokenization_result.tokens
-    for num_species_tokens in [3, 2, 1]:
+    for num_species_tokens in MAX_SPECIES_NAME_TOKENS_RANGE:
         if len(tokens) >= num_species_tokens:
             query = " ".join([t.seq for t in tokens[:num_species_tokens]])
             token_matches = find_matching_species_objects(query)

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.60.0"
+__version__ = "3.61.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,39 +1,36 @@
-# An opt-in policy for printing only attested prefixes (#129)
+# Let a species be named by more than three words (#177)
 
 ## Review
 
-- **The issue proposes this, and I had not read it closely enough.** #129's
-  "API/compatibility shape" section says the change "could ship as an explicit
-  formatting policy first, then become the default in a documented minor
-  release". The 467-species migration was declined; the opt-in policy had never
-  been on the table. I had been reporting the whole issue as blocked on a
-  decision that only covered half of it.
+- **Found by a measurement, not by a report.** #176 required that every printed
+  form parse back. 148 did not, all CD1 -- and chasing why turned up something
+  much wider than CD1.
 
-- **It reads a curated judgement rather than making a new one.**
-  `Species.prefix_provenance` is what #131 spent its length populating:
-  "designated" means a URL or PMID sits beside the entry. So the policy is one
-  branch -- designated keeps its short prefix, everything else prints the
-  concatenated binomial.
+- **The species matcher tried three leading tokens, then two, then one.**
+  Forty-one common names in the ontology are longer than that once hyphens are
+  counted: "north atlantic right whale", "thirteen-lined ground squirrel",
+  "kemp's ridley sea turtle", "rio grande silvery minnow". **None of them could
+  be parsed at all.** Not a CD1 problem -- a whole class of input that silently
+  failed.
 
-- **One property, not ten signatures.** Every `to_string` in the package reads
-  `species_prefix`, so the policy lives there. No call-site churn, and
-  `MhcClass`, `Haplotype`, `Serotype` and a bare `Species` all inherit it.
+- **My first diagnosis on #177 was wrong, and testing it is what corrected it.**
+  I filed the issue blaming hyphens and apostrophes in common names. It is the
+  word count: `gray bellied night monkey-CD1a`, with no punctuation at all,
+  failed identically.
 
-- **Two recursions, both caught immediately.** `Species.prefix` delegates to
-  `species_prefix`, so reading `.prefix` inside the policy recursed until the
-  stack gave out; the same for `unambiguous_prefix_for`'s fallback. Both now
-  read `canonical_mhc_prefix`, the underlying curated field.
+- **The window is now a named bound with a test.** `MAX_SPECIES_NAME_TOKENS = 5`
+  covers the longest name curated, and the test fails if a longer one is added
+  -- otherwise that name silently stops parsing, which is the state all 41 were
+  in.
 
-- **Thread-local, not a module global**, so a policy set by one caller cannot
-  change what another thread is midway through formatting. There is a test.
+- **Measured:** 28 of 36,752 corpus names change, **every one of them `None` ->
+  a result**. Nothing stops parsing; the loop already tried longest-first, so a
+  wider window cannot change a shorter match. All 41 long common names now
+  work. 16,521 tests pass; setting the bound back to 3 fails 16 of them.
 
-- **Found a pre-existing bug while measuring.** Requiring that every printed
-  form parse back showed **148** corpus names that do not -- all CD1, where
-  `Gene.to_string` renders class `Id` genes with the *common species name*:
-  "gray-bellied night monkey-CD1a". Identical count on main, so this change
-  neither caused nor worsened it. Filed separately.
-
-- **Measured:** 0 of 36,752 corpus names change under the default policy. Under
-  ATTESTED, 25,389 printed forms differ and every one parses back. 16,473 tests
-  pass.
-- Bumped to 3.60.0.
+- **#177 keeps the residual, with a sharper diagnosis.** Round-trip failures
+  drop 148 -> 130. The rest are common names whose *first* token contains a
+  hyphen -- "long-haired rat-CD1a" tokenizes as `[long-haired, rat-cd1a]`, so
+  no leading-token query can match. That is a tokenizer question, not a window
+  one.
+- Bumped to 3.61.0.

--- a/tests/test_long_species_names.py
+++ b/tests/test_long_species_names.py
@@ -1,0 +1,97 @@
+"""
+Species named by a common name of more than three words.
+
+The species matcher tried the first three tokens, then two, then one. Forty-one
+common names in the ontology are longer than that once hyphens are counted --
+"north atlantic right whale", "thirteen-lined ground squirrel", "kemp's ridley
+sea turtle" -- so none of them could be read back, and any input naming those
+species by common name simply failed.
+
+Found while measuring #176, which required every printed form to parse back:
+`Gene.to_string` prints CD1 genes with the common species name, so the package
+was emitting strings it then refused.
+
+https://github.com/pirl-unc/mhcgnomes/issues/177
+"""
+
+import pytest
+
+from mhcgnomes import parse
+from mhcgnomes.species import (
+    MAX_SPECIES_NAME_TOKENS,
+    latin_name_to_species_object,
+)
+
+from .common import eq_, ok_
+
+
+def _token_count(name):
+    return len(str(name).replace("-", " ").split())
+
+
+LONG_COMMON_NAMES = sorted(
+    {
+        (str(common_name), species.name)
+        for species in latin_name_to_species_object.values()
+        for common_name in species.all_common_names
+        if _token_count(common_name) > 3
+    }
+)
+
+
+def test_there_are_long_common_names_to_test():
+    ok_(
+        len(LONG_COMMON_NAMES) >= 40,
+        f"only {len(LONG_COMMON_NAMES)} found; did the ontology shrink?",
+    )
+
+
+@pytest.mark.parametrize("common_name,latin_name", LONG_COMMON_NAMES)
+def test_a_long_common_name_can_lead_a_string(common_name, latin_name):
+    result = parse(f"{common_name} class I", raise_on_error=False)
+    ok_(result is not None, f"{common_name!r} does not parse as a leading species name")
+    eq_(result.species.name, latin_name)
+
+
+def test_the_window_covers_the_longest_name_curated():
+    """
+    The constant is a bound on the ontology, so it has to move if a longer name
+    is ever added -- otherwise that name silently stops being parseable, which
+    is the state all 41 of these were in.
+    """
+    longest = max(
+        (
+            (_token_count(common_name), str(common_name), species.name)
+            for species in latin_name_to_species_object.values()
+            for common_name in species.all_common_names
+        ),
+        default=(0, "", ""),
+    )
+    ok_(
+        longest[0] <= MAX_SPECIES_NAME_TOKENS,
+        f"{longest[1]!r} ({longest[2]}) is {longest[0]} tokens, over the "
+        f"MAX_SPECIES_NAME_TOKENS of {MAX_SPECIES_NAME_TOKENS}",
+    )
+
+
+@pytest.mark.parametrize(
+    "text,expected_species",
+    [
+        ("north atlantic right whale class I", "Eubalaena glacialis"),
+        ("north island brown kiwi-B2M", "Apteryx mantelli"),
+        ("nancy ma's night monkey-B2M", "Aotus nancymaae"),
+        ("hong kong whipping frog-DAB", "Polypedates megacephalus"),
+    ],
+)
+def test_names_that_used_to_return_none(text, expected_species):
+    result = parse(text)
+    eq_(result.species.name, expected_species)
+
+
+def test_short_names_are_unaffected():
+    # The loop tries longest first and always did, so a wider window cannot
+    # change what a shorter name matches.
+    eq_(parse("homo sapiens class I").species.name, "Homo sapiens")
+    eq_(parse("human-CD1a").species.name, "Homo sapiens")
+    eq_(parse("rhesus monkey-CD1a").species.name, "Macaca mulatta")
+    eq_(parse("HLA-A*02:01").to_string(), "HLA-A*02:01")


### PR DESCRIPTION
Advances #177, and corrects the diagnosis I filed on it.

### Not hyphens — word count

I filed #177 blaming hyphens and apostrophes in common names. Testing it says
otherwise: `gray bellied night monkey-CD1a`, with no punctuation at all, fails
identically.

The species matcher tried the first **three** tokens, then two, then one. **41
common names in the ontology are longer than that** once hyphens are counted:

```
north atlantic right whale      thirteen-lined ground squirrel
kemp's ridley sea turtle        rio grande silvery minnow
north island brown kiwi         narrow-ridged finless porpoise
```

None of them could be parsed at all. That is not a CD1 problem — it is a whole
class of input that silently failed, and CD1 only exposed it because
`Gene.to_string` prints those genes with the common name.

### The window is now a bound with a test

`MAX_SPECIES_NAME_TOKENS = 5` covers the longest name curated, and
`test_the_window_covers_the_longest_name_curated` fails if a longer one is ever
added — otherwise that name silently stops parsing, which is exactly the state
all 41 were in.

### Measurement

- **28 of 36,752** corpus names change, and **every one is `None` → a result**.
  Nothing stops parsing: the loop already tried longest-first, so a wider window
  cannot change what a shorter name matches.
- All **41** long common names now work as a leading species name.
- 16,521 tests pass; setting the bound back to 3 fails 16 of them.

### What stays on #177

Round-trip failures drop **148 → 130**. The residual is common names whose
*first* token contains a hyphen: `long-haired rat-CD1a` tokenizes as
`[long-haired, rat-cd1a]`, so no leading-token query can match it. That is a
tokenizer question rather than a window one, and worth deciding separately
alongside whether `Gene.to_string`'s CD1 branch should print common names at
all.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH