### PR TITLE
Correct what the Lr- tables say about "+" (#162)

### DIFF
--- a/mhcgnomes/data/haplotypes.yaml
+++ b/mhcgnomes/data/haplotypes.yaml
@@ -120,11 +120,19 @@ SLA:
   #   composite or unconfirmed name   01.0/04.0, 16.0 mod, 31.0/63.0,
   #                                   0.08b, 0.15a, 0.15b, 0.19a, 0.19b
   #   untyped locus (Blank + fn)      24.0, 33.0, 0.29
-  #   "+" -- an allele beyond group   38.0, 45.0, 0.21, 0.25, 0.27
+  #   "+" -- meaning not established  38.0, 45.0, 0.21, 0.25, 0.27
   #   "/" -- alternatives at a locus  52.0, 53.0, 0.11
   #
-  # The last two shapes need a member that is a disjunction, which this format
-  # does not have. That is the remaining half of #162.
+  # On "+": Table 1 does not explain it at all, and Table 2's footnote 3 says
+  # only "Positive with both DQA*04XX primer sets in lanes D12 and C12" of one
+  # instance -- which describes an assay result rather than defining the
+  # notation. Whether "12XX + 11:04" means a second allele at the locus, a
+  # duplicated locus, or an unresolved call is not something these tables say,
+  # so those five rows stay out until it can be read somewhere that does.
+  #
+  # "/" is safe by comparison: a slash between two specificities at one locus
+  # reads as alternatives, and that is a member this format cannot express --
+  # a disjunction. It is the remaining half of #162.
   ##########################################################################
   # ---- low-resolution class I haplotypes ----
   Lr-01.0:

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.64.0"
+__version__ = "3.64.1"
 
 
 def print_version():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,43 +1,25 @@
-# Curate the low-resolution (Lr-) swine haplotype series (#162)
+# Correct what the Lr- tables say about "+" (#162)
 
 ## Review
 
-- **The data was reachable after all, and I had said twice that it was not.**
-  I checked PMC for Ho et al. 2009 and Hammer et al. 2020 (no full text) and
-  read the cohort papers' HTML tables (per-line counts only), then concluded
-  the compositions were paywalled. What I never tried was **Europe PMC**, which
-  serves the same articles as structured full-text XML:
+- **I wrote an interpretation into a curated file that the source does not
+  state.** #183's comment said the five excluded rows use `+` to mean "an
+  additional allele beyond the group". That was my reading, not the paper's.
 
-      https://www.ebi.ac.uk/europepmc/webservices/rest/PMC8362188/fullTextXML
+- **What the paper actually says.** Table 1 never explains `+` at all. Table 2's
+  footnote 3 addresses one instance and says only "Positive with both DQA*04XX
+  primer sets in lanes D12 and C12" -- an assay result, not a definition of the
+  notation. Whether `12XX + 11:04` means a second allele at the locus, a
+  duplicated locus, or an unresolved call is not something these tables say.
 
-  Tables 1 and 2 are in it in full -- 49 class I and 31 class II rows. The
-  supplementary route was a dead end too (PMC gates the download behind an
-  interstitial; Europe PMC's supplementaryFiles endpoint serves it, and it
-  turned out to hold only primer layouts and frequency figures).
+- **And "+" was never the representation problem I implied.** Two members at
+  one locus is already how Lr-02.0 records `02XX,07XX`. Those five rows are out
+  because the meaning is unestablished, not because the format cannot hold
+  them -- a materially different reason, and the one a future curator needs.
 
-  My greps for "Lr-" had also been finding nothing because the XML uses a
-  Unicode hyphen, U+2010.
+- **"/" is unaffected.** A slash between two specificities at one locus reads
+  as alternatives, and a disjunction really is a member this format cannot
+  express. That remains the open half of #162.
 
-- **59 haplotypes curated**, 39 class I and 20 class II, every member a
-  one-field allele because that is what a group specificity is: `1*04` is
-  SLA-1*04XX.
-
-- **The footnotes carry the finding.** Table 1's footnote 5 is "Untyped SLA
-  class I locus", and Lr-24.0 and Lr-33.0 show `Blank` **with that footnote**.
-  Same word, opposite claim from the plain `Blank` in Lr-23.0. A naive import
-  would have recorded two untyped loci as positively absent -- exactly the
-  distinction #162 was filed about, confirmed by the source itself.
-
-- **19 rows deliberately left out, each with its reason recorded** in the YAML
-  and pinned in a test: composite or unconfirmed names, untyped loci, `+`
-  meaning an allele beyond the group, and `/` meaning alternatives. The last
-  two need a disjunction member, which is the only part of #162 still open.
-
-- **Cross-validation, unlooked for.** Footnote 3 says Lr-02.0 "did not appear
-  to possess an expressed SLA-3 gene", which is the same fact Table 2 of
-  PMC5472656 records as Hp-2.0's SLA-3 being *null*. Two independent papers,
-  one haplotype at two resolutions, agreeing.
-
-- **Measured:** 0 of 36,752 corpus names change; 0 printed forms fail to parse
-  back; 17,129 tests pass, 76 new; no parser warnings from the new entries.
-- Bumped to 3.64.0.
+- No data changed; 17,130 tests pass.
+- Bumped to 3.64.1.

--- a/tests/test_sla_lr_haplotypes.py
+++ b/tests/test_sla_lr_haplotypes.py
@@ -103,9 +103,9 @@ DELIBERATELY_ABSENT = {
     "24.0": "SLA-1 untyped, not blank",
     "33.0": "SLA-1 untyped, not blank",
     "0.29": "DRB1 untyped, not blank",
-    "38.0": "'+' means an allele beyond the group",
-    "45.0": "'+' at two loci",
-    "0.21": "'+' at DQA",
+    "38.0": "'+' notation not defined by the source",
+    "45.0": "'+' at two loci, notation not defined",
+    "0.21": "'+' at DQA, notation not defined",
     "52.0": "'/' means alternatives at one locus",
     "53.0": "'/' at SLA-2",
     "0.11": "'/' at DRB1",
@@ -154,6 +154,19 @@ def test_a_blank_locus_is_recorded_and_an_untyped_one_is_not():
 @pytest.mark.parametrize("name", sorted(DELIBERATELY_ABSENT))
 def test_the_rows_left_out_stay_out(name):
     eq_(parse(f"Lr-{name}", raise_on_error=False), None)
+
+
+def test_the_plus_rows_are_out_because_the_notation_is_undefined():
+    """
+    Not because "+" is hard to represent -- two members at one locus is
+    already how Lr-02.0 records "02XX,07XX". Table 1 never explains "+", and
+    Table 2's footnote 3 describes one instance as "Positive with both
+    DQA*04XX primer sets", which is an assay result rather than a definition.
+    Guessing between "a second allele", "a duplicated locus" and "an
+    unresolved call" is the kind of thing AGENTS.md exists to stop.
+    """
+    for name in ["38.0", "45.0", "0.21", "0.25", "0.27"]:
+        eq_(parse(f"Lr-{name}", raise_on_error=False), None)
 
 
 def test_multiple_alleles_at_one_locus_are_both_listed():


### PR DESCRIPTION
Follows #183 with a correction to it.

### I wrote an interpretation into a curated file that the source does not state

#183's comment said the five excluded rows use `+` to mean *"an additional
allele beyond the group"*. That was my reading, not the paper's, and it went in
as though it were sourced — which is the one thing `AGENTS.md` is most explicit
about.

**What the tables actually say:** Table 1 never explains `+` at all. Table 2's
footnote 3 addresses a single instance and says only *"Positive with both
DQA\*04XX primer sets in lanes D12 and C12"* — an assay result, not a definition
of the notation. Whether `12XX + 11:04` means a second allele at the locus, a
duplicated locus, or an unresolved call is not something these tables say.

### `+` was also never the representation problem I implied

Two members at one locus is already how `Lr-02.0` records `02XX,07XX`. Those
five rows are out because the **meaning is unestablished**, not because the
format cannot hold them. That is a materially different reason, and the one a
future curator needs — someone reading the old note would have gone looking for
a disjunction type when what is missing is a sentence in a paper.

### `/` is unaffected

A slash between two specificities at one locus reads as alternatives, and a
disjunction genuinely is a member this format cannot express. That stays the
open half of #162.

No data changed; 17,130 tests pass.

https://claude.ai/code/session_012s4siLj2Vm33eNMGjNSazH