### PR TITLE
Sweep the four group nodes, the last entries never checked (#131)

### DIFF
--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.63.1"
+__version__ = "3.63.2"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,37 +1,30 @@
-# A shared identifier names the containing node (#129)
+# Sweep the four group nodes, the last entries never checked (#131)
 
 ## Review
 
-- **Found by asking what else the round-trip technique would find.** Sweeping
-  "does every identifier a species advertises resolve back to it" turned up 109
-  exceptions. 105 were umbrella prefixes resolving to their owner, which is
-  correct and by design. **Four were not.**
+- **A gap in my own method, not in the sources.** The GenBank sweep in #169
+  skipped every `<Genus> sp.` row -- `if species.endswith(" sp."): continue` --
+  because a group node has no organism to search under. So four of #131's
+  fifteen had never actually been searched, while I was describing the list as
+  exhaustively checked.
 
-- **`Species.get` disagreed with `parse` about the same string.**
-  `Species.get("swordtail")` returned None while
-  `parse("swordtail class I")` answered *Xiphophorus sp.* The public lookup and
-  the parser giving different answers is the bug; which one is right is
-  secondary.
+- **Searching under the genus instead finds nothing**, in nuccore or protein:
 
-- **Another comment describing behaviour the code did not implement.** The
-  ladder's step 3 says "prefer the species that isn't a subspecies (no parent
-  with same identifier)" and tested `sp.parent_species is None` -- "no parent at
-  all" -- so it only ever fired for root entries. Umbrella prefixes were
-  unaffected because step 2 catches them: `MusSp` is *Mus sp.*'s own prefix. A
-  shared *common name* has no step 2, so it fell through to None. Same shape as
-  #160, where the case-aware ranking key had never fired.
+      Coregonus + Cosp   0        Manacus + Mana   0
+      Tropheus  + Trsp   0        Mus     + MusSp  0 as a prefix
 
-- **The predicate is now named and tested directly.** `_containing_species`
-  returns the one claimant that contains all the others, or None.
+- **`MusSp` returns 18 records and none of them count.** They are *Mus spretus*
+  microsatellites named `MUSSP-16`, `MUSSP-17`, `MUSSP-18` -- a coincidental
+  string, the same false-positive shape as `Xetr` appearing only as clone tags
+  for bitter taste receptors.
 
-- **The ontology has zero aliases with unrelated claimants**, because #112 and
-  #134 moved every contested string -- Caau, Hyam, Moal, Orla -- to `context
-  only prefixes`. So the "decline to guess" branch is unexercised by data,
-  which is exactly why it is now tested with a constructed pair instead of
-  borrowed ones. My first draft asserted Caau was still ambiguous; it is not,
-  and the test failed and said so.
+- **They stay `None`, and now for a checked reason rather than an unchecked
+  one.** Reclassifying them as "group label" would need the predicate that also
+  gates prefix inheritance, and 18 species inherit these as `old_mhc_prefix`.
+  That trade is recorded on #131 and has not changed.
 
-- **Measured:** 0 of 36,752 corpus names change -- the parser already resolved
-  these; only the public lookup was wrong. 16,994 tests pass; restoring the old
-  predicate fails 4.
-- Bumped to 3.63.0.
+- **All fifteen of #131's remaining entries have now been searched**, which was
+  not true before this.
+
+- No data changed, so no corpus measurement applies. 16,994 tests pass.
+- Bumped to 3.63.2.

--- a/tests/test_species_identity.py
+++ b/tests/test_species_identity.py
@@ -717,6 +717,27 @@ def test_unestablished_provenance_stays_none():
         "Meleagris gallopavo",
         "Pavo cristatus",
         "Xenopus tropicalis",
+        #
+        # The four group-node abbreviations. These were the last entries never
+        # swept, because the GenBank pass skipped "<Genus> sp." rows -- a group
+        # node has no organism of its own to search under. Searching under the
+        # genus instead finds nothing for any of them, in nuccore or protein:
+        #
+        #   Coregonus + Cosp   0      Manacus + Mana   0
+        #   Tropheus  + Trsp   0      Mus     + MusSp  0 as a prefix
+        #
+        # MusSp does return 18 records, all of them Mus spretus microsatellites
+        # named MUSSP-16, MUSSP-17, MUSSP-18 -- a coincidental string, not a
+        # prefix, the same false positive shape as Xetr's taste receptors.
+        #
+        # So all four are labels this project minted. They stay None rather
+        # than being reclassified: the predicate that would call them
+        # "group label" also gates prefix inheritance, and 18 species inherit
+        # these as old_mhc_prefix. See the comment on #131.
+        "Coregonus sp.",
+        "Manacus sp.",
+        "Mus sp.",
+        "Tropheus sp.",
         "Aotus sp.",
         "Callithrix sp.",
         "Gorilla sp.",


### PR DESCRIPTION
Closes the last gap in #131's search record — a gap in my method, not in the
sources.

### Four entries had never actually been searched

The GenBank sweep in #169 skipped every `<Genus> sp.` row:

```python
if species.endswith(" sp."):
    continue   # group nodes have no organism of their own
```

Sensible as written, but it meant four of #131's fifteen were being described
as exhaustively checked when they had not been checked at all.

### Searching under the genus finds nothing

| group node | searched as | nuccore | protein |
|---|---|---:|---:|
| `Cosp` | *Coregonus* | 0 | 0 |
| `Trsp` | *Tropheus* | 0 | 0 |
| `Mana` | *Manacus* | 0 | 0 |
| `MusSp` | *Mus* | 0 as a prefix | 0 |

`MusSp` returns 18 records and **none of them count** — they are *Mus spretus*
microsatellites named `MUSSP-16`, `MUSSP-17`, `MUSSP-18`. A coincidental
string, not a prefix; the same false-positive shape as `Xetr` appearing only as
clone tags for bitter taste receptors.

### They stay `None`, now for a checked reason

Reclassifying them as `"group label"` would need the predicate that also gates
prefix inheritance, and **18 species inherit these as `old_mhc_prefix`** —
`MusSp` is in *Mus musculus*'s identifier set. That trade is recorded on #131
and has not changed; what has changed is that the alternative was actually
looked for.

**All fifteen of #131's remaining entries have now been searched**, which was
not true before this.

No data changed, so no corpus measurement applies. 16,994 tests pass.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH