### PR TITLE
Resolve an identifier shared with descendants to the containing node (#129)

### DIFF
--- a/mhcgnomes/species.py
+++ b/mhcgnomes/species.py
@@ -620,11 +620,21 @@ class Species(Result):
         ]
         if len(prefix_matches) == 1:
             return prefix_matches[0]
-        # 3. For auto-generated long prefixes (e.g., CanisLupus), prefer
-        # the species that isn't a subspecies (no parent with same identifier)
-        non_child = [sp for sp in species_objects if sp.parent_species is None]
-        if len(non_child) == 1:
-            return non_child[0]
+        # 3. When one claimant contains all the others, it is the answer: an
+        # identifier shared by a node and its own descendants names the node.
+        # "MusSp" reaches this shape and is settled by step 2 because it is
+        # also Mus sp.'s prefix, but a shared *common name* has no step 2 --
+        # "tropheus cichlid" belongs to Tropheus sp. and to Tropheus moorii
+        # under it, and used to return None while parse() answered Tropheus sp.
+        #
+        # This used to test `sp.parent_species is None`, which is "has no
+        # parent at all" rather than the "no parent with same identifier" its
+        # comment claimed, so it only ever fired for root entries. A genuine
+        # collision between unrelated species still returns None, which is what
+        # keeps Caau and Hyam honest.
+        containing = _containing_species(species_objects)
+        if containing is not None:
+            return containing
         # Ambiguous alias: return None instead of picking a heuristic winner
         return None
 
@@ -1604,6 +1614,24 @@ def combine_species_aliases(
                         value = old_value + t(value)
                 result[key] = value
     return result
+
+
+def _containing_species(species_objects):
+    """
+    The one claimant that contains all the others, or None.
+
+    An identifier shared by a node and its own descendants names the node.
+    Unrelated claimants have no container, and get None rather than a
+    heuristic winner -- which is what #112 is about.
+    """
+    containing = [
+        candidate
+        for candidate in species_objects
+        if all(other is candidate or candidate.is_ancestor_of(other) for other in species_objects)
+    ]
+    if len(containing) == 1:
+        return containing[0]
+    return None
 
 
 def _hyphens_as_spaces(identifier):

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.62.0"
+__version__ = "3.63.0"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,30 +1,37 @@
-# Make every printed form parse back (#177)
+# A shared identifier names the containing node (#129)
 
 ## Review
 
-- **The invariant was never tested, which is why 148 names violated it.**
-  Requiring that `parse(x.to_string())` succeed is now a test in its own right,
-  over every CD1 form in the ontology. Whatever is decided later about the CD1
-  branch, printing something unparseable fails here first.
+- **Found by asking what else the round-trip technique would find.** Sweeping
+  "does every identifier a species advertises resolve back to it" turned up 109
+  exceptions. 105 were umbrella prefixes resolving to their owner, which is
+  correct and by design. **Four were not.**
 
-- **Two causes, found by chasing rather than assuming.** #178 fixed the first:
-  the species matcher tried three leading tokens, so 41 long common names were
-  unreachable. That took the failures 148 -> 130 and no further, which is what
-  pointed at the second.
+- **`Species.get` disagreed with `parse` about the same string.**
+  `Species.get("swordtail")` returned None while
+  `parse("swordtail class I")` answered *Xiphophorus sp.* The public lookup and
+  the parser giving different answers is the bug; which one is right is
+  secondary.
 
-- **`normalize_string` deletes hyphens; the parser joins tokens with a space.**
-  So "long-haired rat" is stored as `LONGHAIRED RAT`, while a token sequence
-  produces `LONG HAIRED RAT`. A hyphenated multi-word name could never be
-  reconstructed, however wide the window. Registering the space-substituted
-  spelling as an additional alias makes both reachable, and only ever adds
-  keys.
+- **Another comment describing behaviour the code did not implement.** The
+  ladder's step 3 says "prefer the species that isn't a subspecies (no parent
+  with same identifier)" and tested `sp.parent_species is None` -- "no parent at
+  all" -- so it only ever fired for root entries. Umbrella prefixes were
+  unaffected because step 2 catches them: `MusSp` is *Mus sp.*'s own prefix. A
+  shared *common name* has no step 2, so it fell through to None. Same shape as
+  #160, where the case-aware ranking key had never fired.
 
-- **Guarded so it cannot invent gene names.** The extra alias is added only for
-  identifiers that already contain a space, so `DMB-1` cannot become the
-  two-token `DMB 1`. There is a test for exactly that.
+- **The predicate is now named and tested directly.** `_containing_species`
+  returns the one claimant that contains all the others, or None.
 
-- **Measured:** round-trip failures **130 -> 0**; every printed form in the
-  36,752-name corpus now parses back. 359 corpus names change, **every one
-  `None` -> a result**, none lost. 16,982 tests pass; removing the alias
-  registration fails 127 of them.
-- Bumped to 3.62.0.
+- **The ontology has zero aliases with unrelated claimants**, because #112 and
+  #134 moved every contested string -- Caau, Hyam, Moal, Orla -- to `context
+  only prefixes`. So the "decline to guess" branch is unexercised by data,
+  which is exactly why it is now tested with a constructed pair instead of
+  borrowed ones. My first draft asserted Caau was still ambiguous; it is not,
+  and the test failed and said so.
+
+- **Measured:** 0 of 36,752 corpus names change -- the parser already resolved
+  these; only the public lookup was wrong. 16,994 tests pass; restoring the old
+  predicate fails 4.
+- Bumped to 3.63.0.

--- a/tests/test_shared_alias_resolution.py
+++ b/tests/test_shared_alias_resolution.py
@@ -1,0 +1,116 @@
+"""
+An identifier shared by a node and its own descendants names the node.
+
+`Species.get` walks a ladder when an alias has several claimants: exact latin
+name, exact primary prefix, then -- per its own comment -- "the species that
+isn't a subspecies (no parent with same identifier)". The code tested
+`sp.parent_species is None`, which means "has no parent at all", so it only
+ever fired for root entries.
+
+Umbrella *prefixes* were unaffected because they are settled a step earlier:
+"MusSp" is Mus sp.'s own prefix. A shared *common name* has no such step, so
+"tropheus cichlid" -- Tropheus sp. and Tropheus moorii beneath it -- returned
+None, while `parse("tropheus cichlid class I")` happily answered Tropheus sp.
+The public lookup disagreed with the parser about the same string.
+
+https://github.com/pirl-unc/mhcgnomes/issues/129
+"""
+
+import pytest
+
+from mhcgnomes import Species, parse
+from mhcgnomes.species import latin_name_to_species_object
+
+from .common import eq_, ok_
+
+# (alias, the ancestor that should win)
+SHARED_WITH_DESCENDANTS = [
+    ("tropheus cichlid", "Tropheus sp."),
+    ("swordtail", "Xiphophorus sp."),
+    ("MusSp", "Mus sp."),
+]
+
+
+@pytest.mark.parametrize("alias,expected", SHARED_WITH_DESCENDANTS)
+def test_the_containing_node_wins(alias, expected):
+    got = Species.get(alias)
+    ok_(got is not None, f"{alias!r} still resolves to nothing")
+    eq_(got.name, expected)
+
+
+@pytest.mark.parametrize("alias,expected", SHARED_WITH_DESCENDANTS)
+def test_the_lookup_agrees_with_the_parser(alias, expected):
+    """The disagreement is the bug; the value they agree on is secondary."""
+    parsed = parse(f"{alias} class I")
+    eq_(parsed.species.name, expected)
+    eq_(Species.get(alias).name, parsed.species.name)
+
+
+@pytest.mark.parametrize("alias,expected", SHARED_WITH_DESCENDANTS)
+def test_the_winner_really_does_contain_the_others(alias, expected):
+    claimants = Species.get_multiple(alias)
+    ok_(len(claimants) > 1, f"{alias!r} is no longer shared; pick another example")
+    winner = Species.get_by_latin_name(expected)
+    for other in claimants:
+        ok_(
+            other is winner or winner.is_ancestor_of(other),
+            f"{winner.name} is not an ancestor of {other.name}",
+        )
+
+
+def test_no_alias_in_the_ontology_has_unrelated_claimants():
+    """
+    Why the step is safe today: every multi-claimant alias is a node plus its
+    own descendants. #112 and #134 moved the genuinely contested strings --
+    Caau, Hyam, Moal, Orla and the rest -- to `context only prefixes`, so they
+    have one ordinary claimant each and are reachable only with species=.
+
+    If this ever fails, an alias has been given to two unrelated species and
+    the ladder below will resolve it to nothing, silently.
+    """
+    from mhcgnomes.species import alias_to_species_objects
+
+    unrelated = []
+    for alias, holders in alias_to_species_objects.items():
+        claimants = list(holders)
+        if len(claimants) < 2:
+            continue
+        if any(all(o is s or s.is_ancestor_of(o) for o in claimants) for s in claimants):
+            continue
+        unrelated.append((str(alias), sorted(s.name for s in claimants)))
+    eq_(unrelated, [], f"aliases claimed by unrelated species: {unrelated[:5]}")
+
+
+def test_unrelated_claimants_would_still_be_refused():
+    """
+    The branch the test above leaves unexercised. Built rather than borrowed,
+    because relying on data that no longer collides is how a guard rots.
+    """
+    from mhcgnomes.species import _containing_species
+
+    human = Species.get_by_latin_name("Homo sapiens")
+    chicken = Species.get_by_latin_name("Gallus gallus")
+    primates = Species.get_by_latin_name("Primata sp.")
+
+    ok_(not human.is_ancestor_of(chicken) and not chicken.is_ancestor_of(human))
+    eq_(_containing_species([human, chicken]), None)
+
+    # and the shape that does resolve
+    eq_(_containing_species([primates, human]), primates)
+    eq_(_containing_species([human]), human)
+
+
+def test_every_identifier_resolves_to_its_owner_or_a_containing_ancestor():
+    """
+    The sweep that found this. An identifier must never resolve to a species
+    unrelated to the one advertising it.
+    """
+    wrong = []
+    for latin_name, species in latin_name_to_species_object.items():
+        for identifier in set(species.all_identifiers):
+            got = Species.get(identifier)
+            if got is None or got.name == latin_name:
+                continue
+            if not got.is_ancestor_of(species):
+                wrong.append((latin_name, str(identifier), got.name))
+    eq_(wrong, [], f"identifiers resolving to an unrelated species: {wrong[:5]}")


### PR DESCRIPTION
Found by asking what else the technique from #179 would find: sweep "does every
identifier a species advertises resolve back to it". 109 exceptions — 105 are
umbrella prefixes resolving to their owner, which is correct and by design.
**Four were not.**

### The lookup disagreed with the parser

```python
>>> Species.get("swordtail")                      # before
None
>>> parse("swordtail class I").species.name       # before, same string
'Xiphophorus sp.'
```

`tropheus cichlid` and `swordtail` are each shared by a genus node and one
species beneath it. Which answer is right is secondary; the public lookup and
the parser giving *different* answers is the bug.

### Another comment describing behaviour the code did not implement

The ladder's step 3 reads:

```python
# 3. For auto-generated long prefixes (e.g., CanisLupus), prefer
# the species that isn't a subspecies (no parent with same identifier)
non_child = [sp for sp in species_objects if sp.parent_species is None]
```

"No parent **with same identifier**" in the comment; "no parent **at all**" in
the code — so it only ever fired for root entries. Umbrella prefixes escaped
because step 2 catches them (`MusSp` is *Mus sp.*'s own prefix); a shared
*common name* has no step 2 and fell through to `None`. Same shape as #160,
where the case-aware ranking key had never fired either.

`_containing_species` now returns the one claimant that contains all the
others, or `None`. Unrelated claimants still get `None`, which is what keeps
#112 honest.

### The ambiguity branch is unexercised by data, so it is tested directly

The ontology has **zero** aliases with unrelated claimants — #112 and #134
moved every contested string (`Caau`, `Hyam`, `Moal`, `Orla`) to `context only
prefixes`. My first draft of the test asserted `Caau` was still ambiguous. It
is not, and the test failed and said so. It now builds an unrelated pair rather
than borrowing data that no longer collides, which is how a guard rots.

### Measurement

- **0 of 36,752** corpus names change — the parser already resolved these; only
  the public lookup was wrong.
- 16,994 tests pass; restoring the old predicate fails 4.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH