### PR TITLE
Prevent Saha ambiguity labels from becoming Pair (#186)

### DIFF
--- a/mhcgnomes/ambiguous_alleles.py
+++ b/mhcgnomes/ambiguous_alleles.py
@@ -23,10 +23,11 @@ from .species import Species
 class AmbiguousAlleles(ResultWithMultipleAlleles):
     """
     A set of distinct allele designations that an input string cannot
-    disambiguate between. Used for IPD-MHC style slash designations
-    such as "SahaI*74/88" (Caldwell et al. 2018, PMC6092122), where an
-    observed sequence matches two database entries because they are
-    identical in the region that was typed.
+    disambiguate between. Used for source-specific slash designations such as
+    "SahaI*74/88" (Caldwell et al. 2018, PMCID PMC6092122), where one observed
+    exon-2 sequence carries two historical candidate allele designations. The
+    source-data FASTA contains one sequence for that label
+    (https://doi.org/10.7554/eLife.35314.015); it is not a molecular pair.
 
     Unlike Serotype or Haplotype, the grouping here does not reflect a
     biological or serological relationship — just typing ambiguity.

--- a/mhcgnomes/data/curated_allele_aliases.yaml
+++ b/mhcgnomes/data/curated_allele_aliases.yaml
@@ -574,16 +574,17 @@ Saha:
   I*36: "36"
   I*37: "37"
   I*97: "97"
-  # Slash-ambiguous designations (Table 1): SahaI*49/82 and SahaI*74/88
-  # each describe a single observed DFT2 sequence that matches two IPD
-  # entries identical in the region that was typed. The numbers 49, 74,
-  # 82, and 88 never appear alone in the paper — only paired across a
-  # slash. The entries below exist solely as building blocks for the
-  # slash-parsing machinery (the parser splits on "/" and needs each
-  # side to resolve to AlleleWithoutGene independently so the two sides
-  # can be combined into an AmbiguousAlleles result). They are not
-  # endorsements of SahaI*49 / *74 / *82 / *88 as standalone paper
-  # allele names, and parsers should prefer the paired forms.
+  # Slash-ambiguous designations (Caldwell et al. 2018, Table 1; PMCID
+  # PMC6092122): SahaI*49/82 and SahaI*74/88 each label one observed exon-2
+  # sequence. The paper's source-data FASTA has one record per compound label
+  # (https://doi.org/10.7554/eLife.35314.015), so these are not molecular pairs.
+  # The historical candidate records are GenBank GQ411457 (SahaI*49),
+  # GQ411490 (*82), GQ411482 (*74), and JN389436 (*88). They are not IPD-MHC
+  # entries: release 3.17.0.0 has no Saha or Sarcophilus records.
+  #
+  # Keep the alias targets gene-unassigned here: although the four individual
+  # historical labels have GenBank records, Caldwell's compound calls do not
+  # establish which candidate or locus produced the observed sequence.
   I*49: "49"
   I*82: "82"
   I*74: "74"

--- a/mhcgnomes/data/known_alleles.yaml
+++ b/mhcgnomes/data/known_alleles.yaml
@@ -47,13 +47,11 @@ BoLA:
     - gb1.7
     - amani.1
 Saha:
-  # Bare allele numbers from the DFT2 paper (Caldwell et al. 2018,
-  # PMC6092122) that appear in the slash-ambiguous pairs "SahaI*49/82"
-  # and "SahaI*74/88". These numbers never appear as standalone paper
-  # names — they exist here solely to let the right-hand side of the
-  # slash tokenize and resolve to AlleleWithoutGene, so the parser can
-  # combine the two sides into an AmbiguousAlleles result. Not
-  # endorsements of "49"/"74"/"82"/"88" as standalone Saha allele names.
+  # Parsing components for Caldwell et al.'s compound labels "SahaI*49/82"
+  # and "SahaI*74/88" (2018, PMCID PMC6092122). The corresponding historical
+  # records are GenBank GQ411457, GQ411490, GQ411482, and JN389436; they are
+  # not IPD-MHC entries. These numbers never appear alone in Caldwell and are
+  # not endorsed here as standalone names.
   ~:
     - "49"
     - "74"

--- a/mhcgnomes/data/species.yaml
+++ b/mhcgnomes/data/species.yaml
@@ -6419,9 +6419,10 @@ Monodelphis domestica:
       - UT8
 Sarcophilus harrisii:
   parent: Marsupialia sp.
-  # prefix source: designated -- PMID 35335675 (Hussey et al., Pathogens
-  # 2022;11:351) is titled "Expression of the Nonclassical MHC Class I,
-  # Saha-UD in the Transmissible Cancer Devil Facial Tumour Disease".
+  # prefix source: designated -- Saha is literature-attested, not currently
+  # registered in IPD-MHC. Siddle et al. 2010 (PMID 20219742) deposited
+  # GQ411435--GQ411493 as SahaI*27--SahaI*85; IPD-MHC release 3.17.0.0 has no
+  # Saha or Sarcophilus entries.
   prefix source: designated
   prefix: Saha
   name: Tasmanian devil

--- a/mhcgnomes/parser.py
+++ b/mhcgnomes/parser.py
@@ -65,6 +65,43 @@ _MHC_REGION_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Caldwell et al. 2018, eLife 7:e35314, Table 1 (PMCID PMC6092122) uses each
+# slash label for one sequenced exon-2 product, not for two paired molecules.
+# Its source-data FASTA has one record named DFT2_CL_74_88 and one named
+# Spln_Teu_49_82 (https://doi.org/10.7554/eLife.35314.015). The historical
+# candidate allele records are GenBank GQ411457 (SahaI*49), GQ411490 (*82),
+# GQ411482 (*74), and JN389436 (*88). These are literature-specific compound
+# labels: IPD-MHC release 3.17.0.0 contains no Saha or Sarcophilus entries.
+_PUBLISHED_SAHA_SLASH_AMBIGUITIES = frozenset({("49", "82"), ("74", "88")})
+
+
+def _is_saha_i_placeholder_allele(result):
+    """Is this Caldwell's ``SahaI*NN`` parser placeholder, not a biological locus?"""
+    return (
+        type(result) is Allele and result.species.mhc_prefix == "Saha" and result.gene_name == "I"
+    )
+
+
+def _published_saha_slash_ambiguity(first, second):
+    """Return Caldwell's two gene-unassigned candidates for an attested slash label."""
+    if not _is_saha_i_placeholder_allele(first):
+        return None
+    if type(second) is not AlleleWithoutGene or first.species != second.species:
+        return None
+    if (first.name, second.name) not in _PUBLISHED_SAHA_SLASH_AMBIGUITIES:
+        return None
+
+    alleles = tuple(
+        AlleleWithoutGene.get(
+            first.species,
+            name,
+            mhc_class="I",
+            raw_string=source.raw_string,
+        )
+        for name, source in ((first.name, first), (second.name, second))
+    )
+    return AmbiguousAlleles(species=first.species, alleles=alleles)
+
 
 def _spelling_as_written(normalized_name, raw_name):
     """
@@ -1268,40 +1305,7 @@ class Parser:
             alpha = self.transform_parse_candidate(parse_candidate.alpha)
             beta = self.transform_parse_candidate(parse_candidate.beta)
             if alpha != parse_candidate.alpha or beta != parse_candidate.beta:
-                if (
-                    isinstance(alpha, AlleleWithoutGene)
-                    and isinstance(beta, AlleleWithoutGene)
-                    and alpha.species == beta.species
-                ):
-                    # A slash between two gene-less allele designators of the
-                    # same species is IPD-style typing ambiguity (e.g.
-                    # SahaI*74/88), not a class II alpha/beta pair. The right
-                    # side of the slash is tokenized as a bare number and
-                    # lacks class context on its own, so propagate the class
-                    # from whichever member resolved it.
-                    shared_class = alpha.mhc_class or beta.mhc_class
-                    if shared_class is not None:
-                        if alpha.mhc_class is None:
-                            alpha = AlleleWithoutGene.get(
-                                alpha.species,
-                                alpha.name,
-                                mhc_class=shared_class,
-                                raw_string=alpha.raw_string,
-                            )
-                        if beta.mhc_class is None:
-                            beta = AlleleWithoutGene.get(
-                                beta.species,
-                                beta.name,
-                                mhc_class=shared_class,
-                                raw_string=beta.raw_string,
-                            )
-                    transformed = AmbiguousAlleles(
-                        species=alpha.species,
-                        alleles=(alpha, beta),
-                        raw_string=parse_candidate.raw_string,
-                    )
-                else:
-                    transformed = Pair.get(alpha, beta, raw_string=parse_candidate.raw_string)
+                transformed = Pair.get(alpha, beta, raw_string=parse_candidate.raw_string)
         elif t in (AlleleWithoutGene, Allele):
             raw_string = parse_candidate.raw_string
             species = parse_candidate.species
@@ -1914,14 +1918,23 @@ class Parser:
                         continue
                     if result_before.species != result_after.species:
                         continue
+                    saha_ambiguity = _published_saha_slash_ambiguity(result_before, result_after)
+                    if saha_ambiguity is not None:
+                        candidates.append(saha_ambiguity)
+                        continue
+                    if _is_saha_i_placeholder_allele(result_before):
+                        # `I` exists only to parse the literature's SahaI*NN
+                        # notation. It is neither a biological locus nor one
+                        # chain of a molecular pair, so an unattested numeric
+                        # slash must not fall through to Pair.get().
+                        continue
                     class2_pair = Pair.get(result_before, result_after)
                     if class2_pair:
                         candidates.append(class2_pair)
             elif type(result_before) is AlleleWithoutGene:
-                # IPD-style slash ambiguity between two gene-less allele
-                # designators of the same species, e.g. "SahaI*74/88" from
-                # Caldwell et al. 2018 (PMC6092122) which cannot be
-                # attributed to SahaI*74 or SahaI*88 from the typed region.
+                # A slash between two gene-less allele designators can express
+                # source-specific typing ambiguity. This branch is separate
+                # from Pair because neither candidate identifies a chain.
                 species = result_before.species if result_before.has_species else default_species
                 for result_after in self.parse_tokens_to_multiple_candidates(
                     tokens=tokens_after,

--- a/mhcgnomes/version.py
+++ b/mhcgnomes/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.64.1"
+__version__ = "3.64.2"
 
 
 def print_version():

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -203,3 +203,20 @@ siblings are and run them once. Six were checked here; two found bugs and four
 came back clean, and the clean ones are worth knowing too -- they are why the
 sweep could stop. Stop when the technique stops producing, not when the list of
 possible probes runs out.
+
+## Published nomenclature is not registry membership
+
+**What happened.** Comments called `SahaI*49/82` and `SahaI*74/88` "IPD-style"
+and said their four candidate names were "IPD entries". The `SahaI*NN`
+convention is real and well attested in Tasmanian-devil papers and GenBank, but
+the current IPD-MHC release contains no `Saha` or *Sarcophilus* entry at all.
+
+**Why it was wrong.** A name can be used consistently in primary literature
+without being curated by the registry that governs related nomenclature. The
+paper and registry answer different questions, and borrowing the registry's
+authority made the source-specific slash semantics sound standardized.
+
+**How to apply.** Cite the paper for how an author writes a name, the sequence
+accession for what biological record it denotes, and the registry release for
+whether the registry contains it. Never substitute one of those checks for
+another.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,25 +1,52 @@
-# Correct what the Lr- tables say about "+" (#162)
+# Prevent Tasmanian-devil ambiguity labels from becoming `Pair`
+
+GitHub issue: #186
+
+## Evidence and intended behavior
+
+- [x] Check the current IPD-MHC release rather than inferring registry coverage
+  from search results. IPD-MHC 3.17.0.0 (2026-07-26; 12,833 entries) contains
+  zero entry names beginning `Saha` and zero entries whose organism contains
+  `Sarcophilus`.
+- [x] Check primary literature for the nomenclature. `SahaI*NN` is an attested
+  author-used convention: Siddle et al. deposited `SahaI*27`--`*85`
+  (PMID 20219742), and Caldwell et al. use `SahaI*49/82` and `SahaI*74/88`
+  (PMCID PMC6092122). This is literature usage, not an IPD-MHC registration.
+- [x] Check the underlying records. The candidate designations correspond to
+  GenBank GQ411457 (`SahaI*49`), GQ411490 (`SahaI*82`), GQ411482
+  (`SahaI*74`), and JN389436 (`SahaI*88`). Caldwell's source-data FASTA has
+  one sequence for each slash label, so neither label denotes two paired MHC
+  molecules.
+- [x] Keep both candidates gene-unassigned. Caldwell explicitly labels
+  `SahaI*74/88` unassigned, and the compound labels do not justify promoting
+  either candidate to a particular locus.
+
+## Implementation
+
+- [x] Recognize only the two published Saha compound labels as allele-name
+  ambiguity, independent of the optional alias-resolution flag.
+- [x] Keep ordinary slash parsing unchanged, especially the common class-II
+  alpha/beta `Pair` case.
+- [x] Replace incorrect "IPD-style" / "IPD entries" prose with citations to
+  Caldwell's paper, source-data FASTA, and the four GenBank accessions.
+- [x] Add regression tests for both spellings (`SahaI` and `Saha-I`), both
+  alias settings, gene-unassigned members, class-I context, and non-creation
+  of `Pair`.
+- [x] Add a non-regression test for a genuine class-II alpha/beta pair.
+- [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
 
 ## Review
 
-- **I wrote an interpretation into a curated file that the source does not
-  state.** #183's comment said the five excluded rows use `+` to mean "an
-  additional allele beyond the group". That was my reading, not the paper's.
-
-- **What the paper actually says.** Table 1 never explains `+` at all. Table 2's
-  footnote 3 addresses one instance and says only "Positive with both DQA*04XX
-  primer sets in lanes D12 and C12" -- an assay result, not a definition of the
-  notation. Whether `12XX + 11:04` means a second allele at the locus, a
-  duplicated locus, or an unresolved call is not something these tables say.
-
-- **And "+" was never the representation problem I implied.** Two members at
-  one locus is already how Lr-02.0 records `02XX,07XX`. Those five rows are out
-  because the meaning is unestablished, not because the format cannot hold
-  them -- a materially different reason, and the one a future curator needs.
-
-- **"/" is unaffected.** A slash between two specificities at one locus reads
-  as alternatives, and a disjunction really is a member this format cannot
-  express. That remains the open half of #162.
-
-- No data changed; 17,130 tests pass.
-- Bumped to 3.64.1.
+- IPD-MHC 3.17.0.0 was checked directly: 0 `Saha` entry names and 0
+  *Sarcophilus* organisms. The nomenclature is nevertheless attested by Siddle
+  et al. (PMID 20219742), Caldwell et al. (PMCID PMC6092122), Caldwell's
+  one-record-per-label source FASTA, and GenBank GQ411457/GQ411490/GQ411482/
+  JN389436.
+- Both `SahaI*49/82` and `SahaI*74/88` now return `AmbiguousAlleles` containing
+  two gene-unassigned class-I candidates with aliases either off or on. The
+  parser never constructs a `Pair` from the source's `I` placeholder.
+- The exception is deliberately source-specific. An invented `SahaI*49/74`
+  stays unresolved; ordinary HLA class-II alpha/beta slash notation still
+  returns `Pair`. The broader alias-based ambiguity conversion was removed.
+- `./format.sh` passed; `./lint.sh` passed; all 17,143 tests passed with 92%
+  coverage. Bumped to 3.64.2.

--- a/tests/test_saha_dft2.py
+++ b/tests/test_saha_dft2.py
@@ -12,7 +12,7 @@ attribution.
 
 import pytest
 
-from mhcgnomes import AlleleWithoutGene, AmbiguousAlleles, parse
+from mhcgnomes import AlleleWithoutGene, AmbiguousAlleles, Pair, parse
 
 from .common import eq_
 
@@ -84,20 +84,22 @@ def test_em_dash_normalizes_to_hyphen():
 @pytest.mark.parametrize(
     ("paper_name", "expected_numbers"),
     [
-        # Paper Table 1 slash-ambiguous designations: a single observed
-        # DFT2 sequence that matches two IPD entries identical in the
-        # region typed. Treated as two distinct alleles the input cannot
-        # disambiguate between — not one allele with a slash in its name.
+        # Caldwell Table 1 and its source-data FASTA use each slash label for
+        # one observed exon-2 sequence with two historical candidate names.
+        # The candidates are GenBank records, not IPD-MHC entries or a pair.
         ("SahaI*49/82", ("49", "82")),
         ("SahaI*74/88", ("74", "88")),
+        ("Saha-I*49/82", ("49", "82")),
         ("Saha-I*74/88", ("74", "88")),
     ],
 )
-def test_slash_ambiguity_produces_two_alleles(paper_name, expected_numbers):
-    result = parse(paper_name, use_allele_aliases=True)
+@pytest.mark.parametrize("use_allele_aliases", [False, True])
+def test_slash_ambiguity_produces_two_alleles(paper_name, expected_numbers, use_allele_aliases):
+    result = parse(paper_name, use_allele_aliases=use_allele_aliases)
     assert isinstance(result, AmbiguousAlleles), (
         f"{paper_name!r} should produce AmbiguousAlleles, got {type(result).__name__}"
     )
+    assert not isinstance(result, Pair)
     eq_(result.num_alleles, 2)
     # alleles are sorted by value in ResultWithMultipleAlleles
     names = tuple(a.name for a in result.alleles)
@@ -111,17 +113,45 @@ def test_ambiguous_alleles_round_trip_string():
     result = parse("SahaI*74/88", use_allele_aliases=True)
     eq_(result.to_string(), "Saha-74/88")
     eq_(result.to_string(include_species=False), "74/88")
+    reparsed = parse(result.to_string())
+    assert isinstance(reparsed, AmbiguousAlleles)
+    eq_(tuple(a.name for a in reparsed.alleles), ("74", "88"))
+
+
+@pytest.mark.parametrize("use_allele_aliases", [False, True])
+def test_unpublished_saha_numeric_slash_is_not_inferred_as_pair(use_allele_aliases):
+    # The I token is Caldwell's class-I placeholder, not one chain of a
+    # biological pair. Only the two source-attested combinations above are
+    # promoted to AmbiguousAlleles; other combinations remain unresolved.
+    result = parse(
+        "SahaI*49/74",
+        use_allele_aliases=use_allele_aliases,
+        raise_on_error=False,
+    )
+    assert result is None
+
+
+@pytest.mark.parametrize("use_allele_aliases", [False, True])
+def test_saha_guard_does_not_change_class_ii_pair(use_allele_aliases):
+    result = parse(
+        "HLA-DPA1*01:03/DPB1*04:01",
+        use_allele_aliases=use_allele_aliases,
+    )
+    assert isinstance(result, Pair)
+    eq_(result.alpha.gene_name, "DPA1")
+    eq_(result.beta.gene_name, "DPB1")
 
 
 @pytest.mark.parametrize(
     "paper_name",
     ["SahaI*29", "SahaI*49", "SahaI*49/82", "SahaI*74/88"],
 )
-def test_class_i_context_preserved_without_locus(paper_name):
+@pytest.mark.parametrize("use_allele_aliases", [False, True])
+def test_class_i_context_preserved_without_locus(paper_name, use_allele_aliases):
     # The "I" placeholder gene carries class I context; alias resolution
     # should thread that into AlleleWithoutGene / AmbiguousAlleles so
     # downstream class-based filters continue to work.
-    result = parse(paper_name, use_allele_aliases=True)
+    result = parse(paper_name, use_allele_aliases=use_allele_aliases)
     eq_(result.mhc_class, "I")
     assert result.is_class1
     if isinstance(result, AmbiguousAlleles):


### PR DESCRIPTION
## Summary

- treat Caldwell's two published `SahaI*NN/NN` labels as source-specific allele
  ambiguity with gene-unassigned class-I candidates
- prevent the Tasmanian-devil `I` parser placeholder from falling through to
  biological `Pair`, regardless of alias settings
- replace incorrect IPD-MHC claims with Caldwell source-data and the four
  GenBank accessions; record that IPD-MHC 3.17.0.0 has no Saha entries
- preserve the common class-II alpha/beta slash behavior and reject invented
  Saha numeric combinations rather than generalizing the exception

## Evidence

- Caldwell et al. 2018, PMCID PMC6092122, Table 1
- Caldwell source-data FASTA: https://doi.org/10.7554/eLife.35314.015
- GenBank GQ411457, GQ411490, GQ411482, JN389436
- Siddle et al. 2010, PMID 20219742
- IPD-MHC release 3.17.0.0 (2026-07-26): 0 `Saha` names and 0
  *Sarcophilus* organisms among 12,833 entries

## Verification

- `./format.sh`
- `./lint.sh`
- `./test.sh` — 17,143 passed, 92% coverage

Closes #186.
