### PR TITLE
Make every printed form parse back (#177)

### DIFF
--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -1606,6 +1606,19 @@ def combine_species_aliases(
     return result
 
 
+def _hyphens_as_spaces(identifier):
+    """
+    The same identifier with hyphens written as spaces, or None if unchanged.
+
+    Only meaningful for names that already contain a space -- a single
+    hyphenated word normalizes to one token either way, and turning "DMB-1"
+    into "DMB 1" would invent a two-token gene name.
+    """
+    if not isinstance(identifier, str) or "-" not in identifier or " " not in identifier:
+        return None
+    return identifier.replace("-", " ")
+
+
 def create_species_lookup_dictionaries():
     gene_name_to_species_objects = NormalizingDictionary(default_value_fn=set)
     # Canonical index: latin name → species (never ambiguous)
@@ -1624,6 +1637,15 @@ def create_species_lookup_dictionaries():
         species_name_to_species[latin_name] = species
         for s in species.all_identifiers:
             alias_to_species_objects[s].add(species)
+            # A common name written with a hyphen is unreachable from a token
+            # sequence without this. normalize_string *deletes* hyphens, so
+            # "long-haired rat" is stored as LONGHAIRED RAT, while the parser
+            # builds its species query by joining tokens with a space and gets
+            # LONG HAIRED RAT. Registering the space-substituted spelling as
+            # well makes both reachable; it only ever adds keys. See #177.
+            spaced = _hyphens_as_spaces(s)
+            if spaced is not None:
+                alias_to_species_objects[spaced].add(species)
         for s in species.context_only_mhc_prefixes:
             context_only_alias_to_species_objects[s].add(species)
         for gene_name in species.gene_names_and_aliases:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.61.0"
+__version__ = "3.62.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,36 +1,30 @@
-# Let a species be named by more than three words (#177)
+# Make every printed form parse back (#177)
 
 ## Review
 
-- **Found by a measurement, not by a report.** #176 required that every printed
-  form parse back. 148 did not, all CD1 -- and chasing why turned up something
-  much wider than CD1.
+- **The invariant was never tested, which is why 148 names violated it.**
+  Requiring that `parse(x.to_string())` succeed is now a test in its own right,
+  over every CD1 form in the ontology. Whatever is decided later about the CD1
+  branch, printing something unparseable fails here first.
 
-- **The species matcher tried three leading tokens, then two, then one.**
-  Forty-one common names in the ontology are longer than that once hyphens are
-  counted: "north atlantic right whale", "thirteen-lined ground squirrel",
-  "kemp's ridley sea turtle", "rio grande silvery minnow". **None of them could
-  be parsed at all.** Not a CD1 problem -- a whole class of input that silently
-  failed.
+- **Two causes, found by chasing rather than assuming.** #178 fixed the first:
+  the species matcher tried three leading tokens, so 41 long common names were
+  unreachable. That took the failures 148 -> 130 and no further, which is what
+  pointed at the second.
 
-- **My first diagnosis on #177 was wrong, and testing it is what corrected it.**
-  I filed the issue blaming hyphens and apostrophes in common names. It is the
-  word count: `gray bellied night monkey-CD1a`, with no punctuation at all,
-  failed identically.
+- **`normalize_string` deletes hyphens; the parser joins tokens with a space.**
+  So "long-haired rat" is stored as `LONGHAIRED RAT`, while a token sequence
+  produces `LONG HAIRED RAT`. A hyphenated multi-word name could never be
+  reconstructed, however wide the window. Registering the space-substituted
+  spelling as an additional alias makes both reachable, and only ever adds
+  keys.
 
-- **The window is now a named bound with a test.** `MAX_SPECIES_NAME_TOKENS = 5`
-  covers the longest name curated, and the test fails if a longer one is added
-  -- otherwise that name silently stops parsing, which is the state all 41 were
-  in.
+- **Guarded so it cannot invent gene names.** The extra alias is added only for
+  identifiers that already contain a space, so `DMB-1` cannot become the
+  two-token `DMB 1`. There is a test for exactly that.
 
-- **Measured:** 28 of 36,752 corpus names change, **every one of them `None` ->
-  a result**. Nothing stops parsing; the loop already tried longest-first, so a
-  wider window cannot change a shorter match. All 41 long common names now
-  work. 16,521 tests pass; setting the bound back to 3 fails 16 of them.
-
-- **#177 keeps the residual, with a sharper diagnosis.** Round-trip failures
-  drop 148 -> 130. The rest are common names whose *first* token contains a
-  hyphen -- "long-haired rat-CD1a" tokenizes as `[long-haired, rat-cd1a]`, so
-  no leading-token query can match. That is a tokenizer question, not a window
-  one.
-- Bumped to 3.61.0.
+- **Measured:** round-trip failures **130 -> 0**; every printed form in the
+  36,752-name corpus now parses back. 359 corpus names change, **every one
+  `None` -> a result**, none lost. 16,982 tests pass; removing the alias
+  registration fails 127 of them.
+- Bumped to 3.62.0.

--- a/tests/test_printed_forms_parse_back.py
+++ b/tests/test_printed_forms_parse_back.py
@@ -1,0 +1,88 @@
+"""
+Every string this package prints, it must also accept.
+
+That invariant was never tested, and 148 corpus names violated it. All were
+CD1: `Gene.to_string` renders class `Id` genes with the common species name,
+and the parser could not read those names back.
+
+Two separate causes, both now fixed:
+
+  1. The species matcher tried at most three leading tokens, so the 41 common
+     names longer than that were unreachable (#178).
+  2. `normalize_string` *deletes* hyphens, so "long-haired rat" is stored as
+     LONGHAIRED RAT while the parser, joining tokens with a space, asks for
+     LONG HAIRED RAT. Hyphenated multi-word names were unreachable however wide
+     the window.
+
+The round-trip test is the durable part -- whichever way the CD1 branch is
+settled later, printing something unparseable should fail here first.
+
+https://github.com/pirl-unc/mhcgnomes/issues/177
+"""
+
+import pytest
+
+from mhcgnomes import parse
+from mhcgnomes.species import latin_name_to_species_object
+
+from .common import eq_, ok_
+
+# CD1 is the family that exposed this, because it is the one printed with the
+# common species name rather than a prefix.
+CD1_GENES = ["CD1a", "CD1b", "CD1c", "CD1d", "CD1e"]
+
+CD1_CASES = sorted(
+    {
+        (species.prefix, gene_name)
+        for species in latin_name_to_species_object.values()
+        for gene_name in CD1_GENES
+        if gene_name.upper() in {name.upper() for name in species.gene_names}
+    }
+)
+
+
+def test_there_are_cd1_cases_to_check():
+    ok_(len(CD1_CASES) > 100, f"only {len(CD1_CASES)} CD1 forms found; did the ontology change?")
+
+
+@pytest.mark.parametrize("prefix,gene_name", CD1_CASES)
+def test_a_printed_cd1_form_parses_back(prefix, gene_name):
+    printed = parse(f"{prefix}-{gene_name}").to_string()
+    reparsed = parse(printed, raise_on_error=False)
+    ok_(reparsed is not None, f"{prefix}-{gene_name} prints {printed!r}, which does not parse")
+    eq_(reparsed.to_string(), printed)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # a hyphen inside the first word, which no window width could reach
+        ("long-haired rat-CD1a", "long-haired rat-CD1a"),
+        ("RattVill-CD1a", "long-haired rat-CD1a"),
+        # and the same name written without the hyphen
+        ("long haired rat class I", "long-haired rat class I"),
+        # four words with a hyphen and an apostrophe
+        ("kemp's ridley sea turtle-B2M", "LepiKemp-B2M"),
+    ],
+)
+def test_hyphenated_common_names_are_reachable(text, expected):
+    eq_(parse(text).to_string(), expected)
+
+
+def test_a_hyphenated_gene_name_is_not_split_into_two_words():
+    """
+    The alias is added only for identifiers that already contain a space, so
+    "DMB-1" cannot become the two-token gene name "DMB 1".
+    """
+    from mhcgnomes.species import _hyphens_as_spaces
+
+    eq_(_hyphens_as_spaces("DMB-1"), None)
+    eq_(_hyphens_as_spaces("long-haired rat"), "long haired rat")
+    eq_(_hyphens_as_spaces("rhesus monkey"), None)
+    eq_(parse("DMB-1").to_string(), "SpheMend-DMB-1")
+
+
+def test_the_species_that_already_worked_are_untouched():
+    eq_(parse("human-CD1a").to_string(), "human-CD1a")
+    eq_(parse("rhesus monkey-CD1a").to_string(), "rhesus monkey-CD1a")
+    eq_(parse("HLA-A*02:01").to_string(), "HLA-A*02:01")


### PR DESCRIPTION
Closes #177. Round-trip failures go **130 → 0**.

### The invariant was never tested

That this package accepts what it prints had no test, which is why 148 corpus
names violated it. It has one now, over every CD1 form in the ontology —
whatever is decided later about that branch, printing something unparseable
fails here first.

### Two causes, and the first one only got halfway

#178 widened the species-name window from three tokens to five, which reached
the 41 long common names and took the failures 148 → 130. Stopping there is
what pointed at the second cause.

`normalize_string` **deletes** hyphens, while the parser builds its species
query by **joining tokens with a space**:

```
stored :  "long-haired rat"  ->  LONGHAIRED RAT
asked  :  [long-haired, rat] ->  LONG HAIRED RAT
```

So a hyphenated multi-word name could never be reconstructed, however wide the
window. Registering the space-substituted spelling as an additional alias makes
both reachable, and only ever adds keys.

```python
>>> parse("long-haired rat-CD1a").to_string()
'long-haired rat-CD1a'
>>> parse("long haired rat class I").to_string()   # either spelling
'long-haired rat class I'
```

### Guarded so it cannot invent gene names

The extra alias is added only for identifiers that **already contain a space**,
so `DMB-1` cannot become the two-token gene name `DMB 1`. There is a test for
exactly that, and `parse("DMB-1")` still gives `SpheMend-DMB-1`.

### Measurement

- Round-trip failures across the 36,752-name corpus: **130 → 0**.
- **359** corpus names change, **every one `None` → a result**. None lost.
- 16,982 tests pass; removing the alias registration fails **127** of them.

The CD1 question from the issue body — whether `Gene.to_string` should print
common names at all — is now cosmetic rather than a correctness problem, since
both spellings work either way.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH